### PR TITLE
sync: merge TheSuperHackers main (04-11-2026)

### DIFF
--- a/Core/GameEngine/Include/GameClient/ParticleSys.h
+++ b/Core/GameEngine/Include/GameClient/ParticleSys.h
@@ -840,14 +840,14 @@ private:
 class ParticleSystemManagerDummy : public ParticleSystemManager
 {
 public:
-	Int getOnScreenParticleCount() override { return 0; }
-	void doParticles(RenderInfoClass &rinfo) override {}
-	void queueParticleRender() override {}
+	virtual Int getOnScreenParticleCount() override { return 0; }
+	virtual void doParticles(RenderInfoClass &rinfo) override {}
+	virtual void queueParticleRender() override {}
 
 protected:
-	void crc( Xfer *xfer ) override {}
-	void xfer( Xfer *xfer ) override {}
-	void loadPostProcess() override {}
+	virtual void crc( Xfer *xfer ) override {}
+	virtual void xfer( Xfer *xfer ) override {}
+	virtual void loadPostProcess() override {}
 };
 
 /// The particle system manager singleton

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1001,7 +1001,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 			{
 				DEBUG_LOG(("META: select team %d",group));
 
-				UnsignedInt now = TheGameLogic->getFrame();
+				UnsignedInt now = timeGetTime();
 				if ( m_lastGroupSelTime == 0 )
 				{
 					m_lastGroupSelTime = now;
@@ -1010,7 +1010,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 				Bool performSelection = TRUE;
 
 				// check for double-press to jump view
-				if ( now - m_lastGroupSelTime < 20 && group == m_lastGroupSelGroup )
+				if ( now - m_lastGroupSelTime < TheGlobalData->m_doubleClickTimeMS && group == m_lastGroupSelGroup )
 				{
 					DEBUG_LOG(("META: DOUBLETAP select team %d",group));
 					// TheSuperHackers @bugfix Stubbjax 26/05/2025 Perform selection on double-press
@@ -1082,7 +1082,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 			{
 				DEBUG_LOG(("META: select team %d",group));
 
-				UnsignedInt now = TheGameLogic->getFrame();
+				UnsignedInt now = timeGetTime();
 				if ( m_lastGroupSelTime == 0 )
 				{
 					m_lastGroupSelTime = now;
@@ -1090,7 +1090,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 
 				// check for double-press to jump view
 
-				if ( now - m_lastGroupSelTime < 20 && group == m_lastGroupSelGroup )
+				if ( now - m_lastGroupSelTime < TheGlobalData->m_doubleClickTimeMS && group == m_lastGroupSelGroup )
 				{
 					DEBUG_LOG(("META: DOUBLETAP select team %d",group));
 					Player *player = ThePlayerList->getLocalPlayer();

--- a/Generals/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
+++ b/Generals/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
@@ -64,68 +64,68 @@ class GUIEditDisplay : public Display
 public:
 
 	GUIEditDisplay( void );
-	virtual ~GUIEditDisplay( void );
+	virtual ~GUIEditDisplay( void ) override;
 
-	virtual void draw( void ) { };
+	virtual void draw( void ) override { };
 
 	/// draw a line on the display in pixel coordinates with the specified color
 	virtual void drawLine( Int startX, Int startY, Int endX, Int endY,
-												 Real lineWidth, UnsignedInt lineColor );
+												 Real lineWidth, UnsignedInt lineColor ) override;
 	virtual void drawLine( Int startX, Int startY, Int endX, Int endY,
-												 Real lineWidth, UnsignedInt lineColor1, UnsignedInt lineColor2 ) { }
+												 Real lineWidth, UnsignedInt lineColor1, UnsignedInt lineColor2 ) override { }
 	/// draw a rect border on the display in pixel coordinates with the specified color
 	virtual void drawOpenRect( Int startX, Int startY, Int width, Int height,
-														 Real lineWidth, UnsignedInt lineColor );
+														 Real lineWidth, UnsignedInt lineColor ) override;
 	/// draw a filled rect on the display in pixel coords with the specified color
 	virtual void drawFillRect( Int startX, Int startY, Int width, Int height,
-														 UnsignedInt color );
+														 UnsignedInt color ) override;
 
 	/// Draw a percentage of a rectangle, much like a clock
-	virtual void drawRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color) { }
-	virtual void drawRemainingRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color) { }
+	virtual void drawRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color) override { }
+	virtual void drawRemainingRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color) override { }
 
 	/// draw an image fit within the screen coordinates
 	virtual void drawImage( const Image *image, Int startX, Int startY,
-													Int endX, Int endY, Color color = 0xFFFFFFFF, DrawImageMode mode=DRAW_IMAGE_ALPHA);
+													Int endX, Int endY, Color color = 0xFFFFFFFF, DrawImageMode mode=DRAW_IMAGE_ALPHA) override;
 	/// image clipping support
-	virtual void setClipRegion( IRegion2D *region );
-	virtual Bool isClippingEnabled( void );
-	virtual void enableClipping( Bool onoff );
+	virtual void setClipRegion( IRegion2D *region ) override;
+	virtual Bool isClippingEnabled( void ) override;
+	virtual void enableClipping( Bool onoff ) override;
 
 	// These are stub functions to allow compilation:
 
 	/// Create a video buffer that can be used for this display
-	virtual VideoBuffer*	createVideoBuffer( void ) { return nullptr; }
+	virtual VideoBuffer*	createVideoBuffer( void ) override { return nullptr; }
 
 	/// draw a video buffer fit within the screen coordinates
-	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream ) { }
+	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream ) override { }
 	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY,
-																Int endX, Int endY ) { }
-	virtual void takeScreenShot(void){ }
-	virtual void toggleMovieCapture(void) {}
+																Int endX, Int endY ) override { }
+	virtual void takeScreenShot(void) override { }
+	virtual void toggleMovieCapture(void) override {}
 
 	// methods that we need to stub
-	virtual void setTimeOfDay( TimeOfDay tod ) {}
+	virtual void setTimeOfDay( TimeOfDay tod ) override {}
 	virtual void createLightPulse( const Coord3D *pos, const RGBColor *color, Real innerRadius, Real attenuationWidth,
-																 UnsignedInt increaseFrameTime, UnsignedInt decayFrameTime ) {}
-	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting) {}
-	void setBorderShroudLevel(UnsignedByte level){}
-	virtual void clearShroud() {}
-	virtual void preloadModelAssets( AsciiString model ) {}
-	virtual void preloadTextureAssets( AsciiString texture ) {}
-	virtual void toggleLetterBox(void) {}
-	virtual void enableLetterBox(Bool enable) {}
+																 UnsignedInt increaseFrameTime, UnsignedInt decayFrameTime ) override {}
+	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting) override {}
+	virtual void setBorderShroudLevel(UnsignedByte level) override {}
+	virtual void clearShroud() override {}
+	virtual void preloadModelAssets( AsciiString model ) override {}
+	virtual void preloadTextureAssets( AsciiString texture ) override {}
+	virtual void toggleLetterBox(void) override {}
+	virtual void enableLetterBox(Bool enable) override {}
 #if defined(RTS_DEBUG)
 	virtual void dumpModelAssets(const char *path) {}
 #endif
-	virtual void doSmartAssetPurgeAndPreload(const char* usageFileName) {}
+	virtual void doSmartAssetPurgeAndPreload(const char* usageFileName) override {}
 #if defined(RTS_DEBUG)
 	virtual void dumpAssetUsage(const char* mapname) {}
 #endif
 
-	virtual Real getAverageFPS(void) { return 0; }
-	virtual Real getCurrentFPS(void) { return 0; }
-	virtual Int getLastFrameDrawCalls( void ) { return 0; }
+	virtual Real getAverageFPS(void) override { return 0; }
+	virtual Real getCurrentFPS(void) override { return 0; }
+	virtual Int getLastFrameDrawCalls( void ) override { return 0; }
 
 protected:
 

--- a/Generals/Code/Tools/GUIEdit/Include/GUIEditWindowManager.h
+++ b/Generals/Code/Tools/GUIEdit/Include/GUIEditWindowManager.h
@@ -46,16 +46,16 @@ class GUIEditWindowManager : public W3DGameWindowManager
 public:
 
 	GUIEditWindowManager( void );
-	virtual ~GUIEditWindowManager( void );
+	virtual ~GUIEditWindowManager( void ) override;
 
-	virtual void init( void );  ///< initialize system
+	virtual void init( void ) override;  ///< initialize system
 
-	virtual Int winDestroy( GameWindow *window );  ///< destroy this window
+	virtual Int winDestroy( GameWindow *window ) override;  ///< destroy this window
 	/// create a new window by setting up parameters and callbacks
 	virtual GameWindow *winCreate( GameWindow *parent, UnsignedInt status,
 																 Int x, Int y, Int width, Int height,
 																 GameWinSystemFunc system,
-																 WinInstanceData *instData = nullptr );
+																 WinInstanceData *instData = nullptr ) override;
 
 	// **************************************************************************
 	// GUIEdit specific methods *************************************************

--- a/Generals/Code/Tools/WorldBuilder/include/AutoEdgeOutTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/AutoEdgeOutTool.h
@@ -33,10 +33,10 @@ class AutoEdgeOutTool : public Tool
 {
 public:
 	AutoEdgeOutTool(void);
-	~AutoEdgeOutTool(void);
+	virtual ~AutoEdgeOutTool(void) override;
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
 };

--- a/Generals/Code/Tools/WorldBuilder/include/BaseBuildProps.h
+++ b/Generals/Code/Tools/WorldBuilder/include/BaseBuildProps.h
@@ -41,7 +41,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(BaseBuildProps)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -49,8 +49,8 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(BaseBuildProps)
-	virtual BOOL OnInitDialog();
-	virtual void OnOK();
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 

--- a/Generals/Code/Tools/WorldBuilder/include/BlendEdgeTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/BlendEdgeTool.h
@@ -36,11 +36,11 @@ protected:
 
 public:
 	BlendEdgeTool(void);
-	~BlendEdgeTool(void);
+	virtual ~BlendEdgeTool(void) override;
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
 
 };

--- a/Generals/Code/Tools/WorldBuilder/include/BlendMaterial.h
+++ b/Generals/Code/Tools/WorldBuilder/include/BlendMaterial.h
@@ -45,10 +45,10 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(BlendMaterial)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -56,7 +56,7 @@ protected:
 	enum {MIN_TILE_SIZE=2, MAX_TILE_SIZE = 100};
 	// Generated message map functions
 	//{{AFX_MSG(BlendMaterial)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 

--- a/Generals/Code/Tools/WorldBuilder/include/BorderTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/BorderTool.h
@@ -32,17 +32,17 @@ class BorderTool : public Tool
 
 	public:
 		BorderTool();
-		~BorderTool();
+		virtual ~BorderTool() override;
 
 		Int getToolID(void) {return m_toolID;}
-		virtual void setCursor(void);
+		virtual void setCursor(void) override;
 
-		virtual void activate();
-		virtual void deactivate();
+		virtual void activate() override;
+		virtual void deactivate() override;
 
-		virtual Bool followsTerrain(void) { return false;	}
+		virtual Bool followsTerrain(void) override { return false;	}
 
-		virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-		virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-		virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
+		virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+		virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+		virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
 };

--- a/Generals/Code/Tools/WorldBuilder/include/BrushTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/BrushTool.h
@@ -42,7 +42,7 @@ protected:
 
 public:
 	BrushTool(void);
-	~BrushTool(void);
+	virtual ~BrushTool(void) override;
 
 public:
 	static Int getWidth(void) {return m_brushWidth;};  ///<Returns width.
@@ -53,11 +53,11 @@ public:
 	static void setHeight(Int height);
 
 public:
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual WorldHeightMapEdit *getHeightMap(void) {return m_htMapEditCopy;};
-	virtual void activate(); ///< Become the current tool.
-	virtual Bool followsTerrain(void) {return false;};
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual WorldHeightMapEdit *getHeightMap(void) override {return m_htMapEditCopy;};
+	virtual void activate() override; ///< Become the current tool.
+	virtual Bool followsTerrain(void) override {return false;};
 
 };

--- a/Generals/Code/Tools/WorldBuilder/include/BuildList.h
+++ b/Generals/Code/Tools/WorldBuilder/include/BuildList.h
@@ -36,7 +36,7 @@ class BuildList : public COptionsPanel, public PopupSliderOwner
 public:
  	BuildList(CWnd* pParent = nullptr);   ///< standard constructor
 
-	~BuildList(void);   ///< standard destructor
+	virtual ~BuildList(void) override;   ///< standard destructor
 	enum { NAME_MAX_LEN = 64 };
 // Dialog Data
 	//{{AFX_DATA(BuildList)
@@ -49,9 +49,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(BuildList)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -59,7 +59,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(BuildList)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSelchangeSidesCombo();
 	afx_msg void OnMoveUp();
 	afx_msg void OnMoveDown();
@@ -97,9 +97,9 @@ public:
 	static void update(void) {if (m_staticThis) m_staticThis->loadSides();};
 	static void setSelectedBuildList(BuildListInfo *pInfo);
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 
 };
 

--- a/Generals/Code/Tools/WorldBuilder/include/BuildListTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/BuildListTool.h
@@ -56,7 +56,7 @@ protected:
 
 public:
 	BuildListTool(void);
-	~BuildListTool(void);
+	virtual ~BuildListTool(void) override;
 
 private:
 	void createWindow(void);
@@ -68,10 +68,10 @@ public:
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void setCursor(void);
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become not the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void setCursor(void) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become not the current tool.
 };

--- a/Generals/Code/Tools/WorldBuilder/include/CButtonShowColor.h
+++ b/Generals/Code/Tools/WorldBuilder/include/CButtonShowColor.h
@@ -27,7 +27,7 @@ class CButtonShowColor : public CButton
 		const RGBColor& getColor(void) const { return m_color; }
 		void setColor(Int color) { m_color.setFromInt(color); }
 		void setColor(const RGBColor& color) { m_color = color; }
-		~CButtonShowColor();
+		virtual ~CButtonShowColor() override;
 
 
 		static COLORREF RGBtoBGR(Int color);

--- a/Generals/Code/Tools/WorldBuilder/include/CFixTeamOwnerDialog.h
+++ b/Generals/Code/Tools/WorldBuilder/include/CFixTeamOwnerDialog.h
@@ -31,8 +31,8 @@ class CFixTeamOwnerDialog : public CDialog
 		Bool pickedValidTeam() { return m_pickedValidTeam; }
 
 	protected:
-		virtual BOOL OnInitDialog();
-		afx_msg void OnOK();
+		virtual BOOL OnInitDialog() override;
+		virtual afx_msg void OnOK() override;
 		DECLARE_MESSAGE_MAP()
 
 	protected:

--- a/Generals/Code/Tools/WorldBuilder/include/CUndoable.h
+++ b/Generals/Code/Tools/WorldBuilder/include/CUndoable.h
@@ -42,7 +42,7 @@ protected:
 public:
 		Undoable(void);
 
-		~Undoable(void);
+		virtual ~Undoable(void) override;
 
 public:
 	virtual void Do(void)=0; ///< pure virtual.
@@ -77,10 +77,10 @@ public:
 		WBDocUndoable(CWorldBuilderDoc *pDoc, WorldHeightMapEdit *pNewHtMap, Coord3D *pObjOffset = nullptr);
 
 		// destructor.
-		~WBDocUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
-		virtual void Redo(void);
+		virtual ~WBDocUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
+		virtual void Redo(void) override;
 
 };
 
@@ -99,9 +99,9 @@ public:
 		AddObjectUndoable(CWorldBuilderDoc *pDoc, MapObject *pObjectToAdd);
 
 		// destructor.
-		~AddObjectUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~AddObjectUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 
@@ -146,11 +146,11 @@ protected:
 public:
 		ModifyObjectUndoable(CWorldBuilderDoc *pDoc);
 		// destructor.
-		~ModifyObjectUndoable(void);
+		virtual ~ModifyObjectUndoable(void) override;
 
-		virtual void Do(void);
-		virtual void Undo(void);
-		virtual void Redo(void);
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
+		virtual void Redo(void) override;
 
 		void SetOffset(Real x, Real y);
 		void SetZOffset(Real z);
@@ -188,11 +188,11 @@ protected:
 public:
 		ModifyFlagsUndoable(CWorldBuilderDoc *pDoc, Int flagMask, Int flagValue);
 		// destructor.
-		~ModifyFlagsUndoable(void);
+		virtual ~ModifyFlagsUndoable(void) override;
 
-		virtual void Do(void);
-		virtual void Undo(void);
-		virtual void Redo(void);
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
+		virtual void Redo(void) override;
 
 };
 
@@ -205,10 +205,10 @@ protected:
 public:
 
 	SidesListUndoable(const SidesList& newSL, CWorldBuilderDoc *pDoc);
-	~SidesListUndoable(void);
+	virtual ~SidesListUndoable(void) override;
 
-	virtual void Do(void);
-	virtual void Undo(void);
+	virtual void Do(void) override;
+	virtual void Undo(void) override;
 
 };
 
@@ -231,10 +231,10 @@ public:
 	// if you want to substitute the entire contents of the new dict, pass NAMEKEY_INVALID.
 	DictItemUndoable(Dict **d, Dict data, NameKeyType key, Int dictsToModify = 1, CWorldBuilderDoc *pDoc = nullptr, Bool inval = false);
 	// destructor.
-	~DictItemUndoable(void);
+	virtual ~DictItemUndoable(void) override;
 
-	virtual void Do(void);
-	virtual void Undo(void);
+	virtual void Do(void) override;
+	virtual void Undo(void) override;
 
 };
 
@@ -267,9 +267,9 @@ public:
 		DeleteObjectUndoable(CWorldBuilderDoc *pDoc);
 
 		// destructor.
-		~DeleteObjectUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~DeleteObjectUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 ///                            AddPolygonUndoable
@@ -282,9 +282,9 @@ protected:
 public:
 		AddPolygonUndoable( PolygonTrigger *pTrig);
 		// destructor.
-		~AddPolygonUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~AddPolygonUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 ///                            AddPolygonPointUndoable
@@ -297,9 +297,9 @@ protected:
 public:
 		AddPolygonPointUndoable(PolygonTrigger *pTrig, ICoord3D pt);
 		// destructor.
-		~AddPolygonPointUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~AddPolygonPointUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 ///                            ModifyPolygonPointUndoable
@@ -314,9 +314,9 @@ protected:
 public:
 		ModifyPolygonPointUndoable(PolygonTrigger *pTrig, Int ndx);
 		// destructor.
-		~ModifyPolygonPointUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~ModifyPolygonPointUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 ///                            MovePolygonUndoable
@@ -330,9 +330,9 @@ protected:
 public:
 		MovePolygonUndoable(PolygonTrigger *pTrig);
 		// destructor.
-		~MovePolygonUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~MovePolygonUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 
 		void SetOffset(const ICoord3D &offset);
 		PolygonTrigger *getTrigger(void) {return m_trigger;}
@@ -349,9 +349,9 @@ protected:
 public:
 		InsertPolygonPointUndoable(PolygonTrigger *pTrig, ICoord3D pt, Int ndx);
 		// destructor.
-		~InsertPolygonPointUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~InsertPolygonPointUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 ///                            DeletePolygonPointUndoable
@@ -365,9 +365,9 @@ protected:
 public:
 		DeletePolygonPointUndoable(PolygonTrigger *pTrig, Int ndx);
 		// destructor.
-		~DeletePolygonPointUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~DeletePolygonPointUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 ///                            DeletePolygonUndoable
@@ -380,7 +380,7 @@ protected:
 public:
 		DeletePolygonUndoable(PolygonTrigger *pTrig);
 		// destructor.
-		~DeletePolygonUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~DeletePolygonUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };

--- a/Generals/Code/Tools/WorldBuilder/include/CameraOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/CameraOptions.h
@@ -44,7 +44,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CameraOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -54,7 +54,7 @@ protected:
 	//{{AFX_MSG(CameraOptions)
 	afx_msg void OnCameraReset();
 	afx_msg void OnMove(int x, int y);
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangePitchEdit();
 	afx_msg void OnShowWindow(BOOL bShow, UINT nStatus);
 	//}}AFX_MSG
@@ -73,9 +73,9 @@ protected:
 
 public: // popup slider interface.
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 
 public:
 	void update( void );

--- a/Generals/Code/Tools/WorldBuilder/include/CellWidth.h
+++ b/Generals/Code/Tools/WorldBuilder/include/CellWidth.h
@@ -42,8 +42,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CellWidth)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK();
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -54,7 +54,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CellWidth)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/Generals/Code/Tools/WorldBuilder/include/ContourOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ContourOptions.h
@@ -48,7 +48,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(ContourOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -56,7 +56,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(ContourOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
 	afx_msg void OnShowContours();
 	//}}AFX_MSG

--- a/Generals/Code/Tools/WorldBuilder/include/DrawObject.h
+++ b/Generals/Code/Tools/WorldBuilder/include/DrawObject.h
@@ -46,26 +46,26 @@ public:
 	DrawObject(void);
 	DrawObject(const DrawObject & src);
 	DrawObject & operator = (const DrawObject &);
-	~DrawObject(void);
+	virtual ~DrawObject(void) override;
 
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface
 	/////////////////////////////////////////////////////////////////////////////
-	virtual RenderObjClass *	Clone(void) const;
-	virtual int						Class_ID(void) const;
-	virtual void					Render(RenderInfoClass & rinfo);
+	virtual RenderObjClass *	Clone(void) const override;
+	virtual int						Class_ID(void) const override;
+	virtual void					Render(RenderInfoClass & rinfo) override;
 //	virtual void					Special_Render(SpecialRenderInfoClass & rinfo);
 //	virtual void 					Set_Transform(const Matrix3D &m);
 //	virtual void 					Set_Position(const Vector3 &v);
 //TODO: MW: do these later - only needed for collision detection
-	virtual Bool					Cast_Ray(RayCollisionTestClass & raytest);
+	virtual Bool					Cast_Ray(RayCollisionTestClass & raytest) override;
 //	virtual Bool					Cast_AABox(AABoxCollisionTestClass & boxtest);
 //	virtual Bool					Cast_OBBox(OBBoxCollisionTestClass & boxtest);
 //	virtual Bool					Intersect_AABox(AABoxIntersectionTestClass & boxtest);
 //	virtual Bool					Intersect_OBBox(OBBoxIntersectionTestClass & boxtest);
 
-	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const;
-    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const;
+	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
+	virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const override;
 
 
 //	virtual int					 	Get_Num_Polys(void) const;

--- a/Generals/Code/Tools/WorldBuilder/include/EditAction.h
+++ b/Generals/Code/Tools/WorldBuilder/include/EditAction.h
@@ -45,8 +45,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(EditAction)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -67,7 +67,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(EditAction)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSelchangeScriptActionType();
 	afx_msg void OnTimer(UINT nIDEvent);
 	//}}AFX_MSG

--- a/Generals/Code/Tools/WorldBuilder/include/EditCondition.h
+++ b/Generals/Code/Tools/WorldBuilder/include/EditCondition.h
@@ -44,8 +44,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(EditCondition)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -66,7 +66,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(EditCondition)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSelchangeConditionType();
 	afx_msg void OnTimer(UINT nIDEvent);
 	//}}AFX_MSG

--- a/Generals/Code/Tools/WorldBuilder/include/EditCoordParameter.h
+++ b/Generals/Code/Tools/WorldBuilder/include/EditCoordParameter.h
@@ -43,7 +43,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(EditCoordParameter)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -59,9 +59,9 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(EditCoordParameter)
-	virtual BOOL OnInitDialog();
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/Generals/Code/Tools/WorldBuilder/include/EditGroup.h
+++ b/Generals/Code/Tools/WorldBuilder/include/EditGroup.h
@@ -42,7 +42,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(EditGroup)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -53,8 +53,8 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(EditGroup)
-	virtual void OnOK();
-	virtual BOOL OnInitDialog();
+	virtual void OnOK() override;
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/Generals/Code/Tools/WorldBuilder/include/EditObjectParameter.h
+++ b/Generals/Code/Tools/WorldBuilder/include/EditObjectParameter.h
@@ -43,7 +43,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(EditObjectParameter)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -62,9 +62,9 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(EditObjectParameter)
-	virtual BOOL OnInitDialog();
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/Generals/Code/Tools/WorldBuilder/include/EditParameter.h
+++ b/Generals/Code/Tools/WorldBuilder/include/EditParameter.h
@@ -44,7 +44,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(EditParameter)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -115,9 +115,9 @@ protected:
 	//{{AFX_MSG(EditParameter)
 	afx_msg void OnChangeEdit();
 	afx_msg void OnEditchangeCombo();
-	virtual BOOL OnInitDialog();
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	afx_msg void OnPreviewSound();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/Generals/Code/Tools/WorldBuilder/include/ExportScriptsOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ExportScriptsOptions.h
@@ -41,7 +41,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(ExportScriptsOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -61,8 +61,8 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(ExportScriptsOptions)
-	virtual void OnOK();
-	virtual BOOL OnInitDialog();
+	virtual void OnOK() override;
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/Generals/Code/Tools/WorldBuilder/include/EyedropperTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/EyedropperTool.h
@@ -33,10 +33,10 @@ class EyedropperTool : public Tool
 {
 public:
 	EyedropperTool(void);
-	~EyedropperTool(void);
+	virtual ~EyedropperTool(void) override;
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
 };

--- a/Generals/Code/Tools/WorldBuilder/include/FeatherOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/FeatherOptions.h
@@ -50,9 +50,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(FeatherOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -60,7 +60,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(FeatherOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeSizeEdit();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
@@ -83,9 +83,9 @@ public:
 
 public:
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 
 };
 

--- a/Generals/Code/Tools/WorldBuilder/include/FeatherTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/FeatherTool.h
@@ -41,15 +41,15 @@ protected:
 	static Int m_radius;
 public:
 	FeatherTool(void);
-	~FeatherTool(void);
+	virtual ~FeatherTool(void) override;
 
 	static void setFeather(Int feather);
 	static void setRate(Int rate);
 	static void setRadius(Int Radius);
 public:
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual WorldHeightMapEdit *getHeightMap(void) {return m_htMapEditCopy;};
-	virtual void activate(); ///< Become the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual WorldHeightMapEdit *getHeightMap(void) override {return m_htMapEditCopy;};
+	virtual void activate() override; ///< Become the current tool.
 };

--- a/Generals/Code/Tools/WorldBuilder/include/FenceOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/FenceOptions.h
@@ -35,7 +35,7 @@ class FenceOptions : public COptionsPanel
 public:
 	FenceOptions(CWnd* pParent = nullptr);   ///< standard constructor
 
-	~FenceOptions(void);   ///< standard destructor
+	virtual ~FenceOptions(void) override;   ///< standard destructor
 	enum { NAME_MAX_LEN = 64 };
 // Dialog Data
 	//{{AFX_DATA(FenceOptions)
@@ -48,10 +48,10 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(FenceOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -59,7 +59,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(FenceOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeFenceSpacingEdit();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/Generals/Code/Tools/WorldBuilder/include/FenceTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/FenceTool.h
@@ -42,15 +42,15 @@ protected:
 
 public:
 	FenceTool(void);
-	~FenceTool(void);
+	virtual ~FenceTool(void) override;
 
 protected:
 	void updateMapObjectList(Coord3D downPt, Coord3D curPt, WbView* pView, CWorldBuilderDoc *pDoc, Bool checkPlayers);
 
 public:
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become not the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become not the current tool.
 };

--- a/Generals/Code/Tools/WorldBuilder/include/FloodFillTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/FloodFillTool.h
@@ -32,7 +32,7 @@ class FloodFillTool : public Tool
 {
 public:
 	FloodFillTool(void);
-	~FloodFillTool(void);
+	virtual ~FloodFillTool(void) override;
 
 protected:
 	Int			m_textureClassToDraw; ///< The texture to fill with.  Foreground for mousedDown, background for mouseDownRt.
@@ -40,9 +40,9 @@ protected:
 	static Bool m_adjustCliffTextures;
 
 public:
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
-	virtual void setCursor(void);
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void setCursor(void) override;
 
 	Bool getAdjustCliffs(void) {return m_adjustCliffTextures;}
 	void setAdjustCliffs(Bool val) {m_adjustCliffTextures = val;}

--- a/Generals/Code/Tools/WorldBuilder/include/GlobalLightOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/GlobalLightOptions.h
@@ -53,7 +53,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(GlobalLightOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -61,7 +61,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(GlobalLightOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnShowWindow(BOOL bShow, UINT nStatus);
 	afx_msg void OnMove(int x, int y);
 	afx_msg void OnChangeFrontBackEdit();
@@ -73,8 +73,8 @@ protected:
 	afx_msg void OnColorPress();
 	afx_msg void OnResetLights();
 	afx_msg void OnClose();
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 
@@ -127,9 +127,9 @@ protected:
 	void stuffValuesIntoFields(Int lightIndex = 0);
 public:
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 
 };
 

--- a/Generals/Code/Tools/WorldBuilder/include/GroveOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/GroveOptions.h
@@ -46,10 +46,10 @@ class GroveOptions : public COptionsPanel
 
 	public:
 		GroveOptions(CWnd* pParent = nullptr);
-		~GroveOptions();
+		virtual ~GroveOptions() override;
 		void makeMain(void);
 
-		virtual BOOL OnInitDialog();
+		virtual BOOL OnInitDialog() override;
 		int getNumTrees(void);
 		int getNumType(int type);
 		AsciiString getTypeName(int type);
@@ -69,7 +69,7 @@ class GroveOptions : public COptionsPanel
 		afx_msg void _updateGroveMakeup(void);
 		afx_msg void _updatePlacementAllowed(void);
 
-		virtual void OnOK();
+		virtual void OnOK() override;
 		virtual void OnClose();
 	DECLARE_MESSAGE_MAP()
 };

--- a/Generals/Code/Tools/WorldBuilder/include/GroveTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/GroveTool.h
@@ -46,15 +46,15 @@ protected:
 	void _plantGroveInBox(CPoint tl, CPoint br, WbView* pView);
 
 	void addObj(Coord3D *pos, AsciiString name);
-	void activate();
+	virtual void activate() override;
 
 public:
 	GroveTool(void);
-	~GroveTool(void);
+	virtual ~GroveTool(void) override;
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
 };

--- a/Generals/Code/Tools/WorldBuilder/include/HandScrollTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/HandScrollTool.h
@@ -31,7 +31,7 @@ class HandScrollTool : public Tool
 {
 public:
 	HandScrollTool(void);
-	~HandScrollTool(void);
+	virtual ~HandScrollTool(void) override;
 
 protected:
 	enum {HYSTERESIS = 3};
@@ -42,11 +42,11 @@ protected:
 
 public:
 	/// Start scrolling.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
 	/// Scroll.
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
 	/// End scroll.
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
-	virtual Bool followsTerrain(void) {return false;};
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual Bool followsTerrain(void) override {return false;};
 };

--- a/Generals/Code/Tools/WorldBuilder/include/ImpassableOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ImpassableOptions.h
@@ -25,7 +25,7 @@ class ImpassableOptions : public CDialog
 
 	public:
 		ImpassableOptions(CWnd* pParent = nullptr, Real defaultSlope = 45.0f);
-		virtual ~ImpassableOptions();
+		virtual ~ImpassableOptions() override;
 		Real GetSlopeToShow() const { return m_slopeToShow; }
 		Real GetDefaultSlope() const { return m_defaultSlopeToShow; }
 		void SetDefaultSlopeToShow(Real slopeToShow) { m_slopeToShow = slopeToShow; }
@@ -38,7 +38,7 @@ class ImpassableOptions : public CDialog
 		Bool ValidateSlope();	// Returns TRUE if it was valid, FALSE if it had to adjust it.
 
 	protected:
-		virtual BOOL OnInitDialog();
+		virtual BOOL OnInitDialog() override;
 		afx_msg void OnAngleChange();
 		afx_msg void OnPreview();
 		DECLARE_MESSAGE_MAP()

--- a/Generals/Code/Tools/WorldBuilder/include/LayersList.h
+++ b/Generals/Code/Tools/WorldBuilder/include/LayersList.h
@@ -82,7 +82,7 @@ class LayersList : public CDialog
 	public:
 		enum { IDD = IDD_LAYERSLIST };
 		LayersList(UINT nIDTemplate = LayersList::IDD, CWnd *parentWnd = nullptr);
-		virtual ~LayersList();
+		virtual ~LayersList() override;
 
 		void resetLayers();
 		void addMapObjectToLayersList(IN MapObject *objToAdd, AsciiString layerToAddTo = AsciiString(TheDefaultLayerName.c_str()));
@@ -139,9 +139,9 @@ class LayersList : public CDialog
 		void removeMapObjectFromLayer(IN MapObject *objToRemove, IN ListLayerIt *layerIt = nullptr, IN ListMapObjectPtrIt *MapObjectIt = nullptr);
 
 	protected:
-		virtual void OnOK();
-		virtual void OnCancel();
-		virtual BOOL OnInitDialog();
+		virtual void OnOK() override;
+		virtual void OnCancel() override;
+		virtual BOOL OnInitDialog() override;
 
 		afx_msg void OnBeginEditLabel(NMHDR *pNotifyStruct, LRESULT* pResult);
 		afx_msg void OnEndEditLabel(NMHDR *pNotifyStruct, LRESULT* pResult);

--- a/Generals/Code/Tools/WorldBuilder/include/LightOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/LightOptions.h
@@ -44,9 +44,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(LightOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -54,7 +54,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(LightOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeLightEdit();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/Generals/Code/Tools/WorldBuilder/include/MainFrm.h
+++ b/Generals/Code/Tools/WorldBuilder/include/MainFrm.h
@@ -68,12 +68,12 @@ public:
 // Overrides
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CMainFrame)
-	virtual BOOL PreCreateWindow(CREATESTRUCT& cs);
+	virtual BOOL PreCreateWindow(CREATESTRUCT& cs) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
 public:
-	virtual ~CMainFrame();
+	virtual ~CMainFrame() override;
 #ifdef RTS_DEBUG
 	virtual void AssertValid() const;
 	virtual void Dump(CDumpContext& dc) const;

--- a/Generals/Code/Tools/WorldBuilder/include/MapSettings.h
+++ b/Generals/Code/Tools/WorldBuilder/include/MapSettings.h
@@ -41,7 +41,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(MapSettings)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -51,8 +51,8 @@ protected:
 	//{{AFX_MSG(MapSettings)
 	afx_msg void OnChangeMapTimeofday();
 	afx_msg void OnChangeMapWeather();
-	virtual BOOL OnInitDialog();
-	virtual void OnOK();
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override;
 	afx_msg void OnChangeMapTitle();
 	afx_msg void OnChangeMapCompression();
 	//}}AFX_MSG

--- a/Generals/Code/Tools/WorldBuilder/include/MeshMoldOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/MeshMoldOptions.h
@@ -50,11 +50,11 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(MeshMoldOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnInitDialog();
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -103,9 +103,9 @@ public:
 	static AsciiString getModelName(void) {if (m_staticThis) return m_staticThis->m_meshModelName; return "";};
 
 public:	 //PopupSliderOwner methods.
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 };
 
 //{{AFX_INSERT_LOCATION}}

--- a/Generals/Code/Tools/WorldBuilder/include/MeshMoldTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/MeshMoldTool.h
@@ -42,7 +42,7 @@ protected:
 
 public:
 	MeshMoldTool(void);
-	~MeshMoldTool(void);
+	virtual ~MeshMoldTool(void) override;
 protected:
 	static void applyMesh(CWorldBuilderDoc *pDoc);  ///< Apply the mesh to copy of terrain.
 
@@ -50,13 +50,13 @@ public:
 	static void apply(CWorldBuilderDoc *pDoc);  ///< Apply the mesh to the terrain & execute undoable.
 
 public:  //Tool methods.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual WorldHeightMapEdit *getHeightMap(void) {return m_htMapEditCopy;};
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become the current tool.
-	virtual Bool followsTerrain(void) {return false;};
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual WorldHeightMapEdit *getHeightMap(void) override {return m_htMapEditCopy;};
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become the current tool.
+	virtual Bool followsTerrain(void) override {return false;};
 
 public:	// Methods specific to MeshMoldTool.
 	static void updateMeshLocation(Bool changePreview);

--- a/Generals/Code/Tools/WorldBuilder/include/MoundOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/MoundOptions.h
@@ -54,9 +54,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(MoundOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -64,7 +64,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(MoundOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeFeatherEdit();
 	afx_msg void OnChangeSizeEdit();
 	afx_msg void OnChangeHeightEdit();
@@ -89,9 +89,9 @@ public:
 
 public:
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 };
 
 //{{AFX_INSERT_LOCATION}}

--- a/Generals/Code/Tools/WorldBuilder/include/MoundTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/MoundTool.h
@@ -42,7 +42,7 @@ protected:
 
 public:
 	MoundTool(void);
-	~MoundTool(void);
+	virtual ~MoundTool(void) override;
 
 public:
 	static Int getMoundHeight(void) {return m_moundHeight;};
@@ -53,11 +53,11 @@ public:
 	static void setFeather(Int feather);
 
 public:
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual WorldHeightMapEdit *getHeightMap(void) {return m_htMapEditCopy;};
-	virtual void activate(); ///< Become the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual WorldHeightMapEdit *getHeightMap(void) override {return m_htMapEditCopy;};
+	virtual void activate() override; ///< Become the current tool.
 };
 
 /*************************************************************************

--- a/Generals/Code/Tools/WorldBuilder/include/MyToolbar.h
+++ b/Generals/Code/Tools/WorldBuilder/include/MyToolbar.h
@@ -33,11 +33,11 @@ protected:
 
 protected:
 	afx_msg void OnVScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
-	virtual LRESULT WindowProc( UINT message, WPARAM wParam, LPARAM lParam );
+	virtual LRESULT WindowProc( UINT message, WPARAM wParam, LPARAM lParam ) override;
 	DECLARE_MESSAGE_MAP()
 
 public:
-	~CellSizeToolBar(void);
+	virtual ~CellSizeToolBar(void) override;
 	void SetupSlider(void);
 	static void CellSizeChanged(Int cellSize);
 

--- a/Generals/Code/Tools/WorldBuilder/include/NewHeightMap.h
+++ b/Generals/Code/Tools/WorldBuilder/include/NewHeightMap.h
@@ -57,9 +57,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CNewHeightMap)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK();
-	virtual BOOL OnCommand(WPARAM wParam, LPARAM lParam);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override;
+	virtual BOOL OnCommand(WPARAM wParam, LPARAM lParam) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -74,7 +74,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CNewHeightMap)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/Generals/Code/Tools/WorldBuilder/include/ObjectOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ObjectOptions.h
@@ -35,7 +35,7 @@ class ObjectOptions : public COptionsPanel
 public:
 	ObjectOptions(CWnd* pParent = nullptr);   ///< standard constructor
 
-	~ObjectOptions(void);   ///< standard destructor
+	virtual ~ObjectOptions(void) override;   ///< standard destructor
 	enum { NAME_MAX_LEN = 64 };
 // Dialog Data
 	//{{AFX_DATA(ObjectOptions)
@@ -48,10 +48,10 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(ObjectOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -59,7 +59,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(ObjectOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnEditchangeOwningteam();
 	afx_msg void OnCloseupOwningteam();
 	afx_msg void OnSelchangeOwningteam();

--- a/Generals/Code/Tools/WorldBuilder/include/ObjectPreview.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ObjectPreview.h
@@ -46,7 +46,7 @@ public:
 
 // Implementation
 public:
-	virtual ~ObjectPreview();
+	virtual ~ObjectPreview() override;
 
 	void SetThingTemplate(const ThingTemplate *tTempl);
 

--- a/Generals/Code/Tools/WorldBuilder/include/ObjectTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ObjectTool.h
@@ -37,16 +37,16 @@ protected:
 
 public:
 	ObjectTool(void);
-	~ObjectTool(void);
+	virtual ~ObjectTool(void) override;
 
 public:
 	static Real calcAngle(Coord3D downPt, Coord3D curPt, WbView* pView);
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become not the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become not the current tool.
 };

--- a/Generals/Code/Tools/WorldBuilder/include/OpenMap.h
+++ b/Generals/Code/Tools/WorldBuilder/include/OpenMap.h
@@ -48,7 +48,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(OpenMap)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -63,8 +63,8 @@ protected:
 	afx_msg void OnBrowse();
 	afx_msg void OnSystemMaps();
 	afx_msg void OnUserMaps();
-	virtual void OnOK();
-	virtual BOOL OnInitDialog();
+	virtual void OnOK() override;
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnDblclkOpenList();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/Generals/Code/Tools/WorldBuilder/include/OptionsPanel.h
+++ b/Generals/Code/Tools/WorldBuilder/include/OptionsPanel.h
@@ -45,7 +45,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(COptionsPanel)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/Generals/Code/Tools/WorldBuilder/include/PickUnitDialog.h
+++ b/Generals/Code/Tools/WorldBuilder/include/PickUnitDialog.h
@@ -48,7 +48,7 @@ protected:
 public:
 	PickUnitDialog(CWnd* pParent = nullptr);   // standard constructor
 	PickUnitDialog(UINT id, CWnd* pParent = nullptr);   // standard constructor
-	~PickUnitDialog(void);   ///< standard destructor
+	virtual ~PickUnitDialog(void) override;   ///< standard destructor
 
 // Dialog Data
 	//{{AFX_DATA(PickUnitDialog)
@@ -61,8 +61,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(PickUnitDialog)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -70,7 +70,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(PickUnitDialog)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnMove(int x, int y);
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
@@ -95,7 +95,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(ReplaceUnitDialog)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 

--- a/Generals/Code/Tools/WorldBuilder/include/PointerTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/PointerTool.h
@@ -58,17 +58,17 @@ protected:
 
 public:
 	PointerTool(void);
-	~PointerTool(void);
+	virtual ~PointerTool(void) override;
 
 public:
 	/// Clear the selection on activate or deactivate.
-	virtual void activate();
-	virtual void deactivate();
+	virtual void activate() override;
+	virtual void deactivate() override;
 
-	virtual void setCursor(void);
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
+	virtual void setCursor(void) override;
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
 
 public:
 	static void clearSelection(void); ///< Clears the selected objects selected flags.

--- a/Generals/Code/Tools/WorldBuilder/include/PolygonTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/PolygonTool.h
@@ -36,7 +36,7 @@ class PolygonTool : public Tool
 {
 public:
 	PolygonTool(void);
-	~PolygonTool(void);
+	virtual ~PolygonTool(void) override;
 
 protected:
 	Coord3D m_poly_mouseDownPt;
@@ -74,10 +74,10 @@ public:
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void setCursor(void);
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become not the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void setCursor(void) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become not the current tool.
 };

--- a/Generals/Code/Tools/WorldBuilder/include/RampOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/RampOptions.h
@@ -48,7 +48,7 @@ class RampOptions : public COptionsPanel
 	public:
 		enum { IDD = IDD_RAMP_OPTIONS };
 		RampOptions(CWnd* pParent = nullptr);
-		virtual ~RampOptions();
+		virtual ~RampOptions() override;
 
 		Bool shouldApplyTheRamp();
 		Real getRampWidth() { return m_rampWidth; }

--- a/Generals/Code/Tools/WorldBuilder/include/RampTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/RampTool.h
@@ -49,14 +49,14 @@ class RampTool : public Tool
 
 	public:
 		RampTool();
-		virtual void activate();
-		virtual void deactivate(); ///< Become not the current tool.
+		virtual void activate() override;
+		virtual void deactivate() override; ///< Become not the current tool.
 
-		virtual Bool followsTerrain(void);
+		virtual Bool followsTerrain(void) override;
 
-		virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-		virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-		virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
+		virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+		virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+		virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
 
 	protected:
 		void drawFeedback(Coord3D* endPoint);

--- a/Generals/Code/Tools/WorldBuilder/include/RoadOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/RoadOptions.h
@@ -35,7 +35,7 @@ class RoadOptions : public COptionsPanel
 public:
 	RoadOptions(CWnd* pParent = nullptr);   ///< standard constructor
 
-	~RoadOptions(void);   ///< standard destructor
+	virtual ~RoadOptions(void) override;   ///< standard destructor
 	enum { NAME_MAX_LEN = 64 };
 // Dialog Data
 	//{{AFX_DATA(RoadOptions)
@@ -48,10 +48,10 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(RoadOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -59,7 +59,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(RoadOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnTightCurve();
 	afx_msg void OnAngled();
 	afx_msg void OnBroadCurve();

--- a/Generals/Code/Tools/WorldBuilder/include/RoadTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/RoadTool.h
@@ -43,15 +43,15 @@ private:
 
 public:
 	RoadTool(void);
-	~RoadTool(void);
+	virtual ~RoadTool(void) override;
 
 public:
 	static Bool snap(Coord3D *pLoc, Bool skipLast);
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
 };

--- a/Generals/Code/Tools/WorldBuilder/include/SaveMap.h
+++ b/Generals/Code/Tools/WorldBuilder/include/SaveMap.h
@@ -49,7 +49,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(SaveMap)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -61,13 +61,13 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(SaveMap)
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	afx_msg void OnBrowse();
 	afx_msg void OnSystemMaps();
 	afx_msg void OnUserMaps();
 	afx_msg void OnSelchangeSaveList();
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/Generals/Code/Tools/WorldBuilder/include/ScorchOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ScorchOptions.h
@@ -47,9 +47,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(ScorchOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -57,7 +57,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(ScorchOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeScorchtype();
 	afx_msg void OnChangeSizeEdit();
 	//}}AFX_MSG
@@ -83,9 +83,9 @@ public:
 	static Scorches getScorchType(void) {return m_scorchtype;}
 	static Real getScorchSize(void) {return m_scorchsize;}
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 };
 
 //{{AFX_INSERT_LOCATION}}

--- a/Generals/Code/Tools/WorldBuilder/include/ScorchTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ScorchTool.h
@@ -32,7 +32,7 @@ class ScorchTool : public Tool
 {
 public:
 	ScorchTool(void);
-	~ScorchTool(void);
+	virtual ~ScorchTool(void) override;
 
 protected:
 	Coord3D m_mouseDownPt;
@@ -42,9 +42,9 @@ protected:
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become not the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become not the current tool.
 };

--- a/Generals/Code/Tools/WorldBuilder/include/ScriptActionsFalse.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ScriptActionsFalse.h
@@ -33,7 +33,7 @@ class ScriptActionsFalse : public CPropertyPage
 // Construction
 public:
 	ScriptActionsFalse();
-	~ScriptActionsFalse();
+	virtual ~ScriptActionsFalse() override;
 
 // Dialog Data
 	//{{AFX_DATA(ScriptActionsFalse)
@@ -47,7 +47,7 @@ public:
 	// ClassWizard generate virtual function overrides
 	//{{AFX_VIRTUAL(ScriptActionsFalse)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -67,7 +67,7 @@ protected:
 protected:
 	// Generated message map functions
 	//{{AFX_MSG(ScriptActionsFalse)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnEditAction();
 	afx_msg void OnSelchangeActionList();
 	afx_msg void OnDblclkActionList();

--- a/Generals/Code/Tools/WorldBuilder/include/ScriptActionsTrue.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ScriptActionsTrue.h
@@ -33,7 +33,7 @@ class ScriptActionsTrue : public CPropertyPage
 // Construction
 public:
 	ScriptActionsTrue();
-	~ScriptActionsTrue();
+	virtual ~ScriptActionsTrue() override;
 
 // Dialog Data
 	//{{AFX_DATA(ScriptActionsTrue)
@@ -47,7 +47,7 @@ public:
 	// ClassWizard generate virtual function overrides
 	//{{AFX_VIRTUAL(ScriptActionsTrue)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -67,7 +67,7 @@ protected:
 protected:
 	// Generated message map functions
 	//{{AFX_MSG(ScriptActionsTrue)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnEditAction();
 	afx_msg void OnSelchangeActionList();
 	afx_msg void OnDblclkActionList();

--- a/Generals/Code/Tools/WorldBuilder/include/ScriptConditions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ScriptConditions.h
@@ -34,7 +34,7 @@ class ScriptConditionsDlg : public CPropertyPage
 // Construction
 public:
 	ScriptConditionsDlg();
-	~ScriptConditionsDlg();
+	virtual ~ScriptConditionsDlg() override;
 
 // Dialog Data
 	//{{AFX_DATA(ScriptConditionsDlg)
@@ -48,7 +48,7 @@ public:
 	// ClassWizard generate virtual function overrides
 	//{{AFX_VIRTUAL(ScriptConditionsDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -71,7 +71,7 @@ protected:
 protected:
 	// Generated message map functions
 	//{{AFX_MSG(ScriptConditionsDlg)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnEditCondition();
 	afx_msg void OnSelchangeConditionList();
 	afx_msg void OnDblclkConditionList();

--- a/Generals/Code/Tools/WorldBuilder/include/ScriptDialog.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ScriptDialog.h
@@ -62,7 +62,7 @@ class ScriptDialog : public CDialog
 // Construction
 public:
 	ScriptDialog(CWnd* pParent = nullptr);   // standard constructor
-	~ScriptDialog();   //  destructor
+	virtual ~ScriptDialog() override;   //  destructor
 
 // Dialog Data
 	//{{AFX_DATA(ScriptDialog)
@@ -75,7 +75,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(ScriptDialog)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -132,7 +132,7 @@ protected:
 	// Generated message map functions
 	//{{AFX_MSG(ScriptDialog)
 	afx_msg void OnSelchangedScriptTree(NMHDR* pNMHDR, LRESULT* pResult);
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnNewFolder();
 	afx_msg void OnNewScript();
 	afx_msg void OnEditScript();
@@ -141,8 +141,8 @@ protected:
 	afx_msg void OnSave();
 	afx_msg void OnLoad();
 	afx_msg void OnDblclkScriptTree(NMHDR* pNMHDR, LRESULT* pResult);
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	afx_msg void OnBegindragScriptTree(NMHDR* pNMHDR, LRESULT* pResult);
 	afx_msg void OnScriptActivate();
 	afx_msg void OnMouseMove(UINT nFlags, CPoint point);

--- a/Generals/Code/Tools/WorldBuilder/include/ScriptProperties.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ScriptProperties.h
@@ -31,7 +31,7 @@ class ScriptProperties : public CPropertyPage
 // Construction
 public:
 	ScriptProperties();
-	~ScriptProperties();
+	virtual ~ScriptProperties() override;
 
 // Dialog Data
 	//{{AFX_DATA(ScriptProperties)
@@ -45,9 +45,9 @@ public:
 	// ClassWizard generate virtual function overrides
 	//{{AFX_VIRTUAL(ScriptProperties)
 	public:
-	virtual BOOL OnSetActive();
+	virtual BOOL OnSetActive() override;
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/Generals/Code/Tools/WorldBuilder/include/SelectMacrotexture.h
+++ b/Generals/Code/Tools/WorldBuilder/include/SelectMacrotexture.h
@@ -41,8 +41,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(SelectMacrotexture)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 protected:
@@ -54,7 +54,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(SelectMacrotexture)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/Generals/Code/Tools/WorldBuilder/include/ShadowOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ShadowOptions.h
@@ -41,7 +41,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(ShadowOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -60,7 +60,7 @@ protected:
 	afx_msg void OnChangeBaEdit();
 	afx_msg void OnChangeGaEdit();
 	afx_msg void OnChangeRaEdit();
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/Generals/Code/Tools/WorldBuilder/include/TeamBehavior.h
+++ b/Generals/Code/Tools/WorldBuilder/include/TeamBehavior.h
@@ -41,7 +41,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(TeamBehavior)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -57,7 +57,7 @@ protected:
 	// Generated message map functions
 	//{{AFX_MSG(TeamBehavior)
 	afx_msg void OnSelchangeOnCreateScript();
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnTransportsReturn();
 	afx_msg void OnAvoidThreats();
 	afx_msg void OnSelchangeOnEnemySighted();

--- a/Generals/Code/Tools/WorldBuilder/include/TeamGeneric.h
+++ b/Generals/Code/Tools/WorldBuilder/include/TeamGeneric.h
@@ -40,7 +40,7 @@ class TeamGeneric : public CPropertyPage
 
 
 	protected: // Windows Functions
-		virtual BOOL OnInitDialog();
+		virtual BOOL OnInitDialog() override;
 		afx_msg void _scriptsToDict();
 		afx_msg void OnScriptAdjust();
 		DECLARE_MESSAGE_MAP()

--- a/Generals/Code/Tools/WorldBuilder/include/TeamIdentity.h
+++ b/Generals/Code/Tools/WorldBuilder/include/TeamIdentity.h
@@ -43,8 +43,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(TeamIdentity)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnCommand(WPARAM wParam, LPARAM lParam);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnCommand(WPARAM wParam, LPARAM lParam) override;
 	//}}AFX_VIRTUAL
 
 protected:
@@ -64,7 +64,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(TeamIdentity)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnAiRecruitable();
 	afx_msg void OnAutoReinforce();
 	afx_msg void OnBaseDefense();

--- a/Generals/Code/Tools/WorldBuilder/include/TeamReinforcement.h
+++ b/Generals/Code/Tools/WorldBuilder/include/TeamReinforcement.h
@@ -41,7 +41,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(TeamReinforcement)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -59,7 +59,7 @@ protected:
 	afx_msg void OnTransportsExit();
 	afx_msg void OnSelchangeVeterancy();
 	afx_msg void OnSelchangeWaypointCombo();
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/Generals/Code/Tools/WorldBuilder/include/TerrainMaterial.h
+++ b/Generals/Code/Tools/WorldBuilder/include/TerrainMaterial.h
@@ -45,10 +45,10 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(TerrainMaterial)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -56,7 +56,7 @@ protected:
 	enum {MIN_TILE_SIZE=2, MAX_TILE_SIZE = 100};
 	// Generated message map functions
 	//{{AFX_MSG(TerrainMaterial)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSwapTextures();
 	afx_msg void OnChangeSizeEdit();
 	afx_msg void OnImpassable();
@@ -102,9 +102,9 @@ public:
 	Bool setTerrainTreeViewSelection(HTREEITEM parent, Int selection);
 
 	// Popup slider interface.
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 };
 
 //{{AFX_INSERT_LOCATION}}

--- a/Generals/Code/Tools/WorldBuilder/include/TerrainModal.h
+++ b/Generals/Code/Tools/WorldBuilder/include/TerrainModal.h
@@ -44,8 +44,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(TerrainModal)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -53,7 +53,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(TerrainModal)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 

--- a/Generals/Code/Tools/WorldBuilder/include/TerrainSwatches.h
+++ b/Generals/Code/Tools/WorldBuilder/include/TerrainSwatches.h
@@ -44,7 +44,7 @@ public:
 
 // Implementation
 public:
-	virtual ~TerrainSwatches();
+	virtual ~TerrainSwatches() override;
 
 	// Generated message map functions
 protected:

--- a/Generals/Code/Tools/WorldBuilder/include/TileTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/TileTool.h
@@ -36,14 +36,14 @@ protected:
 
 public:
 	TileTool(void);
-	~TileTool(void);
+	virtual ~TileTool(void) override;
 
 public:
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual WorldHeightMapEdit *getHeightMap(void) {return m_htMapEditCopy;};
-	virtual void activate(); ///< Become the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual WorldHeightMapEdit *getHeightMap(void) override {return m_htMapEditCopy;};
+	virtual void activate() override; ///< Become the current tool.
 	virtual Int getWidth(void) {return 1;};
 };
 
@@ -57,12 +57,12 @@ protected:
 	static Int m_currentWidth;
 
 public:
- 	virtual void activate(); ///< Become the current tool.
+	virtual void activate() override; ///< Become the current tool.
 
 public:
 	BigTileTool(void);
 
 	static void setWidth(Int width) ;
-	virtual Int getWidth(void) {return m_currentWidth;};
+	virtual Int getWidth(void) override {return m_currentWidth;};
 
 };

--- a/Generals/Code/Tools/WorldBuilder/include/WBFrameWnd.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WBFrameWnd.h
@@ -42,13 +42,13 @@ public:
 	virtual BOOL LoadFrame(UINT nIDResource,
 				DWORD dwDefaultStyle = WS_OVERLAPPEDWINDOW | FWS_ADDTOTITLE,
 				CWnd* pParentWnd = nullptr,
-				CCreateContext* pContext = nullptr);
+				CCreateContext* pContext = nullptr) override;
 	// ClassWizard generated virtual function overrides
 	//}}AFX_VIRTUAL
 
 // Implementation
 protected:
-	virtual ~CWBFrameWnd();
+	virtual ~CWBFrameWnd() override;
 
 	// Generated message map functions
 	//{{AFX_MSG(CWBFrameWnd)
@@ -71,14 +71,14 @@ public:
 	virtual BOOL LoadFrame(UINT nIDResource,
 				DWORD dwDefaultStyle = WS_OVERLAPPEDWINDOW | FWS_ADDTOTITLE,
 				CWnd* pParentWnd = nullptr,
-				CCreateContext* pContext = nullptr);
+				CCreateContext* pContext = nullptr) override;
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CWB3dFrameWnd)
 	public:
 	//}}AFX_VIRTUAL
 // Implementation
 protected:
-	virtual ~CWB3dFrameWnd();
+	virtual ~CWB3dFrameWnd() override;
 	// Generated message map functions
 	//{{AFX_MSG(CWB3dFrameWnd)
 	afx_msg void OnMove(int x, int y);

--- a/Generals/Code/Tools/WorldBuilder/include/WBHeightMap.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WBHeightMap.h
@@ -29,8 +29,8 @@ public:
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface (W3D methods)
 	/////////////////////////////////////////////////////////////////////////////
-	virtual void					Render(RenderInfoClass & rinfo);
-	virtual Bool					Cast_Ray(RayCollisionTestClass & raytest);
+	virtual void					Render(RenderInfoClass & rinfo) override;
+	virtual Bool					Cast_Ray(RayCollisionTestClass & raytest) override;
 
 	virtual Real getHeightMapHeight(Real x, Real y, Coord3D* normal);	///<return height and normal at given point
 	virtual Real getMaxCellHeight(Real x, Real y);	///< returns maximum height of the 4 cell corners.

--- a/Generals/Code/Tools/WorldBuilder/include/WBPopupSlider.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WBPopupSlider.h
@@ -56,7 +56,7 @@ public:
 
 // Implementation
 public:
-	virtual ~WBPopupSliderButton();
+	virtual ~WBPopupSliderButton() override;
 
 	// Generated message map functions
 protected:
@@ -113,12 +113,12 @@ public:
 	public:
 	virtual BOOL Create(const RECT& rect, CWnd* pParentWnd);
 	protected:
-	virtual void PostNcDestroy();
+	virtual void PostNcDestroy() override;
 	//}}AFX_VIRTUAL
 
 // Implementation
 public:
-	virtual ~PopupSlider();
+	virtual ~PopupSlider() override;
 
 	// Generated message map functions
 protected:

--- a/Generals/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
@@ -96,7 +96,7 @@ public: // construction
 	WorldHeightMapEdit(Int xExtent, Int yExtent, UnsignedByte initialHeight, Int border); ///< create.
 	WorldHeightMapEdit(WorldHeightMapEdit *pThis);								///< duplicate.
 	WorldHeightMapEdit(ChunkInputStream *pStrm);											///< read from file.
-	~WorldHeightMapEdit(void);													    ///< destroy.
+	virtual ~WorldHeightMapEdit(void) override;													    ///< destroy.
 
 	void saveToFile(DataChunkOutput &chunkWriter);
 	WorldHeightMapEdit *duplicate(void);

--- a/Generals/Code/Tools/WorldBuilder/include/WaterOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WaterOptions.h
@@ -48,9 +48,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(WaterOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -58,7 +58,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(WaterOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeWaterEdit();
 	afx_msg void OnChangeHeightEdit();
 	afx_msg void OnChangeSpacingEdit();
@@ -92,9 +92,9 @@ public:
 
 public:
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 
 };
 

--- a/Generals/Code/Tools/WorldBuilder/include/WaterTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WaterTool.h
@@ -36,7 +36,7 @@ class WaterTool : public PolygonTool
 {
 public:
 	WaterTool(void);
-	~WaterTool(void);
+	virtual ~WaterTool(void) override;
 
 protected:
 	static Bool		m_water_isActive;
@@ -48,12 +48,12 @@ public:
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void setCursor(void);
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become not the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void setCursor(void) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become not the current tool.
 
 protected:
 	void fillTheArea(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);

--- a/Generals/Code/Tools/WorldBuilder/include/WaypointOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WaypointOptions.h
@@ -47,9 +47,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(WaypointOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -57,7 +57,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(WaypointOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeWaypointnameEdit();
 	afx_msg void OnChangeSelectedWaypoint();
 	afx_msg void OnEditWaypointLocationX();

--- a/Generals/Code/Tools/WorldBuilder/include/WaypointTool.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WaypointTool.h
@@ -34,7 +34,7 @@ class WaypointTool : public Tool
 {
 public:
 	WaypointTool(void);
-	~WaypointTool(void);
+	virtual ~WaypointTool(void) override;
 
 protected:
 	Int m_downWaypointID;
@@ -49,9 +49,9 @@ public:
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become not the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become not the current tool.
 };

--- a/Generals/Code/Tools/WorldBuilder/include/WorldBuilder.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WorldBuilder.h
@@ -71,14 +71,14 @@ class CWorldBuilderApp : public CWinApp
 {
 public:
 	CWorldBuilderApp();
-	~CWorldBuilderApp();
+	virtual ~CWorldBuilderApp() override;
 
 // Overrides
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CWorldBuilderApp)
 	public:
-	virtual BOOL InitInstance();
-	virtual int ExitInstance();
+	virtual BOOL InitInstance() override;
+	virtual int ExitInstance() override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -181,7 +181,7 @@ public:
 
 	/// Handles command messages.
 	virtual BOOL OnCmdMsg(UINT nID, int nCode, void* pExtra,
-						  AFX_CMDHANDLERINFO* pHandlerInfo);
+						  AFX_CMDHANDLERINFO* pHandlerInfo) override;
 };
 
 inline CWorldBuilderApp *WbApp() { return (CWorldBuilderApp*)::AfxGetApp(); }

--- a/Generals/Code/Tools/WorldBuilder/include/WorldBuilderDoc.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WorldBuilderDoc.h
@@ -97,8 +97,8 @@ public:
 	Bool ParseWaypointData(DataChunkInput &file, DataChunkInfo *info, void *userData);
 
 public: // overridden
-	virtual BOOL DoSave(LPCTSTR lpszPathName, BOOL bReplace = TRUE);
-	virtual BOOL DoFileSave();
+	virtual BOOL DoSave(LPCTSTR lpszPathName, BOOL bReplace = TRUE) override;
+	virtual BOOL DoFileSave() override;
 
 // Attributes
 public:
@@ -156,15 +156,15 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CWorldBuilderDoc)
 	public:
-	virtual BOOL OnNewDocument();
-	virtual void Serialize(CArchive& ar);
-	virtual BOOL OnOpenDocument(LPCTSTR lpszPathName);
-	virtual BOOL CanCloseFrame(CFrameWnd* pFrame);
+	virtual BOOL OnNewDocument() override;
+	virtual void Serialize(CArchive& ar) override;
+	virtual BOOL OnOpenDocument(LPCTSTR lpszPathName) override;
+	virtual BOOL CanCloseFrame(CFrameWnd* pFrame) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
 public:
-	virtual ~CWorldBuilderDoc();
+	virtual ~CWorldBuilderDoc() override;
 #ifdef RTS_DEBUG
 	virtual void AssertValid() const;
 	virtual void Dump(CDumpContext& dc) const;

--- a/Generals/Code/Tools/WorldBuilder/include/WorldBuilderView.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WorldBuilderView.h
@@ -44,17 +44,17 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CWorldBuilderView)
 	public:
-	virtual BOOL PreCreateWindow(CREATESTRUCT& cs);
+	virtual BOOL PreCreateWindow(CREATESTRUCT& cs) override;
 	protected:
-	virtual BOOL OnPreparePrinting(CPrintInfo* pInfo);
-	virtual void OnBeginPrinting(CDC* pDC, CPrintInfo* pInfo);
-	virtual void OnEndPrinting(CDC* pDC, CPrintInfo* pInfo);
-	virtual void OnDraw(CDC* pDC);
+	virtual BOOL OnPreparePrinting(CPrintInfo* pInfo) override;
+	virtual void OnBeginPrinting(CDC* pDC, CPrintInfo* pInfo) override;
+	virtual void OnEndPrinting(CDC* pDC, CPrintInfo* pInfo) override;
+	virtual void OnDraw(CDC* pDC) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
 public:
-	virtual ~CWorldBuilderView();
+	virtual ~CWorldBuilderView() override;
 #ifdef RTS_DEBUG
 	virtual void AssertValid() const;
 	virtual void Dump(CDumpContext& dc) const;
@@ -115,23 +115,23 @@ public:
 protected:
 
 public:
-	virtual Bool viewToDocCoords(CPoint curPt, Coord3D *newPt, Bool constrain);
-	virtual Bool docToViewCoords(Coord3D curPt, CPoint* newPt);
+	virtual Bool viewToDocCoords(CPoint curPt, Coord3D *newPt, Bool constrain) override;
+	virtual Bool docToViewCoords(Coord3D curPt, CPoint* newPt) override;
 
 	/// Set the center for display.
-	virtual void setCenterInView(Real x, Real y);
+	virtual void setCenterInView(Real x, Real y) override;
 
 	/// the doc has changed size; readjust view as necessary.
-	virtual void adjustDocSize();
+	virtual void adjustDocSize() override;
 
 	/// Invalidates an object. Pass null to inval all objects.
-	virtual void invalObjectInView(MapObject *pObj);
+	virtual void invalObjectInView(MapObject *pObj) override;
 
 	/// Invalidates the area of one height map cell in the 2d view.
-	virtual void invalidateCellInView(int xIndex, int yIndex);
+	virtual void invalidateCellInView(int xIndex, int yIndex) override;
 
 	/// Scrolls the window by this amount (doc coords).
-	virtual void scrollInView(Real x, Real y, Bool end);
+	virtual void scrollInView(Real x, Real y, Bool end) override;
 
 // Generated message map functions
 protected:

--- a/Generals/Code/Tools/WorldBuilder/include/addplayerdialog.h
+++ b/Generals/Code/Tools/WorldBuilder/include/addplayerdialog.h
@@ -49,7 +49,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(AddPlayerDialog)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -57,9 +57,9 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(AddPlayerDialog)
-	virtual void OnOK();
-	virtual void OnCancel();
-	virtual BOOL OnInitDialog();
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnEditchangeCombo1();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/Generals/Code/Tools/WorldBuilder/include/brushoptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/brushoptions.h
@@ -50,9 +50,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(BrushOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -60,7 +60,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(BrushOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeFeatherEdit();
 	afx_msg void OnChangeSizeEdit();
 	afx_msg void OnChangeHeightEdit();
@@ -85,9 +85,9 @@ public:
 
 public:
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 
 };
 

--- a/Generals/Code/Tools/WorldBuilder/include/mapobjectprops.h
+++ b/Generals/Code/Tools/WorldBuilder/include/mapobjectprops.h
@@ -42,7 +42,7 @@ class MapObjectProps : public COptionsPanel, public PopupSliderOwner
 // Construction
 public:
 	MapObjectProps(Dict* dictToEdit = nullptr, const char* title = nullptr, CWnd* pParent = nullptr);   // standard constructor
-	~MapObjectProps();
+	virtual ~MapObjectProps() override;
 	void makeMain();
 
 // Dialog Data
@@ -55,7 +55,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(MapObjectProps)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -82,13 +82,13 @@ protected:
 	// Generated message map functions
 	//{{AFX_MSG(MapObjectProps)
 	afx_msg void OnSelchangeProperties();
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnEditprop();
 	afx_msg void OnNewprop();
 	afx_msg void OnRemoveprop();
 	afx_msg void OnDblclkProperties();
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	afx_msg void _TeamToDict(void);
 	afx_msg void _NameToDict(void);
 	afx_msg void _HealthToDict(void);
@@ -140,9 +140,9 @@ protected:
 	void _DictToPrebuiltUpgrades(void);
 
 public:
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 
 	static MapObject *getSingleSelectedMapObject(void);
 	static void update(void);

--- a/Generals/Code/Tools/WorldBuilder/include/playerlistdlg.h
+++ b/Generals/Code/Tools/WorldBuilder/include/playerlistdlg.h
@@ -44,7 +44,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(PlayerListDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -65,12 +65,12 @@ protected:
 	afx_msg void OnEditplayer();
 	afx_msg void OnRemoveplayer();
 	afx_msg void OnSelchangePlayers();
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnDblclkPlayers();
 	afx_msg void OnSelchangeAllieslist();
 	afx_msg void OnSelchangeEnemieslist();
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	afx_msg void OnPlayeriscomputer();
 	afx_msg void OnEditchangePlayerfaction();
 	afx_msg void OnChangePlayername();

--- a/Generals/Code/Tools/WorldBuilder/include/propedit.h
+++ b/Generals/Code/Tools/WorldBuilder/include/propedit.h
@@ -41,7 +41,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(PropEdit)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -61,7 +61,7 @@ protected:
 	afx_msg void OnCloseupKeytype();
 	afx_msg void OnSelchangeKeytype();
 	afx_msg void OnChangeValue();
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnPropbool();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/Generals/Code/Tools/WorldBuilder/include/teamsdialog.h
+++ b/Generals/Code/Tools/WorldBuilder/include/teamsdialog.h
@@ -43,7 +43,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CTeamsDialog)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -51,9 +51,9 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CTeamsDialog)
-	virtual BOOL OnInitDialog();
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	afx_msg void OnNewteam();
 	afx_msg void OnDeleteteam();
 	afx_msg void OnEditTemplate();

--- a/Generals/Code/Tools/WorldBuilder/include/wbview.h
+++ b/Generals/Code/Tools/WorldBuilder/include/wbview.h
@@ -149,12 +149,12 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(WbView)
 	protected:
-	virtual void OnDraw(CDC* pDC);      // overridden to draw this view
+	virtual void OnDraw(CDC* pDC) override;      // overridden to draw this view
 	//}}AFX_VIRTUAL
 
 // Implementation
 protected:
-	virtual ~WbView();
+	virtual ~WbView() override;
 #ifdef RTS_DEBUG
 	virtual void AssertValid() const;
 	virtual void Dump(CDumpContext& dc) const;

--- a/Generals/Code/Tools/WorldBuilder/include/wbview3d.h
+++ b/Generals/Code/Tools/WorldBuilder/include/wbview3d.h
@@ -65,8 +65,8 @@ protected:
 public:
 
 	// DX8_CleanupHook methods
-	virtual void ReleaseResources(void);	///< Release all dx8 resources so the device can be reset.
-	virtual void ReAcquireResources(void);  ///< Reacquire all resources after device reset.
+	virtual void ReleaseResources(void) override;	///< Release all dx8 resources so the device can be reset.
+	virtual void ReAcquireResources(void) override;  ///< Reacquire all resources after device reset.
 
 // Operations
 public:
@@ -75,12 +75,12 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(WbView3d)
 	protected:
-	virtual void OnDraw(CDC* pDC);      // overridden to draw this view
+	virtual void OnDraw(CDC* pDC) override;      // overridden to draw this view
 	//}}AFX_VIRTUAL
 
 // Implementation
 protected:
-	virtual ~WbView3d();
+	virtual ~WbView3d() override;
 #ifdef RTS_DEBUG
 	virtual void AssertValid() const;
 	virtual void Dump(CDumpContext& dc) const;
@@ -222,13 +222,13 @@ protected:
 	void updateScorches();
 
 public:
-	virtual Bool viewToDocCoords(CPoint curPt, Coord3D *newPt, Bool constrain=true);
-	virtual Bool docToViewCoords(Coord3D curPt, CPoint* newPt);
+	virtual Bool viewToDocCoords(CPoint curPt, Coord3D *newPt, Bool constrain=true) override;
+	virtual Bool docToViewCoords(Coord3D curPt, CPoint* newPt) override;
 
-	virtual void updateHeightMapInView(WorldHeightMap *htMap, Bool partial, const IRegion2D &partialRange);
+	virtual void updateHeightMapInView(WorldHeightMap *htMap, Bool partial, const IRegion2D &partialRange) override;
 
 	/// Invalidates an object. Pass null to inval all objects.
-	virtual void invalObjectInView(MapObject *pObj);
+	virtual void invalObjectInView(MapObject *pObj) override;
 
 	// find the best model for an object
 	AsciiString getBestModelName(const ThingTemplate* tt, const ModelConditionFlags& c);
@@ -237,14 +237,14 @@ public:
 	void invalBuildListItemInView(BuildListInfo *pBuild);
 
 	/// Invalidates the area of one height map cell in the 2d view.
-	virtual void invalidateCellInView(int xIndex, int yIndex);
+	virtual void invalidateCellInView(int xIndex, int yIndex) override;
 
 	/// Scrolls the window by this amount.
-	virtual void scrollInView(Real x, Real y, Bool end);
+	virtual void scrollInView(Real x, Real y, Bool end) override;
 
-	virtual void setDefaultCamera();
-	virtual void rotateCamera(Real delta);
-	virtual void pitchCamera(Real delta);
+	virtual void setDefaultCamera() override;
+	virtual void rotateCamera(Real delta) override;
+	virtual void pitchCamera(Real delta) override;
 	void setCameraPitch(Real absolutePitch);
 	Real getCameraPitch(void);
 	Real getHeightAboveGround(void) { return m_actualHeightAboveGround; }
@@ -252,8 +252,8 @@ public:
 	Vector3 getCameraTarget(void) { return m_cameraTarget; }
 	Real getCameraAngle(void) { return m_cameraAngle; }
 
-	virtual MapObject *picked3dObjectInView(CPoint viewPt);
-	virtual BuildListInfo *pickedBuildObjectInView(CPoint viewPt);
+	virtual MapObject *picked3dObjectInView(CPoint viewPt) override;
+	virtual BuildListInfo *pickedBuildObjectInView(CPoint viewPt) override;
 
 	void removeFenceListObjects(MapObject *pObject);
 	void updateFenceListObjects(MapObject *pObject);
@@ -270,14 +270,14 @@ public:
 
 	AsciiString getModelNameAndScale(MapObject *pMapObj, Real *scale, BodyDamageType curDamageState);
 
-	virtual Int getPickPixels(void) {return m_pickPixels;}
-	virtual Bool viewToDocCoordZ(CPoint curPt, Coord3D *newPt, Real Z);
+	virtual Int getPickPixels(void) override {return m_pickPixels;}
+	virtual Bool viewToDocCoordZ(CPoint curPt, Coord3D *newPt, Real Z) override;
 public:
 
 //	void init(CWorldBuilderView *pMainView, HINSTANCE hInstance, CWnd* parent);
 	void redraw();
 
-	virtual void setCenterInView(Real x, Real y);
+	virtual void setCenterInView(Real x, Real y) override;
 
 	Bool getShowTerrain();
 	Bool getShowWireframe();
@@ -289,7 +289,7 @@ public:
 	Bool getShowAmbientSoundsFeedback(void) const { return m_showAmbientSounds; }
 
 	void togglePitchAndRotation( void ) { m_doPitch = !m_doPitch; }
-	virtual Bool isDoingPitch( void ) { return m_doPitch; }
+	virtual Bool isDoingPitch( void ) override { return m_doPitch; }
 };
 
 inline UINT WbView3d::getLastDrawTime() { return m_time; }

--- a/Generals/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
@@ -969,7 +969,7 @@ protected:
 	CFile *m_file;
 public:
 	LocalMFCFileOutputStream(CFile *pFile):m_file(pFile) {};
-	virtual Int write(const void *pData, Int numBytes) {
+	virtual Int write(const void *pData, Int numBytes) override {
 		Int numBytesWritten = 0;
 		try {
 			m_file->Write(pData, numBytes);

--- a/Generals/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
@@ -109,7 +109,7 @@ class WBGameFileClass : public GameFileClass
 
 public:
 	WBGameFileClass(char const *filename):GameFileClass(filename){};
-	virtual char const * Set_Name(char const *filename);
+	virtual char const * Set_Name(char const *filename) override;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -136,7 +136,7 @@ char const * WBGameFileClass::Set_Name( char const *filename )
 // wb only data.  jba.
 
 class	WB_W3DFileSystem : public W3DFileSystem {
-	virtual FileClass * Get_File( char const *filename );
+	virtual FileClass * Get_File( char const *filename ) override;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -571,7 +571,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CAboutDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -158,7 +158,7 @@ protected:
 	CFile *m_file;
 public:
 	MFCFileOutputStream(CFile *pFile):m_file(pFile) {};
-	virtual Int write(const void *pData, Int numBytes) {
+	virtual Int write(const void *pData, Int numBytes) override {
 		Int numBytesWritten = 0;
 		try {
 			m_file->Write(pData, numBytes);
@@ -182,7 +182,7 @@ protected:
 	Int m_totalBytes;
 public:
 	CachedMFCFileOutputStream(CFile *pFile):m_file(pFile), m_totalBytes(0) {};
-	virtual Int write(const void *pData, Int numBytes) {
+	virtual Int write(const void *pData, Int numBytes) override {
 		UnsignedByte *tmp = new UnsignedByte[numBytes];
 		memcpy(tmp, pData, numBytes);
 		CachedChunk c;
@@ -216,7 +216,7 @@ protected:
 	Int m_totalBytes;
 public:
 	CompressedCachedMFCFileOutputStream(CFile *pFile):m_file(pFile), m_totalBytes(0) {};
-	virtual Int write(const void *pData, Int numBytes) {
+	virtual Int write(const void *pData, Int numBytes) override {
 		UnsignedByte *tmp = new UnsignedByte[numBytes];
 		memcpy(tmp, pData, numBytes);
 		CachedChunk c;

--- a/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -159,128 +159,128 @@ protected:
 	Int m_originX, m_originY;																		///< Location of top/left view corner
 
 protected:
-	virtual View *prependViewToList( View *list ) {return nullptr;};		///< Prepend this view to the given list, return the new list
-	virtual View *getNextView( void ) { return nullptr; }				///< Return next view in the set
+	virtual View *prependViewToList( View *list ) override {return nullptr;};		///< Prepend this view to the given list, return the new list
+	virtual View *getNextView( void ) override { return nullptr; }				///< Return next view in the set
 public:
 
-	virtual void init( void ){};
+	virtual void init( void ) override {};
 
-	virtual UnsignedInt getID( void ) { return 1; }
+	virtual UnsignedInt getID( void ) override { return 1; }
 
-	virtual Drawable *pickDrawable( const ICoord2D *screen, Bool forceAttack, PickType pickType ){return nullptr;};			///< pick drawable given the screen pixel coords
+	virtual Drawable *pickDrawable( const ICoord2D *screen, Bool forceAttack, PickType pickType ) override {return nullptr;};			///< pick drawable given the screen pixel coords
 
 	/// all drawables in the 2D screen region will call the 'callback'
 	virtual Int iterateDrawablesInRegion( IRegion2D *screenRegion,
 																				Bool (*callback)( Drawable *draw, void *userData ),
-																				void *userData ) {return 0;};
-  virtual WorldToScreenReturn worldToScreenTriReturn( const Coord3D *w, ICoord2D *s ) { return WTS_INVALID; };	///< Transform world coordinate "w" into screen coordinate "s"
-	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world ) {};  ///< transform screen coord to a point on the 3D terrain
-	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z ) {};  ///< transform screen point to world point at the specified world Z value
+																				void *userData ) override {return 0;};
+  virtual WorldToScreenReturn worldToScreenTriReturn( const Coord3D *w, ICoord2D *s ) override { return WTS_INVALID; };	///< Transform world coordinate "w" into screen coordinate "s"
+	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world ) override {};  ///< transform screen coord to a point on the 3D terrain
+	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z ) override {};  ///< transform screen point to world point at the specified world Z value
 	virtual void getScreenCornerWorldPointsAtZ( Coord3D *topLeft, Coord3D *topRight,
 																							Coord3D *bottomRight, Coord3D *bottomLeft,
-																							Real z ){};
+																							Real z ) override {};
 
-	virtual void drawView( void ) {};															///< Render the world visible in this view.
-	virtual void updateView( void ) {};															///< Render the world visible in this view.
-	virtual void stepView() {}; ///< Update view for every fixed time step
+	virtual void drawView( void ) override {};															///< Render the world visible in this view.
+	virtual void updateView( void ) override {};															///< Render the world visible in this view.
+	virtual void stepView() override {}; ///< Update view for every fixed time step
 
-	virtual void setZoomLimited( Bool limit ) {}			///< limit the zoom height
-	virtual Bool isZoomLimited( void ) { return TRUE; }							///< get status of zoom limit
+	virtual void setZoomLimited( Bool limit ) override {}			///< limit the zoom height
+	virtual Bool isZoomLimited( void ) const override { return TRUE; }							///< get status of zoom limit
 
-	virtual void setWidth( Int width ) { m_width = width; }
-	virtual Int getWidth( void ) { return m_width; }
-	virtual void setHeight( Int height ) { m_height = height; }
-	virtual Int getHeight( void ) { return m_height; }
-	virtual void setOrigin( Int x, Int y) { m_originX=x; m_originY=y;}				///< Sets location of top-left view corner on display
-	virtual void getOrigin( Int *x, Int *y) { *x=m_originX; *y=m_originY;}			///< Return location of top-left view corner on display
+	virtual void setWidth( Int width ) override { m_width = width; }
+	virtual Int getWidth( void ) override { return m_width; }
+	virtual void setHeight( Int height ) override { m_height = height; }
+	virtual Int getHeight( void ) override { return m_height; }
+	virtual void setOrigin( Int x, Int y) override { m_originX=x; m_originY=y;}				///< Sets location of top-left view corner on display
+	virtual void getOrigin( Int *x, Int *y) override { *x=m_originX; *y=m_originY;}			///< Return location of top-left view corner on display
 
-	virtual void forceRedraw() { }
+	virtual void forceRedraw() override { }
 
-	virtual Bool isDoingScriptedCamera() { return false; }
-	virtual void stopDoingScriptedCamera() {}
+	virtual Bool isDoingScriptedCamera() override { return false; }
+	virtual void stopDoingScriptedCamera() override {}
 
-	virtual void lookAt( const Coord3D *o ){};														///< Center the view on the given coordinate
-	virtual void initHeightForMap( void ) {};														///<  Init the camera height for the map at the current position.
+	virtual void lookAt( const Coord3D *o ) override {};											///< Center the view on the given coordinate
+	virtual void initHeightForMap( void ) override {};												///<  Init the camera height for the map at the current position.
 	virtual void scrollBy( Coord2D *delta ){};														///< Shift the view by the given delta
 	virtual void moveCameraTo(const Coord3D *o, Int frames, Int shutter,
 														Bool orient) {lookAt(o);};
 	virtual void moveCameraAlongWaypointPath(Waypoint *way, Int frames, Int shutter,
 														Bool orient) {};
-	virtual Bool isCameraMovementFinished(void) {return true;};
- 	virtual void resetCamera(const Coord3D *location, Int frames) {}; ///< Move camera to location, and reset to default angle & zoom.
- 	virtual void rotateCamera(Real rotations, Int frames) {}; ///< Rotate camera about current viewpoint.
+	virtual Bool isCameraMovementFinished(void) override {return true;};
+	virtual void resetCamera(const Coord3D *location, Int frames) {}; ///< Move camera to location, and reset to default angle & zoom.
+	virtual void rotateCamera(Real rotations, Int frames) {}; ///< Rotate camera about current viewpoint.
 	virtual void rotateCameraTowardObject(ObjectID id, Int milliseconds, Int holdMilliseconds) {};	///< Rotate camera to face an object, and hold on it
 	virtual void cameraModFinalZoom(Real finalZoom){};			 ///< Final zoom for current camera movement.
-	virtual void cameraModRollingAverage(Int framesToAverage){}; ///< Number of frames to average movement for current camera movement.
-	virtual void cameraModFinalTimeMultiplier(Int finalMultiplier){}; ///< Final time multiplier for current camera movement.
+	virtual void cameraModRollingAverage(Int framesToAverage) override {}; ///< Number of frames to average movement for current camera movement.
+	virtual void cameraModFinalTimeMultiplier(Int finalMultiplier) override {}; ///< Final time multiplier for current camera movement.
 	virtual void cameraModFinalPitch(Real finalPitch){};		 ///< Final pitch for current camera movement.
-	virtual void cameraModFreezeTime(void){}					///< Freezes time during the next camera movement.
-	virtual void cameraModFreezeAngle(void){}					///< Freezes time during the next camera movement.
-	virtual void cameraModLookToward(Coord3D *pLoc){}			///< Sets a look at point during camera movement.
-	virtual void cameraModFinalLookToward(Coord3D *pLoc){}			///< Sets a look at point during camera movement.
-	virtual void cameraModFinalMoveTo(Coord3D *pLoc){ };			///< Sets a final move to.
-	virtual Bool isTimeFrozen(void){ return false;}					///< Freezes time during the next camera movement.
-	virtual Int	 getTimeMultiplier(void) {return 1;};				///< Get the time multiplier.
-	virtual void setTimeMultiplier(Int multiple) {}; ///< Set the time multiplier.
-	virtual void setDefaultView(Real pitch, Real angle, Real maxHeight) {};
+	virtual void cameraModFreezeTime(void) override {}					///< Freezes time during the next camera movement.
+	virtual void cameraModFreezeAngle(void) override {}					///< Freezes time during the next camera movement.
+	virtual void cameraModLookToward(Coord3D *pLoc) override {}			///< Sets a look at point during camera movement.
+	virtual void cameraModFinalLookToward(Coord3D *pLoc) override {}			///< Sets a look at point during camera movement.
+	virtual void cameraModFinalMoveTo(Coord3D *pLoc) override { };			///< Sets a final move to.
+	virtual Bool isTimeFrozen(void) override { return false;}					///< Freezes time during the next camera movement.
+	virtual Int	 getTimeMultiplier(void) override {return 1;};				///< Get the time multiplier.
+	virtual void setTimeMultiplier(Int multiple) override {}; ///< Set the time multiplier.
+	virtual void setDefaultView(Real pitch, Real angle, Real maxHeight) override {};
 	virtual void zoomCamera( Real finalZoom, Int milliseconds ) {};
 	virtual void pitchCamera( Real finalPitch, Int milliseconds ) {};
 
-	virtual void setAngle( Real angle ){};																///< Rotate the view around the up axis to the given angle
-	virtual Real getAngle( void ) { return 0; }
-	virtual void setPitch( Real angle ){};																	///< Rotate the view around the horizontal axis to the given angle
-	virtual Real getPitch( void ) { return 0; }							///< Return current camera pitch
-	virtual void setAngleToDefault( void ) {}											///< Set the view angle back to default
-	virtual void setPitchToDefault( void ) {}											///< Set the view pitch back to default
+	virtual void setAngle( Real angle ) override {};																///< Rotate the view around the up axis to the given angle
+	virtual Real getAngle( void ) override { return 0; }
+	virtual void setPitch( Real angle ) override {};																	///< Rotate the view around the horizontal axis to the given angle
+	virtual Real getPitch( void ) override { return 0; }							///< Return current camera pitch
+	virtual void setAngleToDefault( void ) override {}											///< Set the view angle back to default
+	virtual void setPitchToDefault( void ) override {}											///< Set the view pitch back to default
 	virtual void getPosition(Coord3D *pos) {}											///< Return camera position
 
-	virtual Real getHeightAboveGround() { return 1; }
-	virtual void setHeightAboveGround(Real z) { }
-	virtual Real getZoom() { return 1; }
-	virtual void setZoom(Real z) { }
+	virtual Real getHeightAboveGround() override { return 1; }
+	virtual void setHeightAboveGround(Real z) override { }
+	virtual Real getZoom() override { return 1; }
+	virtual void setZoom(Real z) override { }
 	virtual void zoomIn( void ) {  }																			///< Zoom in, closer to the ground, limit to min
 	virtual void zoomOut( void ) {  }																		///< Zoom out, farther away from the ground, limit to max
-	virtual void setZoomToDefault( void ) { }														///< Set zoom to default value
+	virtual void setZoomToDefault( void ) override { }														///< Set zoom to default value
 	virtual Real getMaxZoom( void ) { return 0.0f; }
-	virtual void setOkToAdjustHeight( Bool val ) { }						///< Set this to adjust camera height
+	virtual void setOkToAdjustHeight( Bool val ) override { }						///< Set this to adjust camera height
 
-	virtual Real getTerrainHeightAtPivot() { return 0.0f; }
-	virtual Real getCurrentHeightAboveGround() { return 0.0f; }
+	virtual Real getTerrainHeightAtPivot() override { return 0.0f; }
+	virtual Real getCurrentHeightAboveGround() override { return 0.0f; }
 
-	virtual void getLocation ( ViewLocation *location ) {};								///< write the view's current location in to the view location object
-	virtual void setLocation ( const ViewLocation *location ){};								///< set the view's current location from to the view location object
+	virtual void getLocation ( ViewLocation *location ) override {};								///< write the view's current location in to the view location object
+	virtual void setLocation ( const ViewLocation *location ) override {};								///< set the view's current location from to the view location object
 
-	virtual ObjectID getCameraLock() const { return INVALID_ID; }
-	virtual void setCameraLock(ObjectID id) {  }
-	virtual void snapToCameraLock( void ) {  }
-	virtual void setSnapMode( CameraLockType lockType, Real lockDist ) {  }
+	virtual ObjectID getCameraLock() const override { return INVALID_ID; }
+	virtual void setCameraLock(ObjectID id) override {  }
+	virtual void snapToCameraLock( void ) override {  }
+	virtual void setSnapMode( CameraLockType lockType, Real lockDist ) override {  }
 
-	virtual Drawable *getCameraLockDrawable() const { return nullptr; }
-	virtual void setCameraLockDrawable(Drawable *drawable) { }
+	virtual Drawable *getCameraLockDrawable() const override { return nullptr; }
+	virtual void setCameraLockDrawable(Drawable *drawable) override { }
 
-	virtual void setMouseLock( Bool mouseLocked ) {}					///< lock/unlock the mouse input to the tactical view
-	virtual Bool isMouseLocked( void ) { return FALSE; }			///< is the mouse input locked to the tactical view?
+	virtual void setMouseLock( Bool mouseLocked ) override {}					///< lock/unlock the mouse input to the tactical view
+	virtual Bool isMouseLocked( void ) override { return FALSE; }			///< is the mouse input locked to the tactical view?
 
-	virtual void setFieldOfView( Real angle ) {};							///< Set the horizontal field of view angle
-	virtual Real getFieldOfView( void ) {return 0;};										///< Get the horizontal field of view angle
+	virtual void setFieldOfView( Real angle ) override {};							///< Set the horizontal field of view angle
+	virtual Real getFieldOfView( void ) override {return 0;};										///< Get the horizontal field of view angle
 
-	virtual Bool setViewFilterMode(enum FilterModes) {return FALSE;}	///<stub
-	virtual void setViewFilterPos(const Coord3D *pos) {};	///<stub
-	virtual void setFadeParameters(Int fadeFrames, Int direction) {};	///<stub
-	virtual void set3DWireFrameMode(Bool enable) { }; ///<stub
-	virtual Bool setViewFilter(		enum FilterTypes m_viewFilterMode) { return FALSE;}	///<stub
-	virtual enum FilterModes	 getViewFilterMode(void) {return (enum FilterModes)0;}			///< Turns on viewport special effect (black & white mode)
-	virtual enum FilterTypes	 getViewFilterType(void) {return (enum FilterTypes)0;}			///< Turns on viewport special effect (black & white mode)
+	virtual Bool setViewFilterMode(enum FilterModes) override {return FALSE;}	///<stub
+	virtual void setViewFilterPos(const Coord3D *pos) override {};	///<stub
+	virtual void setFadeParameters(Int fadeFrames, Int direction) override {};	///<stub
+	virtual void set3DWireFrameMode(Bool enable) override { }; ///<stub
+	virtual Bool setViewFilter(		enum FilterTypes m_viewFilterMode) override { return FALSE;}	///<stub
+	virtual enum FilterModes	 getViewFilterMode(void) override {return (enum FilterModes)0;}			///< Turns on viewport special effect (black & white mode)
+	virtual enum FilterTypes	 getViewFilterType(void) override {return (enum FilterTypes)0;}			///< Turns on viewport special effect (black & white mode)
 
-	virtual void shake( const Coord3D *epicenter, CameraShakeType shakeType ) {};
+	virtual void shake( const Coord3D *epicenter, CameraShakeType shakeType ) override {};
 
-	virtual Real getFXPitch( void ) const { return 1.0f; }
-	virtual void forceCameraAreaConstraintRecalc(void) { }
+	virtual Real getFXPitch( void ) const override { return 1.0f; }
+	virtual void forceCameraAreaConstraintRecalc(void) override { }
 	virtual void rotateCameraTowardPosition(const Coord3D *pLoc, Int milliseconds) {};	///< Rotate camera to face an object, and hold on it
 
-	virtual const Coord3D& get3DCameraPosition() const { static Coord3D dummy; return dummy; }							///< Returns the actual camera position
+	virtual const Coord3D& get3DCameraPosition() const override { static Coord3D dummy; return dummy; }							///< Returns the actual camera position
 
-	virtual void setGuardBandBias( const Coord2D *gb ) {};
+	virtual void setGuardBandBias( const Coord2D *gb ) override {};
 
 };
 
@@ -296,10 +296,10 @@ class SkeletonSceneClass : public RTS3DScene
 {
 public:
 	SkeletonSceneClass(void) : m_testPass(nullptr) { }
-	~SkeletonSceneClass(void) { REF_PTR_RELEASE(m_testPass); }
+	virtual ~SkeletonSceneClass(void) override { REF_PTR_RELEASE(m_testPass); }
 
 	void					Set_Material_Pass(MaterialPassClass * pass)	{ REF_PTR_SET(m_testPass, pass); }
-	virtual void Remove_Render_Object(RenderObjClass * obj);
+	virtual void Remove_Render_Object(RenderObjClass * obj) override;
 
 	Bool safeContains(RenderObjClass *obj);
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1076,7 +1076,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 			{
 				DEBUG_LOG(("META: select team %d",group));
 
-				UnsignedInt now = TheGameLogic->getFrame();
+				UnsignedInt now = timeGetTime();
 				if ( m_lastGroupSelTime == 0 )
 				{
 					m_lastGroupSelTime = now;
@@ -1085,7 +1085,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 				Bool performSelection = TRUE;
 
 				// check for double-press to jump view
-				if ( now - m_lastGroupSelTime < 20 && group == m_lastGroupSelGroup )
+				if ( now - m_lastGroupSelTime < TheGlobalData->m_doubleClickTimeMS && group == m_lastGroupSelGroup )
 				{
 					DEBUG_LOG(("META: DOUBLETAP select team %d",group));
 					// TheSuperHackers @bugfix Stubbjax 26/05/2025 Perform selection on double-press
@@ -1157,7 +1157,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 			{
 				DEBUG_LOG(("META: select team %d",group));
 
-				UnsignedInt now = TheGameLogic->getFrame();
+				UnsignedInt now = timeGetTime();
 				if ( m_lastGroupSelTime == 0 )
 				{
 					m_lastGroupSelTime = now;
@@ -1165,7 +1165,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 
 				// check for double-press to jump view
 
-				if ( now - m_lastGroupSelTime < 20 && group == m_lastGroupSelGroup )
+				if ( now - m_lastGroupSelTime < TheGlobalData->m_doubleClickTimeMS && group == m_lastGroupSelGroup )
 				{
 					DEBUG_LOG(("META: DOUBLETAP select team %d",group));
 					Player *player = ThePlayerList->getLocalPlayer();

--- a/GeneralsMD/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
+++ b/GeneralsMD/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
@@ -64,68 +64,68 @@ class GUIEditDisplay : public Display
 public:
 
 	GUIEditDisplay( void );
-	virtual ~GUIEditDisplay( void );
+	virtual ~GUIEditDisplay( void ) override;
 
-	virtual void draw( void ) { };
+	virtual void draw( void ) override { };
 
 	/// draw a line on the display in pixel coordinates with the specified color
 	virtual void drawLine( Int startX, Int startY, Int endX, Int endY,
-												 Real lineWidth, UnsignedInt lineColor );
+												 Real lineWidth, UnsignedInt lineColor ) override;
 	virtual void drawLine( Int startX, Int startY, Int endX, Int endY,
-												 Real lineWidth, UnsignedInt lineColor1, UnsignedInt lineColor2 ) { }
+												 Real lineWidth, UnsignedInt lineColor1, UnsignedInt lineColor2 ) override { }
 	/// draw a rect border on the display in pixel coordinates with the specified color
 	virtual void drawOpenRect( Int startX, Int startY, Int width, Int height,
-														 Real lineWidth, UnsignedInt lineColor );
+														 Real lineWidth, UnsignedInt lineColor ) override;
 	/// draw a filled rect on the display in pixel coords with the specified color
 	virtual void drawFillRect( Int startX, Int startY, Int width, Int height,
-														 UnsignedInt color );
+														 UnsignedInt color ) override;
 
 	/// Draw a percentage of a rectangle, much like a clock
-	virtual void drawRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color) { }
-	virtual void drawRemainingRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color) { }
+	virtual void drawRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color) override { }
+	virtual void drawRemainingRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color) override { }
 
 	/// draw an image fit within the screen coordinates
 	virtual void drawImage( const Image *image, Int startX, Int startY,
-													Int endX, Int endY, Color color = 0xFFFFFFFF, DrawImageMode mode=DRAW_IMAGE_ALPHA);
+													Int endX, Int endY, Color color = 0xFFFFFFFF, DrawImageMode mode=DRAW_IMAGE_ALPHA) override;
 	/// image clipping support
-	virtual void setClipRegion( IRegion2D *region );
-	virtual Bool isClippingEnabled( void );
-	virtual void enableClipping( Bool onoff );
+	virtual void setClipRegion( IRegion2D *region ) override;
+	virtual Bool isClippingEnabled( void ) override;
+	virtual void enableClipping( Bool onoff ) override;
 
 	// These are stub functions to allow compilation:
 
 	/// Create a video buffer that can be used for this display
-	virtual VideoBuffer*	createVideoBuffer( void ) { return nullptr; }
+	virtual VideoBuffer*	createVideoBuffer( void ) override { return nullptr; }
 
 	/// draw a video buffer fit within the screen coordinates
-	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream ) { }
+	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream ) override { }
 	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY,
-																Int endX, Int endY ) { }
-	virtual void takeScreenShot(void){ }
-	virtual void toggleMovieCapture(void) {}
+																Int endX, Int endY ) override { }
+	virtual void takeScreenShot(void) override { }
+	virtual void toggleMovieCapture(void) override {}
 
 	// methods that we need to stub
-	virtual void setTimeOfDay( TimeOfDay tod ) {}
+	virtual void setTimeOfDay( TimeOfDay tod ) override {}
 	virtual void createLightPulse( const Coord3D *pos, const RGBColor *color, Real innerRadius, Real attenuationWidth,
-																 UnsignedInt increaseFrameTime, UnsignedInt decayFrameTime ) {}
-	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting) {}
-	void setBorderShroudLevel(UnsignedByte level){}
-	virtual void clearShroud() {}
-	virtual void preloadModelAssets( AsciiString model ) {}
-	virtual void preloadTextureAssets( AsciiString texture ) {}
-	virtual void toggleLetterBox(void) {}
-	virtual void enableLetterBox(Bool enable) {}
+																 UnsignedInt increaseFrameTime, UnsignedInt decayFrameTime ) override {}
+	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting) override {}
+	virtual void setBorderShroudLevel(UnsignedByte level) override {}
+	virtual void clearShroud() override {}
+	virtual void preloadModelAssets( AsciiString model ) override {}
+	virtual void preloadTextureAssets( AsciiString texture ) override {}
+	virtual void toggleLetterBox(void) override {}
+	virtual void enableLetterBox(Bool enable) override {}
 #if defined(RTS_DEBUG)
 	virtual void dumpModelAssets(const char *path) {}
 #endif
-	virtual void doSmartAssetPurgeAndPreload(const char* usageFileName) {}
+	virtual void doSmartAssetPurgeAndPreload(const char* usageFileName) override {}
 #if defined(RTS_DEBUG)
 	virtual void dumpAssetUsage(const char* mapname) {}
 #endif
 
-	virtual Real getAverageFPS(void) { return 0; }
-	virtual Real getCurrentFPS(void) { return 0; }
-	virtual Int getLastFrameDrawCalls( void ) { return 0; }
+	virtual Real getAverageFPS(void) override { return 0; }
+	virtual Real getCurrentFPS(void) override { return 0; }
+	virtual Int getLastFrameDrawCalls( void ) override { return 0; }
 
 protected:
 

--- a/GeneralsMD/Code/Tools/GUIEdit/Include/GUIEditWindowManager.h
+++ b/GeneralsMD/Code/Tools/GUIEdit/Include/GUIEditWindowManager.h
@@ -46,16 +46,16 @@ class GUIEditWindowManager : public W3DGameWindowManager
 public:
 
 	GUIEditWindowManager( void );
-	virtual ~GUIEditWindowManager( void );
+	virtual ~GUIEditWindowManager( void ) override;
 
-	virtual void init( void );  ///< initialize system
+	virtual void init( void ) override;  ///< initialize system
 
-	virtual Int winDestroy( GameWindow *window );  ///< destroy this window
+	virtual Int winDestroy( GameWindow *window ) override;  ///< destroy this window
 	/// create a new window by setting up parameters and callbacks
 	virtual GameWindow *winCreate( GameWindow *parent, UnsignedInt status,
 																 Int x, Int y, Int width, Int height,
 																 GameWinSystemFunc system,
-																 WinInstanceData *instData = nullptr );
+																 WinInstanceData *instData = nullptr ) override;
 
 	// **************************************************************************
 	// GUIEdit specific methods *************************************************

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/AutoEdgeOutTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/AutoEdgeOutTool.h
@@ -33,10 +33,10 @@ class AutoEdgeOutTool : public Tool
 {
 public:
 	AutoEdgeOutTool(void);
-	~AutoEdgeOutTool(void);
+	virtual ~AutoEdgeOutTool(void) override;
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/BaseBuildProps.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/BaseBuildProps.h
@@ -41,7 +41,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(BaseBuildProps)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -49,8 +49,8 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(BaseBuildProps)
-	virtual BOOL OnInitDialog();
-	virtual void OnOK();
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/BlendEdgeTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/BlendEdgeTool.h
@@ -36,11 +36,11 @@ protected:
 
 public:
 	BlendEdgeTool(void);
-	~BlendEdgeTool(void);
+	virtual ~BlendEdgeTool(void) override;
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
 
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/BlendMaterial.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/BlendMaterial.h
@@ -45,10 +45,10 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(BlendMaterial)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -56,7 +56,7 @@ protected:
 	enum {MIN_TILE_SIZE=2, MAX_TILE_SIZE = 100};
 	// Generated message map functions
 	//{{AFX_MSG(BlendMaterial)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/BorderTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/BorderTool.h
@@ -32,17 +32,17 @@ class BorderTool : public Tool
 
 	public:
 		BorderTool();
-		~BorderTool();
+		virtual ~BorderTool() override;
 
 		Int getToolID(void) {return m_toolID;}
-		virtual void setCursor(void);
+		virtual void setCursor(void) override;
 
-		virtual void activate();
-		virtual void deactivate();
+		virtual void activate() override;
+		virtual void deactivate() override;
 
-		virtual Bool followsTerrain(void) { return false;	}
+		virtual Bool followsTerrain(void) override { return false;	}
 
-		virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-		virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-		virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
+		virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+		virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+		virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/BrushTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/BrushTool.h
@@ -42,7 +42,7 @@ protected:
 
 public:
 	BrushTool(void);
-	~BrushTool(void);
+	virtual ~BrushTool(void) override;
 
 public:
 	static Int getWidth(void) {return m_brushWidth;};  ///<Returns width.
@@ -53,11 +53,11 @@ public:
 	static void setHeight(Int height);
 
 public:
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual WorldHeightMapEdit *getHeightMap(void) {return m_htMapEditCopy;};
-	virtual void activate(); ///< Become the current tool.
-	virtual Bool followsTerrain(void) {return false;};
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual WorldHeightMapEdit *getHeightMap(void) override {return m_htMapEditCopy;};
+	virtual void activate() override; ///< Become the current tool.
+	virtual Bool followsTerrain(void) override {return false;};
 
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/BuildList.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/BuildList.h
@@ -36,7 +36,7 @@ class BuildList : public COptionsPanel, public PopupSliderOwner
 public:
  	BuildList(CWnd* pParent = nullptr);   ///< standard constructor
 
-	~BuildList(void);   ///< standard destructor
+	virtual ~BuildList(void) override;   ///< standard destructor
 	enum { NAME_MAX_LEN = 64 };
 // Dialog Data
 	//{{AFX_DATA(BuildList)
@@ -49,9 +49,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(BuildList)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -59,7 +59,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(BuildList)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSelchangeSidesCombo();
 	afx_msg void OnMoveUp();
 	afx_msg void OnMoveDown();
@@ -97,9 +97,9 @@ public:
 	static void update(void) {if (m_staticThis) m_staticThis->loadSides();};
 	static void setSelectedBuildList(BuildListInfo *pInfo);
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 
 };
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/BuildListTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/BuildListTool.h
@@ -56,7 +56,7 @@ protected:
 
 public:
 	BuildListTool(void);
-	~BuildListTool(void);
+	virtual ~BuildListTool(void) override;
 
 private:
 	void createWindow(void);
@@ -68,10 +68,10 @@ public:
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void setCursor(void);
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become not the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void setCursor(void) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become not the current tool.
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/CButtonShowColor.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/CButtonShowColor.h
@@ -27,7 +27,7 @@ class CButtonShowColor : public CButton
 		const RGBColor& getColor(void) const { return m_color; }
 		void setColor(Int color) { m_color.setFromInt(color); }
 		void setColor(const RGBColor& color) { m_color = color; }
-		~CButtonShowColor();
+		virtual ~CButtonShowColor() override;
 
 
 		static COLORREF RGBtoBGR(Int color);

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/CFixTeamOwnerDialog.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/CFixTeamOwnerDialog.h
@@ -33,8 +33,8 @@ class CFixTeamOwnerDialog : public CDialog
 		Bool pickedValidTeam() { return m_pickedValidTeam; }
 
 	protected:
-		virtual BOOL OnInitDialog();
-		afx_msg void OnOK();
+		virtual BOOL OnInitDialog() override;
+		virtual afx_msg void OnOK() override;
 		DECLARE_MESSAGE_MAP()
 
 	protected:

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/CUndoable.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/CUndoable.h
@@ -42,7 +42,7 @@ protected:
 public:
 		Undoable(void);
 
-		~Undoable(void);
+		virtual ~Undoable(void) override;
 
 public:
 	virtual void Do(void)=0; ///< pure virtual.
@@ -77,10 +77,10 @@ public:
 		WBDocUndoable(CWorldBuilderDoc *pDoc, WorldHeightMapEdit *pNewHtMap, Coord3D *pObjOffset = nullptr);
 
 		// destructor.
-		~WBDocUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
-		virtual void Redo(void);
+		virtual ~WBDocUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
+		virtual void Redo(void) override;
 
 };
 
@@ -99,9 +99,9 @@ public:
 		AddObjectUndoable(CWorldBuilderDoc *pDoc, MapObject *pObjectToAdd);
 
 		// destructor.
-		~AddObjectUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~AddObjectUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 
@@ -146,11 +146,11 @@ protected:
 public:
 		ModifyObjectUndoable(CWorldBuilderDoc *pDoc);
 		// destructor.
-		~ModifyObjectUndoable(void);
+		virtual ~ModifyObjectUndoable(void) override;
 
-		virtual void Do(void);
-		virtual void Undo(void);
-		virtual void Redo(void);
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
+		virtual void Redo(void) override;
 
 		void SetOffset(Real x, Real y);
 		void SetZOffset(Real z);
@@ -188,11 +188,11 @@ protected:
 public:
 		ModifyFlagsUndoable(CWorldBuilderDoc *pDoc, Int flagMask, Int flagValue);
 		// destructor.
-		~ModifyFlagsUndoable(void);
+		virtual ~ModifyFlagsUndoable(void) override;
 
-		virtual void Do(void);
-		virtual void Undo(void);
-		virtual void Redo(void);
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
+		virtual void Redo(void) override;
 
 };
 
@@ -205,10 +205,10 @@ protected:
 public:
 
 	SidesListUndoable(const SidesList& newSL, CWorldBuilderDoc *pDoc);
-	~SidesListUndoable(void);
+	virtual ~SidesListUndoable(void) override;
 
-	virtual void Do(void);
-	virtual void Undo(void);
+	virtual void Do(void) override;
+	virtual void Undo(void) override;
 
 };
 
@@ -231,10 +231,10 @@ public:
 	// if you want to substitute the entire contents of the new dict, pass NAMEKEY_INVALID.
 	DictItemUndoable(Dict **d, Dict data, NameKeyType key, Int dictsToModify = 1, CWorldBuilderDoc *pDoc = nullptr, Bool inval = false);
 	// destructor.
-	~DictItemUndoable(void);
+	virtual ~DictItemUndoable(void) override;
 
-	virtual void Do(void);
-	virtual void Undo(void);
+	virtual void Do(void) override;
+	virtual void Undo(void) override;
 
 };
 
@@ -267,9 +267,9 @@ public:
 		DeleteObjectUndoable(CWorldBuilderDoc *pDoc);
 
 		// destructor.
-		~DeleteObjectUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~DeleteObjectUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 ///                            AddPolygonUndoable
@@ -282,9 +282,9 @@ protected:
 public:
 		AddPolygonUndoable( PolygonTrigger *pTrig);
 		// destructor.
-		~AddPolygonUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~AddPolygonUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 ///                            AddPolygonPointUndoable
@@ -297,9 +297,9 @@ protected:
 public:
 		AddPolygonPointUndoable(PolygonTrigger *pTrig, ICoord3D pt);
 		// destructor.
-		~AddPolygonPointUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~AddPolygonPointUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 ///                            ModifyPolygonPointUndoable
@@ -314,9 +314,9 @@ protected:
 public:
 		ModifyPolygonPointUndoable(PolygonTrigger *pTrig, Int ndx);
 		// destructor.
-		~ModifyPolygonPointUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~ModifyPolygonPointUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 ///                            MovePolygonUndoable
@@ -330,9 +330,9 @@ protected:
 public:
 		MovePolygonUndoable(PolygonTrigger *pTrig);
 		// destructor.
-		~MovePolygonUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~MovePolygonUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 
 		void SetOffset(const ICoord3D &offset);
 		PolygonTrigger *getTrigger(void) {return m_trigger;}
@@ -349,9 +349,9 @@ protected:
 public:
 		InsertPolygonPointUndoable(PolygonTrigger *pTrig, ICoord3D pt, Int ndx);
 		// destructor.
-		~InsertPolygonPointUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~InsertPolygonPointUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 ///                            DeletePolygonPointUndoable
@@ -365,9 +365,9 @@ protected:
 public:
 		DeletePolygonPointUndoable(PolygonTrigger *pTrig, Int ndx);
 		// destructor.
-		~DeletePolygonPointUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~DeletePolygonPointUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 ///                            DeletePolygonUndoable
@@ -380,9 +380,9 @@ protected:
 public:
 		DeletePolygonUndoable(PolygonTrigger *pTrig);
 		// destructor.
-		~DeletePolygonUndoable(void);
-		virtual void Do(void);
-		virtual void Undo(void);
+		virtual ~DeletePolygonUndoable(void) override;
+		virtual void Do(void) override;
+		virtual void Undo(void) override;
 };
 
 ///                            MultipleUndoable
@@ -397,14 +397,14 @@ protected:
 public:
 		MultipleUndoable();
     // destructor.
-    ~MultipleUndoable(void);
+    virtual ~MultipleUndoable(void) override;
 
     /** Add other undoables in the order you would want them UNdone; e.g. in the reverse order you want them done
       * The MultipleUndoable object will then own the pointers.
       */
     void addUndoable( Undoable * undoable );
 
-    virtual void Do(void);
-    virtual void Undo(void);
-    virtual void Redo(void);
+    virtual void Do(void) override;
+    virtual void Undo(void) override;
+    virtual void Redo(void) override;
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/CameraOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/CameraOptions.h
@@ -44,7 +44,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CameraOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -56,7 +56,7 @@ protected:
 	afx_msg void OnDropWaypointButton();
 	afx_msg void OnCenterOnSelectedButton();
 	afx_msg void OnMove(int x, int y);
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangePitchEdit();
 	afx_msg void OnShowWindow(BOOL bShow, UINT nStatus);
 	//}}AFX_MSG
@@ -75,9 +75,9 @@ protected:
 
 public: // popup slider interface.
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 
 public:
 	void update( void );

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/CellWidth.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/CellWidth.h
@@ -42,8 +42,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CellWidth)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK();
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -54,7 +54,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CellWidth)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ContourOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ContourOptions.h
@@ -48,7 +48,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(ContourOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -56,7 +56,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(ContourOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
 	afx_msg void OnShowContours();
 	//}}AFX_MSG

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/DrawObject.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/DrawObject.h
@@ -48,26 +48,26 @@ public:
 	DrawObject(void);
 	DrawObject(const DrawObject & src);
 	DrawObject & operator = (const DrawObject &);
-	~DrawObject(void);
+	virtual ~DrawObject(void) override;
 
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface
 	/////////////////////////////////////////////////////////////////////////////
-	virtual RenderObjClass *	Clone(void) const;
-	virtual int						Class_ID(void) const;
-	virtual void					Render(RenderInfoClass & rinfo);
+	virtual RenderObjClass *	Clone(void) const override;
+	virtual int						Class_ID(void) const override;
+	virtual void					Render(RenderInfoClass & rinfo) override;
 //	virtual void					Special_Render(SpecialRenderInfoClass & rinfo);
 //	virtual void 					Set_Transform(const Matrix3D &m);
 //	virtual void 					Set_Position(const Vector3 &v);
 //TODO: MW: do these later - only needed for collision detection
-	virtual Bool					Cast_Ray(RayCollisionTestClass & raytest);
+	virtual Bool					Cast_Ray(RayCollisionTestClass & raytest) override;
 //	virtual Bool					Cast_AABox(AABoxCollisionTestClass & boxtest);
 //	virtual Bool					Cast_OBBox(OBBoxCollisionTestClass & boxtest);
 //	virtual Bool					Intersect_AABox(AABoxIntersectionTestClass & boxtest);
 //	virtual Bool					Intersect_OBBox(OBBoxIntersectionTestClass & boxtest);
 
-	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const;
-    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const;
+	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
+	virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const override;
 
 
 //	virtual int					 	Get_Num_Polys(void) const;

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/EditAction.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/EditAction.h
@@ -45,8 +45,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(EditAction)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -68,7 +68,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(EditAction)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSelchangeScriptActionType();
 	afx_msg void OnTimer(UINT nIDEvent);
 	//}}AFX_MSG

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/EditCondition.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/EditCondition.h
@@ -28,7 +28,7 @@ class SidesList;
 class CMyTreeCtrl : public CTreeCtrl
 {
 public:
-	virtual LRESULT WindowProc( UINT message, WPARAM wParam, LPARAM lParam );
+	virtual LRESULT WindowProc( UINT message, WPARAM wParam, LPARAM lParam ) override;
 };
 
 /////////////////////////////////////////////////////////////////////////////
@@ -51,8 +51,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(EditCondition)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -74,7 +74,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(EditCondition)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSelchangeConditionType();
 	afx_msg void OnTimer(UINT nIDEvent);
 	//}}AFX_MSG

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/EditCoordParameter.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/EditCoordParameter.h
@@ -43,7 +43,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(EditCoordParameter)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -59,9 +59,9 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(EditCoordParameter)
-	virtual BOOL OnInitDialog();
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/EditGroup.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/EditGroup.h
@@ -42,7 +42,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(EditGroup)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -53,8 +53,8 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(EditGroup)
-	virtual void OnOK();
-	virtual BOOL OnInitDialog();
+	virtual void OnOK() override;
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/EditObjectParameter.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/EditObjectParameter.h
@@ -43,8 +43,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(EditObjectParameter)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -63,9 +63,9 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(EditObjectParameter)
-	virtual BOOL OnInitDialog();
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/EditParameter.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/EditParameter.h
@@ -44,7 +44,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(EditParameter)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -119,9 +119,9 @@ protected:
 	//{{AFX_MSG(EditParameter)
 	afx_msg void OnChangeEdit();
 	afx_msg void OnEditchangeCombo();
-	virtual BOOL OnInitDialog();
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	afx_msg void OnPreviewSound();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ExportScriptsOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ExportScriptsOptions.h
@@ -41,7 +41,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(ExportScriptsOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -63,8 +63,8 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(ExportScriptsOptions)
-	virtual void OnOK();
-	virtual BOOL OnInitDialog();
+	virtual void OnOK() override;
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/EyedropperTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/EyedropperTool.h
@@ -33,10 +33,10 @@ class EyedropperTool : public Tool
 {
 public:
 	EyedropperTool(void);
-	~EyedropperTool(void);
+	virtual ~EyedropperTool(void) override;
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/FeatherOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/FeatherOptions.h
@@ -50,9 +50,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(FeatherOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -60,7 +60,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(FeatherOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeSizeEdit();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
@@ -83,9 +83,9 @@ public:
 
 public:
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 
 };
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/FeatherTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/FeatherTool.h
@@ -41,15 +41,15 @@ protected:
 	static Int m_radius;
 public:
 	FeatherTool(void);
-	~FeatherTool(void);
+	virtual ~FeatherTool(void) override;
 
 	static void setFeather(Int feather);
 	static void setRate(Int rate);
 	static void setRadius(Int Radius);
 public:
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual WorldHeightMapEdit *getHeightMap(void) {return m_htMapEditCopy;};
-	virtual void activate(); ///< Become the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual WorldHeightMapEdit *getHeightMap(void) override {return m_htMapEditCopy;};
+	virtual void activate() override; ///< Become the current tool.
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/FenceOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/FenceOptions.h
@@ -35,7 +35,7 @@ class FenceOptions : public COptionsPanel
 public:
 	FenceOptions(CWnd* pParent = nullptr);   ///< standard constructor
 
-	~FenceOptions(void);   ///< standard destructor
+	virtual ~FenceOptions(void) override;   ///< standard destructor
 	enum { NAME_MAX_LEN = 64 };
 // Dialog Data
 	//{{AFX_DATA(FenceOptions)
@@ -48,10 +48,10 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(FenceOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -59,7 +59,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(FenceOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeFenceSpacingEdit();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/FenceTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/FenceTool.h
@@ -42,15 +42,15 @@ protected:
 
 public:
 	FenceTool(void);
-	~FenceTool(void);
+	virtual ~FenceTool(void) override;
 
 protected:
 	void updateMapObjectList(Coord3D downPt, Coord3D curPt, WbView* pView, CWorldBuilderDoc *pDoc, Bool checkPlayers);
 
 public:
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become not the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become not the current tool.
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/FloodFillTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/FloodFillTool.h
@@ -32,7 +32,7 @@ class FloodFillTool : public Tool
 {
 public:
 	FloodFillTool(void);
-	~FloodFillTool(void);
+	virtual ~FloodFillTool(void) override;
 
 protected:
 	Int			m_textureClassToDraw; ///< The texture to fill with.  Foreground for mousedDown, background for mouseDownRt.
@@ -40,9 +40,9 @@ protected:
 	static Bool m_adjustCliffTextures;
 
 public:
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
-	virtual void setCursor(void);
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void setCursor(void) override;
 
 	Bool getAdjustCliffs(void) {return m_adjustCliffTextures;}
 	void setAdjustCliffs(Bool val) {m_adjustCliffTextures = val;}

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/GlobalLightOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/GlobalLightOptions.h
@@ -53,7 +53,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(GlobalLightOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -61,7 +61,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(GlobalLightOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnShowWindow(BOOL bShow, UINT nStatus);
 	afx_msg void OnMove(int x, int y);
 	afx_msg void OnChangeFrontBackEdit();
@@ -73,8 +73,8 @@ protected:
 	afx_msg void OnColorPress();
 	afx_msg void OnResetLights();
 	afx_msg void OnClose();
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 
@@ -127,9 +127,9 @@ protected:
 	void stuffValuesIntoFields(Int lightIndex = 0);
 public:
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 
 };
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/GroveOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/GroveOptions.h
@@ -46,10 +46,10 @@ class GroveOptions : public COptionsPanel
 
 	public:
 		GroveOptions(CWnd* pParent = nullptr);
-		~GroveOptions();
+		virtual ~GroveOptions() override;
 		void makeMain(void);
 
-		virtual BOOL OnInitDialog();
+		virtual BOOL OnInitDialog() override;
 		int getNumTrees(void);
 		int getNumType(int type);
 		AsciiString getTypeName(int type);
@@ -69,7 +69,7 @@ class GroveOptions : public COptionsPanel
 		afx_msg void _updateGroveMakeup(void);
 		afx_msg void _updatePlacementAllowed(void);
 
-		virtual void OnOK();
+		virtual void OnOK() override;
 		virtual void OnClose();
 	DECLARE_MESSAGE_MAP()
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/GroveTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/GroveTool.h
@@ -46,15 +46,15 @@ protected:
 	void _plantGroveInBox(CPoint tl, CPoint br, WbView* pView);
 
 	void addObj(Coord3D *pos, AsciiString name);
-	void activate();
+	virtual void activate() override;
 
 public:
 	GroveTool(void);
-	~GroveTool(void);
+	virtual ~GroveTool(void) override;
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/HandScrollTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/HandScrollTool.h
@@ -31,7 +31,7 @@ class HandScrollTool : public Tool
 {
 public:
 	HandScrollTool(void);
-	~HandScrollTool(void);
+	virtual ~HandScrollTool(void) override;
 
 protected:
 	enum {HYSTERESIS = 3};
@@ -42,11 +42,11 @@ protected:
 
 public:
 	/// Start scrolling.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
 	/// Scroll.
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
 	/// End scroll.
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
-	virtual Bool followsTerrain(void) {return false;};
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual Bool followsTerrain(void) override {return false;};
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ImpassableOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ImpassableOptions.h
@@ -25,7 +25,7 @@ class ImpassableOptions : public CDialog
 
 	public:
 		ImpassableOptions(CWnd* pParent = nullptr, Real defaultSlope = 45.0f);
-		virtual ~ImpassableOptions();
+		virtual ~ImpassableOptions() override;
 		Real GetSlopeToShow() const { return m_slopeToShow; }
 		Real GetDefaultSlope() const { return m_defaultSlopeToShow; }
 		void SetDefaultSlopeToShow(Real slopeToShow) { m_slopeToShow = slopeToShow; }
@@ -38,7 +38,7 @@ class ImpassableOptions : public CDialog
 		Bool ValidateSlope();	// Returns TRUE if it was valid, FALSE if it had to adjust it.
 
 	protected:
-		virtual BOOL OnInitDialog();
+		virtual BOOL OnInitDialog() override;
 		afx_msg void OnAngleChange();
 		afx_msg void OnPreview();
 		DECLARE_MESSAGE_MAP()

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/LayersList.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/LayersList.h
@@ -87,7 +87,7 @@ class LayersList : public CDialog
 	public:
 		enum { IDD = IDD_LAYERSLIST };
 		LayersList(UINT nIDTemplate = LayersList::IDD, CWnd *parentWnd = nullptr);
-		virtual ~LayersList();
+		virtual ~LayersList() override;
 
 		void resetLayers();
 		void addMapObjectToLayersList(IN MapObject *objToAdd, AsciiString layerToAddTo = AsciiString(TheDefaultLayerName.c_str()));
@@ -162,9 +162,9 @@ class LayersList : public CDialog
 		void updateTreeImages();
 
 	protected:
-		virtual void OnOK();
-		virtual void OnCancel();
-		virtual BOOL OnInitDialog();
+		virtual void OnOK() override;
+		virtual void OnCancel() override;
+		virtual BOOL OnInitDialog() override;
 
 		afx_msg void OnBeginEditLabel(NMHDR *pNotifyStruct, LRESULT* pResult);
 		afx_msg void OnEndEditLabel(NMHDR *pNotifyStruct, LRESULT* pResult);

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/LightOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/LightOptions.h
@@ -44,9 +44,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(LightOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -54,7 +54,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(LightOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeLightEdit();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/MainFrm.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/MainFrm.h
@@ -69,12 +69,12 @@ public:
 // Overrides
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CMainFrame)
-	virtual BOOL PreCreateWindow(CREATESTRUCT& cs);
+	virtual BOOL PreCreateWindow(CREATESTRUCT& cs) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
 public:
-	virtual ~CMainFrame();
+	virtual ~CMainFrame() override;
 #ifdef RTS_DEBUG
 	virtual void AssertValid() const;
 	virtual void Dump(CDumpContext& dc) const;

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/MapSettings.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/MapSettings.h
@@ -41,7 +41,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(MapSettings)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -51,8 +51,8 @@ protected:
 	//{{AFX_MSG(MapSettings)
 	afx_msg void OnChangeMapTimeofday();
 	afx_msg void OnChangeMapWeather();
-	virtual BOOL OnInitDialog();
-	virtual void OnOK();
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override;
 	afx_msg void OnChangeMapTitle();
 	afx_msg void OnChangeMapCompression();
 	//}}AFX_MSG

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/MeshMoldOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/MeshMoldOptions.h
@@ -50,11 +50,11 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(MeshMoldOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnInitDialog();
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -103,9 +103,9 @@ public:
 	static AsciiString getModelName(void) {if (m_staticThis) return m_staticThis->m_meshModelName; return "";};
 
 public:	 //PopupSliderOwner methods.
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 };
 
 //{{AFX_INSERT_LOCATION}}

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/MeshMoldTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/MeshMoldTool.h
@@ -42,7 +42,7 @@ protected:
 
 public:
 	MeshMoldTool(void);
-	~MeshMoldTool(void);
+	virtual ~MeshMoldTool(void) override;
 protected:
 	static void applyMesh(CWorldBuilderDoc *pDoc);  ///< Apply the mesh to copy of terrain.
 
@@ -50,13 +50,13 @@ public:
 	static void apply(CWorldBuilderDoc *pDoc);  ///< Apply the mesh to the terrain & execute undoable.
 
 public:  //Tool methods.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual WorldHeightMapEdit *getHeightMap(void) {return m_htMapEditCopy;};
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become the current tool.
-	virtual Bool followsTerrain(void) {return false;};
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual WorldHeightMapEdit *getHeightMap(void) override {return m_htMapEditCopy;};
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become the current tool.
+	virtual Bool followsTerrain(void) override {return false;};
 
 public:	// Methods specific to MeshMoldTool.
 	static void updateMeshLocation(Bool changePreview);

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/MoundOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/MoundOptions.h
@@ -54,9 +54,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(MoundOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -64,7 +64,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(MoundOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeFeatherEdit();
 	afx_msg void OnChangeSizeEdit();
 	afx_msg void OnChangeHeightEdit();
@@ -89,9 +89,9 @@ public:
 
 public:
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 };
 
 //{{AFX_INSERT_LOCATION}}

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/MoundTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/MoundTool.h
@@ -42,7 +42,7 @@ protected:
 
 public:
 	MoundTool(void);
-	~MoundTool(void);
+	virtual ~MoundTool(void) override;
 
 public:
 	static Int getMoundHeight(void) {return m_moundHeight;};
@@ -53,11 +53,11 @@ public:
 	static void setFeather(Int feather);
 
 public:
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual WorldHeightMapEdit *getHeightMap(void) {return m_htMapEditCopy;};
-	virtual void activate(); ///< Become the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual WorldHeightMapEdit *getHeightMap(void) override {return m_htMapEditCopy;};
+	virtual void activate() override; ///< Become the current tool.
 };
 
 /*************************************************************************

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/MyToolbar.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/MyToolbar.h
@@ -33,11 +33,11 @@ protected:
 
 protected:
 	afx_msg void OnVScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
-	virtual LRESULT WindowProc( UINT message, WPARAM wParam, LPARAM lParam );
+	virtual LRESULT WindowProc( UINT message, WPARAM wParam, LPARAM lParam ) override;
 	DECLARE_MESSAGE_MAP()
 
 public:
-	~CellSizeToolBar(void);
+	virtual ~CellSizeToolBar(void) override;
 	void SetupSlider(void);
 	static void CellSizeChanged(Int cellSize);
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/NewHeightMap.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/NewHeightMap.h
@@ -57,9 +57,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CNewHeightMap)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK();
-	virtual BOOL OnCommand(WPARAM wParam, LPARAM lParam);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override;
+	virtual BOOL OnCommand(WPARAM wParam, LPARAM lParam) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -74,7 +74,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CNewHeightMap)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ObjectOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ObjectOptions.h
@@ -35,7 +35,7 @@ class ObjectOptions : public COptionsPanel
 public:
 	ObjectOptions(CWnd* pParent = nullptr);   ///< standard constructor
 
-	~ObjectOptions(void);   ///< standard destructor
+	virtual ~ObjectOptions(void) override;   ///< standard destructor
 	enum { NAME_MAX_LEN = 64 };
 // Dialog Data
 	//{{AFX_DATA(ObjectOptions)
@@ -48,10 +48,10 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(ObjectOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -59,7 +59,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(ObjectOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnEditchangeOwningteam();
 	afx_msg void OnCloseupOwningteam();
 	afx_msg void OnSelchangeOwningteam();

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ObjectPreview.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ObjectPreview.h
@@ -46,7 +46,7 @@ public:
 
 // Implementation
 public:
-	virtual ~ObjectPreview();
+	virtual ~ObjectPreview() override;
 
 	void SetThingTemplate(const ThingTemplate *tTempl);
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ObjectTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ObjectTool.h
@@ -37,16 +37,16 @@ protected:
 
 public:
 	ObjectTool(void);
-	~ObjectTool(void);
+	virtual ~ObjectTool(void) override;
 
 public:
 	static Real calcAngle(Coord3D downPt, Coord3D curPt, WbView* pView);
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become not the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become not the current tool.
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/OpenMap.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/OpenMap.h
@@ -48,7 +48,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(OpenMap)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -63,8 +63,8 @@ protected:
 	afx_msg void OnBrowse();
 	afx_msg void OnSystemMaps();
 	afx_msg void OnUserMaps();
-	virtual void OnOK();
-	virtual BOOL OnInitDialog();
+	virtual void OnOK() override;
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnDblclkOpenList();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/OptionsPanel.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/OptionsPanel.h
@@ -45,7 +45,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(COptionsPanel)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/PickUnitDialog.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/PickUnitDialog.h
@@ -48,7 +48,7 @@ protected:
 public:
 	PickUnitDialog(CWnd* pParent = nullptr);   // standard constructor
 	PickUnitDialog(UINT id, CWnd* pParent = nullptr);   // standard constructor
-	~PickUnitDialog(void);   ///< standard destructor
+	virtual ~PickUnitDialog(void) override;   ///< standard destructor
 
 // Dialog Data
 	//{{AFX_DATA(PickUnitDialog)
@@ -61,8 +61,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(PickUnitDialog)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -70,7 +70,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(PickUnitDialog)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnMove(int x, int y);
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
@@ -95,7 +95,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(ReplaceUnitDialog)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/PointerTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/PointerTool.h
@@ -58,17 +58,17 @@ protected:
 
 public:
 	PointerTool(void);
-	~PointerTool(void);
+	virtual ~PointerTool(void) override;
 
 public:
 	/// Clear the selection on activate or deactivate.
-	virtual void activate();
-	virtual void deactivate();
+	virtual void activate() override;
+	virtual void deactivate() override;
 
-	virtual void setCursor(void);
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
+	virtual void setCursor(void) override;
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
 
 public:
 	static void clearSelection(void); ///< Clears the selected objects selected flags.

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/PolygonTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/PolygonTool.h
@@ -36,7 +36,7 @@ class PolygonTool : public Tool
 {
 public:
 	PolygonTool(void);
-	~PolygonTool(void);
+	virtual ~PolygonTool(void) override;
 
 protected:
 	Coord3D m_poly_mouseDownPt;
@@ -74,10 +74,10 @@ public:
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void setCursor(void);
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become not the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void setCursor(void) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become not the current tool.
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/RampOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/RampOptions.h
@@ -48,7 +48,7 @@ class RampOptions : public COptionsPanel
 	public:
 		enum { IDD = IDD_RAMP_OPTIONS };
 		RampOptions(CWnd* pParent = nullptr);
-		virtual ~RampOptions();
+		virtual ~RampOptions() override;
 
 		Bool shouldApplyTheRamp();
 		Real getRampWidth() { return m_rampWidth; }

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/RampTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/RampTool.h
@@ -49,14 +49,14 @@ class RampTool : public Tool
 
 	public:
 		RampTool();
-		virtual void activate();
-		virtual void deactivate(); ///< Become not the current tool.
+		virtual void activate() override;
+		virtual void deactivate() override; ///< Become not the current tool.
 
-		virtual Bool followsTerrain(void);
+		virtual Bool followsTerrain(void) override;
 
-		virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-		virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-		virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
+		virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+		virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+		virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
 
 	protected:
 		void drawFeedback(Coord3D* endPoint);

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/RoadOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/RoadOptions.h
@@ -35,7 +35,7 @@ class RoadOptions : public COptionsPanel
 public:
 	RoadOptions(CWnd* pParent = nullptr);   ///< standard constructor
 
-	~RoadOptions(void);   ///< standard destructor
+	virtual ~RoadOptions(void) override;   ///< standard destructor
 	enum { NAME_MAX_LEN = 64 };
 // Dialog Data
 	//{{AFX_DATA(RoadOptions)
@@ -48,10 +48,10 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(RoadOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -59,7 +59,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(RoadOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnTightCurve();
 	afx_msg void OnAngled();
 	afx_msg void OnBroadCurve();

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/RoadTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/RoadTool.h
@@ -43,15 +43,15 @@ private:
 
 public:
 	RoadTool(void);
-	~RoadTool(void);
+	virtual ~RoadTool(void) override;
 
 public:
 	static Bool snap(Coord3D *pLoc, Bool skipLast);
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/RulerOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/RulerOptions.h
@@ -44,9 +44,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(RulerOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -54,7 +54,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(RulerOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeWidthEdit();
 	afx_msg void OnChangeCheckRuler();
 	//}}AFX_MSG

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/RulerTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/RulerTool.h
@@ -35,17 +35,17 @@ protected:
 
 public:
 	RulerTool(void);
-	~RulerTool(void);
+	virtual ~RulerTool(void) override;
 
 public:
 	/// Clear the selection on activate or deactivate.
-	virtual void activate();
-	virtual void deactivate();
+	virtual void activate() override;
+	virtual void deactivate() override;
 
-	virtual void setCursor(void);
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual Bool followsTerrain(void) {return false;};
+	virtual void setCursor(void) override;
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual Bool followsTerrain(void) override {return false;};
 
 	static void setLength(Real length);
 	static Bool switchType();

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/SaveMap.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/SaveMap.h
@@ -49,7 +49,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(SaveMap)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -61,13 +61,13 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(SaveMap)
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	afx_msg void OnBrowse();
 	afx_msg void OnSystemMaps();
 	afx_msg void OnUserMaps();
 	afx_msg void OnSelchangeSaveList();
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ScorchOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ScorchOptions.h
@@ -47,9 +47,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(ScorchOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -57,7 +57,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(ScorchOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeScorchtype();
 	afx_msg void OnChangeSizeEdit();
 	//}}AFX_MSG
@@ -83,9 +83,9 @@ public:
 	static Scorches getScorchType(void) {return m_scorchtype;}
 	static Real getScorchSize(void) {return m_scorchsize;}
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 };
 
 //{{AFX_INSERT_LOCATION}}

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ScorchTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ScorchTool.h
@@ -32,7 +32,7 @@ class ScorchTool : public Tool
 {
 public:
 	ScorchTool(void);
-	~ScorchTool(void);
+	virtual ~ScorchTool(void) override;
 
 protected:
 	Coord3D m_mouseDownPt;
@@ -42,9 +42,9 @@ protected:
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become not the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become not the current tool.
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ScriptActionsFalse.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ScriptActionsFalse.h
@@ -33,7 +33,7 @@ class ScriptActionsFalse : public CPropertyPage
 // Construction
 public:
 	ScriptActionsFalse();
-	~ScriptActionsFalse();
+	virtual ~ScriptActionsFalse() override;
 
 // Dialog Data
 	//{{AFX_DATA(ScriptActionsFalse)
@@ -47,7 +47,7 @@ public:
 	// ClassWizard generate virtual function overrides
 	//{{AFX_VIRTUAL(ScriptActionsFalse)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -67,7 +67,7 @@ protected:
 protected:
 	// Generated message map functions
 	//{{AFX_MSG(ScriptActionsFalse)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnEditAction();
 	afx_msg void OnSelchangeActionList();
 	afx_msg void OnDblclkActionList();

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ScriptActionsTrue.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ScriptActionsTrue.h
@@ -33,7 +33,7 @@ class ScriptActionsTrue : public CPropertyPage
 // Construction
 public:
 	ScriptActionsTrue();
-	~ScriptActionsTrue();
+	virtual ~ScriptActionsTrue() override;
 
 // Dialog Data
 	//{{AFX_DATA(ScriptActionsTrue)
@@ -47,7 +47,7 @@ public:
 	// ClassWizard generate virtual function overrides
 	//{{AFX_VIRTUAL(ScriptActionsTrue)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -67,7 +67,7 @@ protected:
 protected:
 	// Generated message map functions
 	//{{AFX_MSG(ScriptActionsTrue)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnEditAction();
 	afx_msg void OnSelchangeActionList();
 	afx_msg void OnDblclkActionList();

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ScriptConditions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ScriptConditions.h
@@ -34,7 +34,7 @@ class ScriptConditionsDlg : public CPropertyPage
 // Construction
 public:
 	ScriptConditionsDlg();
-	~ScriptConditionsDlg();
+	virtual ~ScriptConditionsDlg() override;
 
 // Dialog Data
 	//{{AFX_DATA(ScriptConditionsDlg)
@@ -48,7 +48,7 @@ public:
 	// ClassWizard generate virtual function overrides
 	//{{AFX_VIRTUAL(ScriptConditionsDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -71,7 +71,7 @@ protected:
 protected:
 	// Generated message map functions
 	//{{AFX_MSG(ScriptConditionsDlg)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnEditCondition();
 	afx_msg void OnSelchangeConditionList();
 	afx_msg void OnDblclkConditionList();

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ScriptDialog.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ScriptDialog.h
@@ -62,7 +62,7 @@ class ScriptDialog : public CDialog
 // Construction
 public:
 	ScriptDialog(CWnd* pParent = nullptr);   // standard constructor
-	~ScriptDialog();   //  destructor
+	virtual ~ScriptDialog() override;   //  destructor
 
 // Dialog Data
 	//{{AFX_DATA(ScriptDialog)
@@ -75,7 +75,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(ScriptDialog)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -138,7 +138,7 @@ protected:
 	// Generated message map functions
 	//{{AFX_MSG(ScriptDialog)
 	afx_msg void OnSelchangedScriptTree(NMHDR* pNMHDR, LRESULT* pResult);
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnNewFolder();
 	afx_msg void OnNewScript();
 	afx_msg void OnEditScript();
@@ -150,8 +150,8 @@ protected:
 	afx_msg void OnSave();
 	afx_msg void OnLoad();
 	afx_msg void OnDblclkScriptTree(NMHDR* pNMHDR, LRESULT* pResult);
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	afx_msg void OnBegindragScriptTree(NMHDR* pNMHDR, LRESULT* pResult);
 	afx_msg void OnScriptActivate();
 	afx_msg void OnMouseMove(UINT nFlags, CPoint point);

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ScriptProperties.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ScriptProperties.h
@@ -31,7 +31,7 @@ class ScriptProperties : public CPropertyPage
 // Construction
 public:
 	ScriptProperties();
-	~ScriptProperties();
+	virtual ~ScriptProperties() override;
 
 // Dialog Data
 	//{{AFX_DATA(ScriptProperties)
@@ -45,9 +45,9 @@ public:
 	// ClassWizard generate virtual function overrides
 	//{{AFX_VIRTUAL(ScriptProperties)
 	public:
-	virtual BOOL OnSetActive();
+	virtual BOOL OnSetActive() override;
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/SelectMacrotexture.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/SelectMacrotexture.h
@@ -41,8 +41,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(SelectMacrotexture)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 protected:
@@ -54,7 +54,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(SelectMacrotexture)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ShadowOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ShadowOptions.h
@@ -41,7 +41,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(ShadowOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -60,7 +60,7 @@ protected:
 	afx_msg void OnChangeBaEdit();
 	afx_msg void OnChangeGaEdit();
 	afx_msg void OnChangeRaEdit();
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/TeamBehavior.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/TeamBehavior.h
@@ -41,7 +41,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(TeamBehavior)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -57,7 +57,7 @@ protected:
 	// Generated message map functions
 	//{{AFX_MSG(TeamBehavior)
 	afx_msg void OnSelchangeOnCreateScript();
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnTransportsReturn();
 	afx_msg void OnAvoidThreats();
 	afx_msg void OnSelchangeOnEnemySighted();

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/TeamGeneric.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/TeamGeneric.h
@@ -40,7 +40,7 @@ class TeamGeneric : public CPropertyPage
 
 
 	protected: // Windows Functions
-		virtual BOOL OnInitDialog();
+		virtual BOOL OnInitDialog() override;
 		afx_msg void _scriptsToDict();
 		afx_msg void OnScriptAdjust();
 		DECLARE_MESSAGE_MAP()

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/TeamIdentity.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/TeamIdentity.h
@@ -43,8 +43,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(TeamIdentity)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnCommand(WPARAM wParam, LPARAM lParam);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnCommand(WPARAM wParam, LPARAM lParam) override;
 	//}}AFX_VIRTUAL
 
 protected:
@@ -64,7 +64,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(TeamIdentity)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnAiRecruitable();
 	afx_msg void OnAutoReinforce();
 	afx_msg void OnBaseDefense();

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/TeamObjectProperties.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/TeamObjectProperties.h
@@ -36,7 +36,7 @@ class TeamObjectProperties : public CPropertyPage
 // Construction
 public:
 	TeamObjectProperties(Dict* dictToEdit = nullptr);
-	~TeamObjectProperties();
+	virtual ~TeamObjectProperties() override;
 
 // Dialog Data
 	//{{AFX_DATA(MapObjectProps)
@@ -48,8 +48,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(TeamObjectProperties)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnCommand(WPARAM wParam, LPARAM lParam);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnCommand(WPARAM wParam, LPARAM lParam) override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/TeamReinforcement.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/TeamReinforcement.h
@@ -41,7 +41,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(TeamReinforcement)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -59,7 +59,7 @@ protected:
 	afx_msg void OnTransportsExit();
 	afx_msg void OnSelchangeVeterancy();
 	afx_msg void OnSelchangeWaypointCombo();
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/TerrainMaterial.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/TerrainMaterial.h
@@ -45,10 +45,10 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(TerrainMaterial)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  ///< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; ///< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -56,7 +56,7 @@ protected:
 	enum {MIN_TILE_SIZE=2, MAX_TILE_SIZE = 100};
 	// Generated message map functions
 	//{{AFX_MSG(TerrainMaterial)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSwapTextures();
 	afx_msg void OnChangeSizeEdit();
 	afx_msg void OnImpassable();
@@ -102,9 +102,9 @@ public:
 	Bool setTerrainTreeViewSelection(HTREEITEM parent, Int selection);
 
 	// Popup slider interface.
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 };
 
 //{{AFX_INSERT_LOCATION}}

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/TerrainModal.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/TerrainModal.h
@@ -44,8 +44,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(TerrainModal)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -53,7 +53,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(TerrainModal)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/TerrainSwatches.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/TerrainSwatches.h
@@ -44,7 +44,7 @@ public:
 
 // Implementation
 public:
-	virtual ~TerrainSwatches();
+	virtual ~TerrainSwatches() override;
 
 	// Generated message map functions
 protected:

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/TileTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/TileTool.h
@@ -36,14 +36,14 @@ protected:
 
 public:
 	TileTool(void);
-	~TileTool(void);
+	virtual ~TileTool(void) override;
 
 public:
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual WorldHeightMapEdit *getHeightMap(void) {return m_htMapEditCopy;};
-	virtual void activate(); ///< Become the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual WorldHeightMapEdit *getHeightMap(void) override {return m_htMapEditCopy;};
+	virtual void activate() override; ///< Become the current tool.
 	virtual Int getWidth(void) {return 1;};
 };
 
@@ -57,12 +57,12 @@ protected:
 	static Int m_currentWidth;
 
 public:
- 	virtual void activate(); ///< Become the current tool.
+	virtual void activate() override; ///< Become the current tool.
 
 public:
 	BigTileTool(void);
 
 	static void setWidth(Int width) ;
-	virtual Int getWidth(void) {return m_currentWidth;};
+	virtual Int getWidth(void) override {return m_currentWidth;};
 
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WBFrameWnd.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WBFrameWnd.h
@@ -42,13 +42,13 @@ public:
 	virtual BOOL LoadFrame(UINT nIDResource,
 				DWORD dwDefaultStyle = WS_OVERLAPPEDWINDOW | FWS_ADDTOTITLE,
 				CWnd* pParentWnd = nullptr,
-				CCreateContext* pContext = nullptr);
+				CCreateContext* pContext = nullptr) override;
 	// ClassWizard generated virtual function overrides
 	//}}AFX_VIRTUAL
 
 // Implementation
 protected:
-	virtual ~CWBFrameWnd();
+	virtual ~CWBFrameWnd() override;
 
 	// Generated message map functions
 	//{{AFX_MSG(CWBFrameWnd)
@@ -71,14 +71,14 @@ public:
 	virtual BOOL LoadFrame(UINT nIDResource,
 				DWORD dwDefaultStyle = WS_OVERLAPPEDWINDOW | FWS_ADDTOTITLE,
 				CWnd* pParentWnd = nullptr,
-				CCreateContext* pContext = nullptr);
+				CCreateContext* pContext = nullptr) override;
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CWB3dFrameWnd)
 	public:
 	//}}AFX_VIRTUAL
 // Implementation
 protected:
-	virtual ~CWB3dFrameWnd();
+	virtual ~CWB3dFrameWnd() override;
 	// Generated message map functions
 	//{{AFX_MSG(CWB3dFrameWnd)
 	afx_msg void OnMove(int x, int y);

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WBHeightMap.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WBHeightMap.h
@@ -34,8 +34,8 @@ public:
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface (W3D methods)
 	/////////////////////////////////////////////////////////////////////////////
-	virtual void					Render(RenderInfoClass & rinfo);
-	virtual Bool					Cast_Ray(RayCollisionTestClass & raytest);
+	virtual void					Render(RenderInfoClass & rinfo) override;
+	virtual Bool					Cast_Ray(RayCollisionTestClass & raytest) override;
 
 	virtual Real getHeightMapHeight(Real x, Real y, Coord3D* normal);	///<return height and normal at given point
 	virtual Real getMaxCellHeight(Real x, Real y);	///< returns maximum height of the 4 cell corners.

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WBPopupSlider.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WBPopupSlider.h
@@ -56,7 +56,7 @@ public:
 
 // Implementation
 public:
-	virtual ~WBPopupSliderButton();
+	virtual ~WBPopupSliderButton() override;
 
 	// Generated message map functions
 protected:
@@ -113,12 +113,12 @@ public:
 	public:
 	virtual BOOL Create(const RECT& rect, CWnd* pParentWnd);
 	protected:
-	virtual void PostNcDestroy();
+	virtual void PostNcDestroy() override;
 	//}}AFX_VIRTUAL
 
 // Implementation
 public:
-	virtual ~PopupSlider();
+	virtual ~PopupSlider() override;
 
 	// Generated message map functions
 protected:

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
@@ -96,7 +96,7 @@ public: // construction
 	WorldHeightMapEdit(Int xExtent, Int yExtent, UnsignedByte initialHeight, Int border); ///< create.
 	WorldHeightMapEdit(WorldHeightMapEdit *pThis);								///< duplicate.
 	WorldHeightMapEdit(ChunkInputStream *pStrm);											///< read from file.
-	~WorldHeightMapEdit(void);													    ///< destroy.
+	virtual ~WorldHeightMapEdit(void) override;													    ///< destroy.
 
 	void saveToFile(DataChunkOutput &chunkWriter);
 	WorldHeightMapEdit *duplicate(void);

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WaterOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WaterOptions.h
@@ -48,9 +48,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(WaterOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -58,7 +58,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(WaterOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeWaterEdit();
 	afx_msg void OnChangeHeightEdit();
 	afx_msg void OnChangeSpacingEdit();
@@ -92,9 +92,9 @@ public:
 
 public:
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 
 };
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WaterTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WaterTool.h
@@ -36,7 +36,7 @@ class WaterTool : public PolygonTool
 {
 public:
 	WaterTool(void);
-	~WaterTool(void);
+	virtual ~WaterTool(void) override;
 
 protected:
 	static Bool		m_water_isActive;
@@ -48,12 +48,12 @@ public:
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void setCursor(void);
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become not the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void setCursor(void) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become not the current tool.
 
 protected:
 	void fillTheArea(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WaypointOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WaypointOptions.h
@@ -47,9 +47,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(WaypointOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -57,7 +57,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(WaypointOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeWaypointnameEdit();
 	afx_msg void OnChangeSelectedWaypoint();
 	afx_msg void OnEditWaypointLocationX();

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WaypointTool.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WaypointTool.h
@@ -34,7 +34,7 @@ class WaypointTool : public Tool
 {
 public:
 	WaypointTool(void);
-	~WaypointTool(void);
+	virtual ~WaypointTool(void) override;
 
 protected:
 	Int m_downWaypointID;
@@ -49,9 +49,9 @@ public:
 
 public:
 	/// Perform tool on mouse down.
-	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc);
-	virtual void activate(); ///< Become the current tool.
-	virtual void deactivate(); ///< Become not the current tool.
+	virtual void mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBuilderDoc *pDoc) override;
+	virtual void activate() override; ///< Become the current tool.
+	virtual void deactivate() override; ///< Become not the current tool.
 };

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilder.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilder.h
@@ -72,14 +72,14 @@ class CWorldBuilderApp : public CWinApp
 {
 public:
 	CWorldBuilderApp();
-	~CWorldBuilderApp();
+	virtual ~CWorldBuilderApp() override;
 
 // Overrides
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CWorldBuilderApp)
 	public:
-	virtual BOOL InitInstance();
-	virtual int ExitInstance();
+	virtual BOOL InitInstance() override;
+	virtual int ExitInstance() override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -183,7 +183,7 @@ public:
 
 	/// Handles command messages.
 	virtual BOOL OnCmdMsg(UINT nID, int nCode, void* pExtra,
-						  AFX_CMDHANDLERINFO* pHandlerInfo);
+						  AFX_CMDHANDLERINFO* pHandlerInfo) override;
 };
 
 inline CWorldBuilderApp *WbApp() { return (CWorldBuilderApp*)::AfxGetApp(); }

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilderDoc.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilderDoc.h
@@ -97,8 +97,8 @@ public:
 	Bool ParseWaypointData(DataChunkInput &file, DataChunkInfo *info, void *userData);
 
 public: // overridden
-	virtual BOOL DoSave(LPCTSTR lpszPathName, BOOL bReplace = TRUE);
-	virtual BOOL DoFileSave();
+	virtual BOOL DoSave(LPCTSTR lpszPathName, BOOL bReplace = TRUE) override;
+	virtual BOOL DoFileSave() override;
 
 // Attributes
 public:
@@ -156,15 +156,15 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CWorldBuilderDoc)
 	public:
-	virtual BOOL OnNewDocument();
-	virtual void Serialize(CArchive& ar);
-	virtual BOOL OnOpenDocument(LPCTSTR lpszPathName);
-	virtual BOOL CanCloseFrame(CFrameWnd* pFrame);
+	virtual BOOL OnNewDocument() override;
+	virtual void Serialize(CArchive& ar) override;
+	virtual BOOL OnOpenDocument(LPCTSTR lpszPathName) override;
+	virtual BOOL CanCloseFrame(CFrameWnd* pFrame) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
 public:
-	virtual ~CWorldBuilderDoc();
+	virtual ~CWorldBuilderDoc() override;
 #ifdef RTS_DEBUG
 	virtual void AssertValid() const;
 	virtual void Dump(CDumpContext& dc) const;

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilderView.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilderView.h
@@ -44,17 +44,17 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CWorldBuilderView)
 	public:
-	virtual BOOL PreCreateWindow(CREATESTRUCT& cs);
+	virtual BOOL PreCreateWindow(CREATESTRUCT& cs) override;
 	protected:
-	virtual BOOL OnPreparePrinting(CPrintInfo* pInfo);
-	virtual void OnBeginPrinting(CDC* pDC, CPrintInfo* pInfo);
-	virtual void OnEndPrinting(CDC* pDC, CPrintInfo* pInfo);
-	virtual void OnDraw(CDC* pDC);
+	virtual BOOL OnPreparePrinting(CPrintInfo* pInfo) override;
+	virtual void OnBeginPrinting(CDC* pDC, CPrintInfo* pInfo) override;
+	virtual void OnEndPrinting(CDC* pDC, CPrintInfo* pInfo) override;
+	virtual void OnDraw(CDC* pDC) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
 public:
-	virtual ~CWorldBuilderView();
+	virtual ~CWorldBuilderView() override;
 #ifdef RTS_DEBUG
 	virtual void AssertValid() const;
 	virtual void Dump(CDumpContext& dc) const;
@@ -115,23 +115,23 @@ public:
 protected:
 
 public:
-	virtual Bool viewToDocCoords(CPoint curPt, Coord3D *newPt, Bool constrain);
-	virtual Bool docToViewCoords(Coord3D curPt, CPoint* newPt);
+	virtual Bool viewToDocCoords(CPoint curPt, Coord3D *newPt, Bool constrain) override;
+	virtual Bool docToViewCoords(Coord3D curPt, CPoint* newPt) override;
 
 	/// Set the center for display.
-	virtual void setCenterInView(Real x, Real y);
+	virtual void setCenterInView(Real x, Real y) override;
 
 	/// the doc has changed size; readjust view as necessary.
-	virtual void adjustDocSize();
+	virtual void adjustDocSize() override;
 
 	/// Invalidates an object. Pass null to inval all objects.
-	virtual void invalObjectInView(MapObject *pObj);
+	virtual void invalObjectInView(MapObject *pObj) override;
 
 	/// Invalidates the area of one height map cell in the 2d view.
-	virtual void invalidateCellInView(int xIndex, int yIndex);
+	virtual void invalidateCellInView(int xIndex, int yIndex) override;
 
 	/// Scrolls the window by this amount (doc coords).
-	virtual void scrollInView(Real x, Real y, Bool end);
+	virtual void scrollInView(Real x, Real y, Bool end) override;
 
 // Generated message map functions
 protected:

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/addplayerdialog.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/addplayerdialog.h
@@ -49,7 +49,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(AddPlayerDialog)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -57,9 +57,9 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(AddPlayerDialog)
-	virtual void OnOK();
-	virtual void OnCancel();
-	virtual BOOL OnInitDialog();
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnEditchangeCombo1();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/brushoptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/brushoptions.h
@@ -50,9 +50,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(BrushOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual void OnOK(){return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
-	virtual void OnCancel(){return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual void OnOK() override {return;};  //!< Modeless dialogs don't OK, so eat this for modeless.
+	virtual void OnCancel() override {return;}; //!< Modeless dialogs don't close on ESC, so eat this for modeless.
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -60,7 +60,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(BrushOptions)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeFeatherEdit();
 	afx_msg void OnChangeSizeEdit();
 	afx_msg void OnChangeHeightEdit();
@@ -85,9 +85,9 @@ public:
 
 public:
 
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 
 };
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/mapobjectprops.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/mapobjectprops.h
@@ -45,7 +45,7 @@ class MapObjectProps : public COptionsPanel, public PopupSliderOwner
 // Construction
 public:
 	MapObjectProps(Dict* dictToEdit = nullptr, const char* title = nullptr, CWnd* pParent = nullptr);   // standard constructor
-	~MapObjectProps();
+	virtual ~MapObjectProps() override;
 	void makeMain();
 
 // Dialog Data
@@ -58,7 +58,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(MapObjectProps)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -100,9 +100,9 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(MapObjectProps)
-	virtual BOOL OnInitDialog();
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	afx_msg void OnSelchangeProperties();
 	afx_msg void OnEditprop();
 	afx_msg void OnNewprop();
@@ -189,9 +189,9 @@ protected:
 	void clearCustomizeFlag( CWorldBuilderDoc* pDoc, MultipleUndoable * ownerUndoable );
 
 	// Implementation of PopupSliderOwner callbacks
-	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial);
-	virtual void PopSliderChanged(const long sliderID, long theVal);
-	virtual void PopSliderFinished(const long sliderID, long theVal);
+	virtual void GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial) override;
+	virtual void PopSliderChanged(const long sliderID, long theVal) override;
+	virtual void PopSliderFinished(const long sliderID, long theVal) override;
 
 public:
 	static MapObject *getSingleSelectedMapObject(void);

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/playerlistdlg.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/playerlistdlg.h
@@ -44,7 +44,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(PlayerListDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -65,12 +65,12 @@ protected:
 	afx_msg void OnEditplayer();
 	afx_msg void OnRemoveplayer();
 	afx_msg void OnSelchangePlayers();
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnDblclkPlayers();
 	afx_msg void OnSelchangeAllieslist();
 	afx_msg void OnSelchangeEnemieslist();
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	afx_msg void OnPlayeriscomputer();
 	afx_msg void OnEditchangePlayerfaction();
 	afx_msg void OnChangePlayername();

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/propedit.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/propedit.h
@@ -41,7 +41,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(PropEdit)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -61,7 +61,7 @@ protected:
 	afx_msg void OnCloseupKeytype();
 	afx_msg void OnSelchangeKeytype();
 	afx_msg void OnChangeValue();
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnPropbool();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/teamsdialog.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/teamsdialog.h
@@ -43,7 +43,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CTeamsDialog)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -51,9 +51,9 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CTeamsDialog)
-	virtual BOOL OnInitDialog();
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	afx_msg void OnNewteam();
 	afx_msg void OnDeleteteam();
 	afx_msg void OnEditTemplate();

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/wbview.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/wbview.h
@@ -160,12 +160,12 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(WbView)
 	protected:
-	virtual void OnDraw(CDC* pDC);      // overridden to draw this view
+	virtual void OnDraw(CDC* pDC) override;      // overridden to draw this view
 	//}}AFX_VIRTUAL
 
 // Implementation
 protected:
-	virtual ~WbView();
+	virtual ~WbView() override;
 #ifdef RTS_DEBUG
 	virtual void AssertValid() const;
 	virtual void Dump(CDumpContext& dc) const;

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/wbview3d.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/wbview3d.h
@@ -66,8 +66,8 @@ protected:
 public:
 
 	// DX8_CleanupHook methods
-	virtual void ReleaseResources(void);	///< Release all dx8 resources so the device can be reset.
-	virtual void ReAcquireResources(void);  ///< Reacquire all resources after device reset.
+	virtual void ReleaseResources(void) override;	///< Release all dx8 resources so the device can be reset.
+	virtual void ReAcquireResources(void) override;  ///< Reacquire all resources after device reset.
 
 // Operations
 public:
@@ -76,12 +76,12 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(WbView3d)
 	protected:
-	virtual void OnDraw(CDC* pDC);      // overridden to draw this view
+	virtual void OnDraw(CDC* pDC) override;      // overridden to draw this view
 	//}}AFX_VIRTUAL
 
 // Implementation
 protected:
-	virtual ~WbView3d();
+	virtual ~WbView3d() override;
 #ifdef RTS_DEBUG
 	virtual void AssertValid() const;
 	virtual void Dump(CDumpContext& dc) const;
@@ -235,13 +235,13 @@ protected:
 	void updateTrees();
 
 public:
-	virtual Bool viewToDocCoords(CPoint curPt, Coord3D *newPt, Bool constrain=true);
-	virtual Bool docToViewCoords(Coord3D curPt, CPoint* newPt);
+	virtual Bool viewToDocCoords(CPoint curPt, Coord3D *newPt, Bool constrain=true) override;
+	virtual Bool docToViewCoords(Coord3D curPt, CPoint* newPt) override;
 
-	virtual void updateHeightMapInView(WorldHeightMap *htMap, Bool partial, const IRegion2D &partialRange);
+	virtual void updateHeightMapInView(WorldHeightMap *htMap, Bool partial, const IRegion2D &partialRange) override;
 
 	/// Invalidates an object. Pass null to inval all objects.
-	virtual void invalObjectInView(MapObject *pObj);
+	virtual void invalObjectInView(MapObject *pObj) override;
 
 	// find the best model for an object
 	AsciiString getBestModelName(const ThingTemplate* tt, const ModelConditionFlags& c);
@@ -250,14 +250,14 @@ public:
 	void invalBuildListItemInView(BuildListInfo *pBuild);
 
 	/// Invalidates the area of one height map cell in the 2d view.
-	virtual void invalidateCellInView(int xIndex, int yIndex);
+	virtual void invalidateCellInView(int xIndex, int yIndex) override;
 
 	/// Scrolls the window by this amount.
-	virtual void scrollInView(Real x, Real y, Bool end);
+	virtual void scrollInView(Real x, Real y, Bool end) override;
 
-	virtual void setDefaultCamera();
-	virtual void rotateCamera(Real delta);
-	virtual void pitchCamera(Real delta);
+	virtual void setDefaultCamera() override;
+	virtual void rotateCamera(Real delta) override;
+	virtual void pitchCamera(Real delta) override;
 	void setCameraPitch(Real absolutePitch);
 	Real getCameraPitch(void);
 	Real getCurrentZoom(void); //WST 10/17/2002
@@ -267,8 +267,8 @@ public:
 	Real getCameraAngle(void) { return m_cameraAngle; }
 	CPoint getActualWinSize(void) {return m_actualWinSize;}
 
-	virtual MapObject *picked3dObjectInView(CPoint viewPt);
-	virtual BuildListInfo *pickedBuildObjectInView(CPoint viewPt);
+	virtual MapObject *picked3dObjectInView(CPoint viewPt) override;
+	virtual BuildListInfo *pickedBuildObjectInView(CPoint viewPt) override;
 
 	void removeFenceListObjects(MapObject *pObject);
 	void updateFenceListObjects(MapObject *pObject);
@@ -285,14 +285,14 @@ public:
 
 	AsciiString getModelNameAndScale(MapObject *pMapObj, Real *scale, BodyDamageType curDamageState);
 
-	virtual Int getPickPixels(void) {return m_pickPixels;}
-	virtual Bool viewToDocCoordZ(CPoint curPt, Coord3D *newPt, Real Z);
+	virtual Int getPickPixels(void) override {return m_pickPixels;}
+	virtual Bool viewToDocCoordZ(CPoint curPt, Coord3D *newPt, Real Z) override;
 public:
 
 //	void init(CWorldBuilderView *pMainView, HINSTANCE hInstance, CWnd* parent);
 	void redraw();
 
-	virtual void setCenterInView(Real x, Real y);
+	virtual void setCenterInView(Real x, Real y) override;
 
 	Bool getShowTerrain();
 	Bool getShowWireframe();
@@ -304,7 +304,7 @@ public:
 	Bool getShowAmbientSoundsFeedback(void) const { return m_showAmbientSounds; }
 
 	void togglePitchAndRotation( void ) { m_doPitch = !m_doPitch; }
-	virtual Bool isDoingPitch( void ) { return m_doPitch; }
+	virtual Bool isDoingPitch( void ) override { return m_doPitch; }
 	void setShowBoundingBoxes(Bool toggle) {m_showBoundingBoxes = toggle;}
 	Bool getShowBoundingBoxes(void) { return m_showBoundingBoxes;}
 	void setShowSightRanges(Bool toggle) {m_showSightRanges = toggle;}

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
@@ -1121,7 +1121,7 @@ protected:
 	CFile *m_file;
 public:
 	LocalMFCFileOutputStream(CFile *pFile):m_file(pFile) {};
-	virtual Int write(const void *pData, Int numBytes) {
+	virtual Int write(const void *pData, Int numBytes) override {
 		Int numBytesWritten = 0;
 		try {
 			m_file->Write(pData, numBytes);

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
@@ -109,7 +109,7 @@ class WBGameFileClass : public GameFileClass
 
 public:
 	WBGameFileClass(char const *filename):GameFileClass(filename){};
-	virtual char const * Set_Name(char const *filename);
+	virtual char const * Set_Name(char const *filename) override;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -136,7 +136,7 @@ char const * WBGameFileClass::Set_Name( char const *filename )
 // wb only data.  jba.
 
 class	WB_W3DFileSystem : public W3DFileSystem {
-	virtual FileClass * Get_File( char const *filename );
+	virtual FileClass * Get_File( char const *filename ) override;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -588,7 +588,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CAboutDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -160,7 +160,7 @@ protected:
 	CFile *m_file;
 public:
 	MFCFileOutputStream(CFile *pFile):m_file(pFile) {};
-	virtual Int write(const void *pData, Int numBytes) {
+	virtual Int write(const void *pData, Int numBytes) override {
 		Int numBytesWritten = 0;
 		try {
 			m_file->Write(pData, numBytes);
@@ -184,7 +184,7 @@ protected:
 	Int m_totalBytes;
 public:
 	CachedMFCFileOutputStream(CFile *pFile):m_file(pFile), m_totalBytes(0) {};
-	virtual Int write(const void *pData, Int numBytes) {
+	virtual Int write(const void *pData, Int numBytes) override {
 		UnsignedByte *tmp = new UnsignedByte[numBytes];
 		memcpy(tmp, pData, numBytes);
 		CachedChunk c;
@@ -218,7 +218,7 @@ protected:
 	Int m_totalBytes;
 public:
 	CompressedCachedMFCFileOutputStream(CFile *pFile):m_file(pFile), m_totalBytes(0) {};
-	virtual Int write(const void *pData, Int numBytes) {
+	virtual Int write(const void *pData, Int numBytes) override {
 		UnsignedByte *tmp = new UnsignedByte[numBytes];
 		memcpy(tmp, pData, numBytes);
 		CachedChunk c;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -160,128 +160,128 @@ protected:
 	Int m_originX, m_originY;																		///< Location of top/left view corner
 
 protected:
-	virtual View *prependViewToList( View *list ) {return nullptr;};		///< Prepend this view to the given list, return the new list
-	virtual View *getNextView( void ) { return nullptr; }				///< Return next view in the set
+	virtual View *prependViewToList( View *list ) override {return nullptr;};		///< Prepend this view to the given list, return the new list
+	virtual View *getNextView( void ) override { return nullptr; }				///< Return next view in the set
 public:
 
-	virtual void init( void ){};
+	virtual void init( void ) override {};
 
-	virtual UnsignedInt getID( void ) { return 1; }
+	virtual UnsignedInt getID( void ) override { return 1; }
 
-	virtual Drawable *pickDrawable( const ICoord2D *screen, Bool forceAttack, PickType pickType ){return nullptr;};			///< pick drawable given the screen pixel coords
+	virtual Drawable *pickDrawable( const ICoord2D *screen, Bool forceAttack, PickType pickType ) override {return nullptr;};			///< pick drawable given the screen pixel coords
 
 	/// all drawables in the 2D screen region will call the 'callback'
 	virtual Int iterateDrawablesInRegion( IRegion2D *screenRegion,
 																				Bool (*callback)( Drawable *draw, void *userData ),
-																				void *userData ) {return 0;};
-  virtual WorldToScreenReturn worldToScreenTriReturn( const Coord3D *w, ICoord2D *s ) { return WTS_INVALID; };	///< Transform world coordinate "w" into screen coordinate "s"
-	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world ) {};  ///< transform screen coord to a point on the 3D terrain
-	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z ) {};  ///< transform screen point to world point at the specified world Z value
+																				void *userData ) override {return 0;};
+  virtual WorldToScreenReturn worldToScreenTriReturn( const Coord3D *w, ICoord2D *s ) override { return WTS_INVALID; };	///< Transform world coordinate "w" into screen coordinate "s"
+	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world ) override {};  ///< transform screen coord to a point on the 3D terrain
+	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z ) override {};  ///< transform screen point to world point at the specified world Z value
 	virtual void getScreenCornerWorldPointsAtZ( Coord3D *topLeft, Coord3D *topRight,
 																							Coord3D *bottomRight, Coord3D *bottomLeft,
-																							Real z ){};
+																							Real z ) override {};
 
-	virtual void drawView( void ) {};															///< Render the world visible in this view.
-	virtual void updateView( void ) {};															///< Render the world visible in this view.
-	virtual void stepView() {}; ///< Update view for every fixed time step
+	virtual void drawView( void ) override {};															///< Render the world visible in this view.
+	virtual void updateView( void ) override {};															///< Render the world visible in this view.
+	virtual void stepView() override {}; ///< Update view for every fixed time step
 
-	virtual void setZoomLimited( Bool limit ) {}			///< limit the zoom height
-	virtual Bool isZoomLimited( void ) { return TRUE; }							///< get status of zoom limit
+	virtual void setZoomLimited( Bool limit ) override {}			///< limit the zoom height
+	virtual Bool isZoomLimited( void ) const override { return TRUE; }							///< get status of zoom limit
 
-	virtual void setWidth( Int width ) { m_width = width; }
-	virtual Int getWidth( void ) { return m_width; }
-	virtual void setHeight( Int height ) { m_height = height; }
-	virtual Int getHeight( void ) { return m_height; }
-	virtual void setOrigin( Int x, Int y) { m_originX=x; m_originY=y;}				///< Sets location of top-left view corner on display
-	virtual void getOrigin( Int *x, Int *y) { *x=m_originX; *y=m_originY;}			///< Return location of top-left view corner on display
+	virtual void setWidth( Int width ) override { m_width = width; }
+	virtual Int getWidth( void ) override { return m_width; }
+	virtual void setHeight( Int height ) override { m_height = height; }
+	virtual Int getHeight( void ) override { return m_height; }
+	virtual void setOrigin( Int x, Int y) override { m_originX=x; m_originY=y;}				///< Sets location of top-left view corner on display
+	virtual void getOrigin( Int *x, Int *y) override { *x=m_originX; *y=m_originY;}			///< Return location of top-left view corner on display
 
-	virtual void forceRedraw() { }
+	virtual void forceRedraw() override { }
 
-	virtual Bool isDoingScriptedCamera() { return false; }
-	virtual void stopDoingScriptedCamera() {}
+	virtual Bool isDoingScriptedCamera() override { return false; }
+	virtual void stopDoingScriptedCamera() override {}
 
-	virtual void lookAt( const Coord3D *o ){};														///< Center the view on the given coordinate
-	virtual void initHeightForMap( void ) {};														///<  Init the camera height for the map at the current position.
+	virtual void lookAt( const Coord3D *o ) override {};											///< Center the view on the given coordinate
+	virtual void initHeightForMap( void ) override {};												///<  Init the camera height for the map at the current position.
 	virtual void scrollBy( Coord2D *delta ){};														///< Shift the view by the given delta
 	virtual void moveCameraTo(const Coord3D *o, Int frames, Int shutter,
-														Bool orient, Real easeIn, Real easeOut) {lookAt(o);};
+														Bool orient, Real easeIn, Real easeOut) override {lookAt(o);};
 	virtual void moveCameraAlongWaypointPath(Waypoint *way, Int frames, Int shutter,
-														Bool orient, Real easeIn, Real easeOut) {};
-	virtual Bool isCameraMovementFinished(void) {return true;};
- 	virtual void resetCamera(const Coord3D *location, Int frames, Real easeIn, Real easeOut) {}; ///< Move camera to location, and reset to default angle & zoom.
- 	virtual void rotateCamera(Real rotations, Int frames, Real easeIn, Real easeOut) {}; ///< Rotate camera about current viewpoint.
-	virtual void rotateCameraTowardObject(ObjectID id, Int milliseconds, Int holdMilliseconds, Real easeIn, Real easeOut) {};	///< Rotate camera to face an object, and hold on it
-	virtual void cameraModFinalZoom(Real finalZoom, Real easeIn, Real easeOut){};			 ///< Final zoom for current camera movement.
-	virtual void cameraModRollingAverage(Int framesToAverage){}; ///< Number of frames to average movement for current camera movement.
-	virtual void cameraModFinalTimeMultiplier(Int finalMultiplier){}; ///< Final time multiplier for current camera movement.
-	virtual void cameraModFinalPitch(Real finalPitch, Real easeIn, Real easeOut){};		 ///< Final pitch for current camera movement.
-	virtual void cameraModFreezeTime(void){}					///< Freezes time during the next camera movement.
-	virtual void cameraModFreezeAngle(void){}					///< Freezes time during the next camera movement.
-	virtual void cameraModLookToward(Coord3D *pLoc){}			///< Sets a look at point during camera movement.
-	virtual void cameraModFinalLookToward(Coord3D *pLoc){}			///< Sets a look at point during camera movement.
-	virtual void cameraModFinalMoveTo(Coord3D *pLoc){ };			///< Sets a final move to.
-	virtual Bool isTimeFrozen(void){ return false;}					///< Freezes time during the next camera movement.
-	virtual Int	 getTimeMultiplier(void) {return 1;};				///< Get the time multiplier.
-	virtual void setTimeMultiplier(Int multiple) {}; ///< Set the time multiplier.
-	virtual void setDefaultView(Real pitch, Real angle, Real maxHeight) {};
-	virtual void zoomCamera( Real finalZoom, Int milliseconds, Real easeIn, Real easeOut ) {};
-	virtual void pitchCamera( Real finalPitch, Int milliseconds, Real easeIn, Real easeOut ) {};
+														Bool orient, Real easeIn, Real easeOut) override {};
+	virtual Bool isCameraMovementFinished(void) override {return true;};
+	virtual void resetCamera(const Coord3D *location, Int frames, Real easeIn, Real easeOut) override {}; ///< Move camera to location, and reset to default angle & zoom.
+	virtual void rotateCamera(Real rotations, Int frames, Real easeIn, Real easeOut) override {}; ///< Rotate camera about current viewpoint.
+	virtual void rotateCameraTowardObject(ObjectID id, Int milliseconds, Int holdMilliseconds, Real easeIn, Real easeOut) override {};	///< Rotate camera to face an object, and hold on it
+	virtual void cameraModFinalZoom(Real finalZoom, Real easeIn, Real easeOut) override {};			 ///< Final zoom for current camera movement.
+	virtual void cameraModRollingAverage(Int framesToAverage) override {}; ///< Number of frames to average movement for current camera movement.
+	virtual void cameraModFinalTimeMultiplier(Int finalMultiplier) override {}; ///< Final time multiplier for current camera movement.
+	virtual void cameraModFinalPitch(Real finalPitch, Real easeIn, Real easeOut) override {};		 ///< Final pitch for current camera movement.
+	virtual void cameraModFreezeTime(void) override {}					///< Freezes time during the next camera movement.
+	virtual void cameraModFreezeAngle(void) override {}					///< Freezes time during the next camera movement.
+	virtual void cameraModLookToward(Coord3D *pLoc) override {}			///< Sets a look at point during camera movement.
+	virtual void cameraModFinalLookToward(Coord3D *pLoc) override {}			///< Sets a look at point during camera movement.
+	virtual void cameraModFinalMoveTo(Coord3D *pLoc) override { };			///< Sets a final move to.
+	virtual Bool isTimeFrozen(void) override { return false;}					///< Freezes time during the next camera movement.
+	virtual Int	 getTimeMultiplier(void) override {return 1;};				///< Get the time multiplier.
+	virtual void setTimeMultiplier(Int multiple) override {}; ///< Set the time multiplier.
+	virtual void setDefaultView(Real pitch, Real angle, Real maxHeight) override {};
+	virtual void zoomCamera( Real finalZoom, Int milliseconds, Real easeIn, Real easeOut ) override {};
+	virtual void pitchCamera( Real finalPitch, Int milliseconds, Real easeIn, Real easeOut ) override {};
 
-	virtual void setAngle( Real angle ){};																///< Rotate the view around the up axis to the given angle
-	virtual Real getAngle( void ) { return 0; }
-	virtual void setPitch( Real angle ){};																	///< Rotate the view around the horizontal axis to the given angle
-	virtual Real getPitch( void ) { return 0; }							///< Return current camera pitch
-	virtual void setAngleToDefault( void ) {}											///< Set the view angle back to default
-	virtual void setPitchToDefault( void ) {}											///< Set the view pitch back to default
+	virtual void setAngle( Real angle ) override {};																///< Rotate the view around the up axis to the given angle
+	virtual Real getAngle( void ) override { return 0; }
+	virtual void setPitch( Real angle ) override {};																	///< Rotate the view around the horizontal axis to the given angle
+	virtual Real getPitch( void ) override { return 0; }							///< Return current camera pitch
+	virtual void setAngleToDefault( void ) override {}											///< Set the view angle back to default
+	virtual void setPitchToDefault( void ) override {}											///< Set the view pitch back to default
 	virtual void getPosition(Coord3D *pos) {}											///< Return camera position
 
-	virtual Real getHeightAboveGround() { return 1; }
-	virtual void setHeightAboveGround(Real z) { }
-	virtual Real getZoom() { return 1; }
-	virtual void setZoom(Real z) { }
+	virtual Real getHeightAboveGround() override { return 1; }
+	virtual void setHeightAboveGround(Real z) override { }
+	virtual Real getZoom() override { return 1; }
+	virtual void setZoom(Real z) override { }
 	virtual void zoomIn( void ) {  }																			///< Zoom in, closer to the ground, limit to min
 	virtual void zoomOut( void ) {  }																		///< Zoom out, farther away from the ground, limit to max
-	virtual void setZoomToDefault( void ) { }														///< Set zoom to default value
+	virtual void setZoomToDefault( void ) override { }														///< Set zoom to default value
 	virtual Real getMaxZoom( void ) { return 0.0f; }
-	virtual void setOkToAdjustHeight( Bool val ) { }						///< Set this to adjust camera height
+	virtual void setOkToAdjustHeight( Bool val ) override { }						///< Set this to adjust camera height
 
-	virtual Real getTerrainHeightAtPivot() { return 0.0f; }
-	virtual Real getCurrentHeightAboveGround() { return 0.0f; }
+	virtual Real getTerrainHeightAtPivot() override { return 0.0f; }
+	virtual Real getCurrentHeightAboveGround() override { return 0.0f; }
 
-	virtual void getLocation ( ViewLocation *location ) {};								///< write the view's current location in to the view location object
-	virtual void setLocation ( const ViewLocation *location ){};								///< set the view's current location from to the view location object
+	virtual void getLocation ( ViewLocation *location ) override {};								///< write the view's current location in to the view location object
+	virtual void setLocation ( const ViewLocation *location ) override {};								///< set the view's current location from to the view location object
 
-	virtual ObjectID getCameraLock() const { return INVALID_ID; }
-	virtual void setCameraLock(ObjectID id) {  }
-	virtual void snapToCameraLock( void ) {  }
-	virtual void setSnapMode( CameraLockType lockType, Real lockDist ) {  }
+	virtual ObjectID getCameraLock() const override { return INVALID_ID; }
+	virtual void setCameraLock(ObjectID id) override {  }
+	virtual void snapToCameraLock( void ) override {  }
+	virtual void setSnapMode( CameraLockType lockType, Real lockDist ) override {  }
 
-	virtual Drawable *getCameraLockDrawable() const { return nullptr; }
-	virtual void setCameraLockDrawable(Drawable *drawable) { }
+	virtual Drawable *getCameraLockDrawable() const override { return nullptr; }
+	virtual void setCameraLockDrawable(Drawable *drawable) override { }
 
-	virtual void setMouseLock( Bool mouseLocked ) {}					///< lock/unlock the mouse input to the tactical view
-	virtual Bool isMouseLocked( void ) { return FALSE; }			///< is the mouse input locked to the tactical view?
+	virtual void setMouseLock( Bool mouseLocked ) override {}					///< lock/unlock the mouse input to the tactical view
+	virtual Bool isMouseLocked( void ) override { return FALSE; }			///< is the mouse input locked to the tactical view?
 
-	virtual void setFieldOfView( Real angle ) {};							///< Set the horizontal field of view angle
-	virtual Real getFieldOfView( void ) {return 0;};										///< Get the horizontal field of view angle
+	virtual void setFieldOfView( Real angle ) override {};							///< Set the horizontal field of view angle
+	virtual Real getFieldOfView( void ) override {return 0;};										///< Get the horizontal field of view angle
 
-	virtual Bool setViewFilterMode(enum FilterModes) {return FALSE;}	///<stub
-	virtual void setViewFilterPos(const Coord3D *pos) {};	///<stub
-	virtual void setFadeParameters(Int fadeFrames, Int direction) {};	///<stub
-	virtual void set3DWireFrameMode(Bool enable) { }; ///<stub
-	virtual Bool setViewFilter(		enum FilterTypes m_viewFilterMode) { return FALSE;}	///<stub
-	virtual enum FilterModes	 getViewFilterMode(void) {return (enum FilterModes)0;}			///< Turns on viewport special effect (black & white mode)
-	virtual enum FilterTypes	 getViewFilterType(void) {return (enum FilterTypes)0;}			///< Turns on viewport special effect (black & white mode)
+	virtual Bool setViewFilterMode(enum FilterModes) override {return FALSE;}	///<stub
+	virtual void setViewFilterPos(const Coord3D *pos) override {};	///<stub
+	virtual void setFadeParameters(Int fadeFrames, Int direction) override {};	///<stub
+	virtual void set3DWireFrameMode(Bool enable) override { }; ///<stub
+	virtual Bool setViewFilter(		enum FilterTypes m_viewFilterMode) override { return FALSE;}	///<stub
+	virtual enum FilterModes	 getViewFilterMode(void) override {return (enum FilterModes)0;}			///< Turns on viewport special effect (black & white mode)
+	virtual enum FilterTypes	 getViewFilterType(void) override {return (enum FilterTypes)0;}			///< Turns on viewport special effect (black & white mode)
 
-	virtual void shake( const Coord3D *epicenter, CameraShakeType shakeType ) {};
+	virtual void shake( const Coord3D *epicenter, CameraShakeType shakeType ) override {};
 
-	virtual Real getFXPitch( void ) const { return 1.0f; }
-	virtual void forceCameraAreaConstraintRecalc(void) { }
-	virtual void rotateCameraTowardPosition(const Coord3D *pLoc, Int milliseconds, Real easeIn, Real easeOut, Bool reverseRotation) {};	///< Rotate camera to face an object, and hold on it
+	virtual Real getFXPitch( void ) const override { return 1.0f; }
+	virtual void forceCameraAreaConstraintRecalc(void) override { }
+	virtual void rotateCameraTowardPosition(const Coord3D *pLoc, Int milliseconds, Real easeIn, Real easeOut, Bool reverseRotation) override {};	///< Rotate camera to face an object, and hold on it
 
-	virtual const Coord3D& get3DCameraPosition() const { static Coord3D dummy; return dummy; }							///< Returns the actual camera position
+	virtual const Coord3D& get3DCameraPosition() const override { static Coord3D dummy; return dummy; }							///< Returns the actual camera position
 
-	virtual void setGuardBandBias( const Coord2D *gb ) {};
+	virtual void setGuardBandBias( const Coord2D *gb ) override {};
 
 };
 
@@ -297,10 +297,10 @@ class SkeletonSceneClass : public RTS3DScene
 {
 public:
 	SkeletonSceneClass(void) : m_testPass(nullptr) { }
-	~SkeletonSceneClass(void) { REF_PTR_RELEASE(m_testPass); }
+	virtual ~SkeletonSceneClass(void) override { REF_PTR_RELEASE(m_testPass); }
 
 	void					Set_Material_Pass(MaterialPassClass * pass)	{ REF_PTR_SET(m_testPass, pass); }
-	virtual void Remove_Render_Object(RenderObjClass * obj);
+	virtual void Remove_Render_Object(RenderObjClass * obj) override;
 
 	Bool safeContains(RenderObjClass *obj);
 

--- a/GeneralsMD/Code/Tools/wdump/wdump.cpp
+++ b/GeneralsMD/Code/Tools/wdump/wdump.cpp
@@ -78,7 +78,7 @@ CWdumpApp theApp;
 // private class declaration of a CCommandLineInfo class that knows about our special options
 class CWDumpCommandLineInfo : public CCommandLineInfo
 {
-	virtual void ParseParam(const TCHAR* pszParam,BOOL bFlag,BOOL bLast)
+	virtual void ParseParam(const TCHAR* pszParam,BOOL bFlag,BOOL bLast) override
 	{
 		if (bFlag)
 		{
@@ -223,7 +223,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CAboutDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -49,6 +49,8 @@ if (NOT IS_VS6_BUILD)
         add_compile_options(/MP)
         # Enforce strict __cplusplus version
         add_compile_options(/Zc:__cplusplus)
+    else()
+        add_compile_options(-Wsuggest-override)
     endif()
 else()
     if(RTS_BUILD_OPTION_VC6_FULL_DEBUG)


### PR DESCRIPTION
## Summary
Sync upstream changes from `TheSuperHackers/GeneralsGameCode` `main` into GeneralsX while preserving the existing cross-platform architecture.

- Branch: `thesuperhackers-sync-04-11-2026`
- Merge commit: `33699c1d0`
- Scope imported: 204 files changed (mostly WorldBuilder headers/sources, plus small Core/CMake updates)

## Key Merge Decisions
- Kept GeneralsX cross-platform stack intact (SDL3 + DXVK + OpenAL + FFmpeg paths remain).
- Accepted upstream updates where they did not remove or downgrade cross-platform behavior.
- No textual conflicts occurred in this merge (`ort` auto-merge), so risk focus is semantic/build validation.
- Build-system delta reviewed: `cmake/compilers.cmake` adds `-Wsuggest-override` for non-MSVC.
- Core delta reviewed: `Core/GameEngine/Include/GameClient/ParticleSys.h` explicit `virtual` keywords in dummy manager class.

## Validation
- macOS configure: PASS
- macOS Zero Hour build: PASS after clean rebuild confirmation by maintainer
- Linux configure/build: PENDING
- Runtime smoke (GeneralsXZH / GeneralsX): PENDING

## Risk Areas For Review
- WorldBuilder API/header harmonization in `Generals/Code/Tools/WorldBuilder/**` and `GeneralsMD/Code/Tools/WorldBuilder/**`
- Warnings promoted by `-Wsuggest-override` may surface latent portability issues over time
- Runtime paths still require explicit smoke checks on both products after this upstream sync

## Test Checklist
- [ ] Configure on macOS
- [ ] Configure on Linux
- [x] Configure on Windows (if applicable for this branch)
- [ ] Build GeneralsXZH
- [ ] Build GeneralsX
- [ ] Launch game binaries
- [ ] Reach main menu
- [ ] Skirmish gameplay smoke
- [ ] Campaign flow smoke
- [ ] Audio playback
- [ ] Video playback
- [ ] Renderer stability (DXVK path)
- [ ] Input handling (SDL3 path)
- [x] Mod loading (if affected)
