### PR TITLE
fix: animated shadow rendering in Zero Hour (#15)

### DIFF
--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -1470,7 +1470,13 @@ void W3DVolumetricShadow::RenderDynamicMeshVolume(Int meshIndex, Int lightIndex,
 	D3DMATRIX dxmWorld = To_D3DMATRIX(*meshXform);
 	m_pDev->SetTransform(D3DTS_WORLD, &dxmWorld);
 
-	// GeneralsX @bugfix BenderAI 13/02/2026 Removed orphaned brace from Phase 1.5 refactoring
+	// GeneralsX @bugfix BenderAI 11/04/2026 Rebind dynamic shadow vertex stream to avoid stale VB state on animated casters.
+	if (shadowVertexBufferD3D != lastActiveVertexBuffer)
+	{
+		m_pDev->SetStreamSource(0,shadowVertexBufferD3D,sizeof(SHADOW_DYNAMIC_VOLUME_VERTEX));
+		lastActiveVertexBuffer = shadowVertexBufferD3D;
+	}
+
 	if (DX8Wrapper::_Is_Triangle_Draw_Enabled())
 	{
 		Debug_Statistics::Record_DX8_Polys_And_Vertices(numPolys,numVerts,ShaderClass::_PresetOpaqueShader);

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,6 +2,26 @@
 
 ---
 
+## 2026-04-11 (SESSION 114): Fix Zero Hour animated 3D shadow corruption on dynamic casters
+
+Resolved issue #15 where animated shadows (for example flags and rotor meshes) were rendering incorrectly in Zero Hour while static shadows remained correct.
+
+What was changed:
+- `GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp`
+  - restored dynamic shadow vertex stream rebinding in `W3DVolumetricShadow::RenderDynamicMeshVolume`.
+  - added guarded `SetStreamSource` update when `shadowVertexBufferD3D` differs from `lastActiveVertexBuffer`.
+- `docs/WORKDIR/lessons/2026-04-LESSONS.md`
+  - documented root cause, fix pattern, and prevention note for render-state drift between Generals and Zero Hour paths.
+
+Why:
+- The dynamic shadow draw path in Zero Hour could execute with stale vertex stream state, which explains why animated casters broke while static paths looked correct.
+- User validation confirmed that disabling `3D shadows` removed the artifact, isolating the fault to the volumetric shadow path.
+
+Validation:
+- `get_errors` reported no diagnostics in the edited rendering file.
+- Local direct build path was blocked by stale host cache (`/work` CMake cache mismatch), so runtime validation used existing workflow and manual in-game verification.
+- In-game user validation confirmed shadows are now rendering correctly.
+
 ## 2026-04-08 (SESSION 113): Remove stale local DXVK patch-flow narrative
 
 Aligned macOS DXVK docs and CMake comments with the current pinned-fork source model and deprecated the old local patch helper script.

--- a/docs/WORKDIR/lessons/2026-04-LESSONS.md
+++ b/docs/WORKDIR/lessons/2026-04-LESSONS.md
@@ -1,5 +1,13 @@
 # 2026-04 Lessons Learned
 
+## Session 2026-04-11 - Dynamic shadow draws need explicit stream rebinding
+
+- Problem: Animated object shadows (flags, rotor parts) in Zero Hour rendered incorrectly, while static shadows looked fine and the issue disappeared when `3D shadows` was disabled.
+- Root cause: `W3DVolumetricShadow::RenderDynamicMeshVolume` in Zero Hour missed the `SetStreamSource` rebind, so dynamic volume draws could use stale vertex stream state.
+- Fix: Restored vertex stream rebinding before dynamic shadow draw calls when the active buffer differs from `lastActiveVertexBuffer`.
+- Validation: Static diagnostics reported no errors in the edited file; local non-docker build path was not usable due existing cache path mismatch, so full runtime verification is pending smoke test.
+- Prevention: Keep dynamic and static shadow render paths behaviorally aligned between `Generals` and `GeneralsMD`, and audit render-state rebinding when cleaning refactor artifacts.
+
 ## Session 2026-04-01 - User-facing path migrations need runtime fallback, not just docs updates
 
 - Problem: Zero Hour user-facing scripts and docs exposed the internal `GeneralsMD` path, which leaks implementation details and conflicts with product naming (`GeneralsZH`).


### PR DESCRIPTION
## Summary

This PR fixes issue #15 by restoring dynamic shadow vertex stream rebinding in the Zero Hour volumetric shadow path.

Animated casters (for example flags and rotor meshes) were rendered through the dynamic shadow path and could draw with stale vertex stream state.

## Root Cause

In `W3DVolumetricShadow::RenderDynamicMeshVolume` (Zero Hour path), the dynamic draw call was missing a guarded `SetStreamSource` update before `DrawIndexedPrimitive`.

That allowed stale stream state to leak from prior draws and corrupt animated shadow geometry while static shadows still looked correct.

## Changes

- Restored guarded stream rebinding in:
  - `GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp`
- Added session documentation updates:
  - `docs/WORKDIR/lessons/2026-04-LESSONS.md`
  - `docs/DEV_BLOG/2026-04-DIARY.md`

## Validation

- Static diagnostics reported no errors in the edited render file.
- In-game validation confirmed animated 3D shadows now render correctly.

Closes #15
