### PR TITLE
docs: add missing macOS brew dependencies

### DIFF
--- a/docs/ETC/MACOS_BUILD_INSTRUCTIONS.md
+++ b/docs/ETC/MACOS_BUILD_INSTRUCTIONS.md
@@ -33,7 +33,7 @@ xcode-select --install
 ### 3. Build Tools
 
 ```bash
-brew install cmake ninja meson python3
+brew install cmake ninja meson python3 pkgconf ffmpeg glm
 ```
 
 > **Note on `meson`**: The DXVK sub-project requires Meson >= 1.0. The Homebrew arm64


### PR DESCRIPTION
## Summary
- Adds `pkgconf`, `ffmpeg`, and `glm` to the macOS build prerequisites in `docs/ETC/MACOS_BUILD_INSTRUCTIONS.md`
- These are required for the `macos-vulkan` preset build but were not listed
