### PR TITLE
feature: Pillarbox for ultrawide monitors and resizable windows

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/Display.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Display.h
@@ -80,6 +80,7 @@ public:
 	virtual UnsignedInt getBitDepth() { return m_bitDepth; }
 	virtual void setWindowed( Bool windowed ) { m_windowed = windowed; }  ///< set windowd/fullscreen flag
 	virtual Bool getWindowed() { return m_windowed; }				///< return widowed/fullscreen flag
+	virtual Bool getViewportRect( Int& x, Int& y, Int& width, Int& height ) const { return FALSE; }  ///< pillarbox/letterbox viewport in logical pixels
 	virtual Bool setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt bitdepth, Bool windowed );	///<sets screen resolution/mode
 	virtual Int getDisplayModeCount() {return 0;}	///<return number of display modes/resolutions supported by video card.
 	virtual void getDisplayModeDescription(Int modeIndex, Int *xres, Int *yres, Int *bitDepth) {}	///<return description of mode

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -63,6 +63,7 @@ public:
 
 	virtual void setWidth( UnsignedInt width ) override;
 	virtual void setHeight( UnsignedInt height ) override;
+	virtual Bool getViewportRect( Int& x, Int& y, Int& width, Int& height ) const override;
 	virtual Bool setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt bitdepth, Bool windowed ) override;
 	virtual Int getDisplayModeCount() override;	///<return number of display modes/resolutions supported by video card.
 	virtual void getDisplayModeDescription(Int modeIndex, Int *xres, Int *yres, Int *bitDepth) override;	///<return description of mode

--- a/Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -734,6 +734,19 @@ void SDL3Mouse::scaleMouseCoordinates(int rawX, int rawY, Uint32 windowID, int& 
 	int internalWidth  = TheDisplay->getWidth();
 	int internalHeight = TheDisplay->getHeight();
 
+	int pbX, pbY, pbW, pbH;
+	if (TheDisplay->getViewportRect(pbX, pbY, pbW, pbH)) {
+		int clampedX = rawX - pbX;
+		if (clampedX < 0) clampedX = 0;
+		if (clampedX > pbW) clampedX = pbW;
+		int clampedY = rawY - pbY;
+		if (clampedY < 0) clampedY = 0;
+		if (clampedY > pbH) clampedY = pbH;
+		scaledX = static_cast<int>(clampedX * static_cast<float>(internalWidth) / static_cast<float>(pbW));
+		scaledY = static_cast<int>(clampedY * static_cast<float>(internalHeight) / static_cast<float>(pbH));
+		return;
+	}
+
 	float factorX = static_cast<float>(internalWidth)  / static_cast<float>(windowWidth);
 	float factorY = static_cast<float>(internalHeight) / static_cast<float>(windowHeight);
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -441,6 +441,36 @@ inline Bool isResolutionSupported(const ResolutionDescClass &res)
 	return res.Width >= DEFAULT_DISPLAY_WIDTH && res.BitDepth >= minBitDepth;
 }
 
+// SDL3 display size providers for DX8Wrapper pillarbox (registered at init)
+#ifdef SAGE_USE_SDL3
+static bool SDL3_GetNativeDisplaySize(int& outW, int& outH, float& outDensity)
+{
+	extern SDL_Window* TheSDL3Window;
+	if (!TheSDL3Window) return false;
+	SDL_DisplayID displayId = SDL_GetDisplayForWindow(TheSDL3Window);
+	const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(displayId);
+	if (!mode || mode->w <= 0 || mode->h <= 0) return false;
+	outDensity = mode->pixel_density > 0 ? mode->pixel_density : 1.0f;
+	outW = (int)(mode->w * outDensity);
+	outH = (int)(mode->h * outDensity);
+	return true;
+}
+
+static bool SDL3_GetWindowSizeInPixels(int& outW, int& outH, float& outDensity)
+{
+	extern SDL_Window* TheSDL3Window;
+	if (!TheSDL3Window) return false;
+	int logW = 0, logH = 0, physW = 0, physH = 0;
+	SDL_GetWindowSize(TheSDL3Window, &logW, &logH);
+	SDL_GetWindowSizeInPixels(TheSDL3Window, &physW, &physH);
+	if (physW <= 0 || physH <= 0) return false;
+	outW = physW;
+	outH = physH;
+	outDensity = (logW > 0) ? (float)physW / (float)logW : 1.0f;
+	return true;
+}
+#endif
+
 // Filtered resolution cache — built once, clamps widths to 4:3..16:9 and deduplicates.
 struct FilteredRes { Int w, h, bits; };
 static std::vector<FilteredRes> s_filteredResolutions;
@@ -670,6 +700,11 @@ void W3DDisplay::init()
 		{
 			SortingRendererClass::SetMinVertexBufferSize(1);
 		}
+		// Register SDL3 display size providers for pillarbox before device init
+#ifdef SAGE_USE_SDL3
+		DX8Wrapper::Set_Display_Size_Provider(SDL3_GetNativeDisplaySize, SDL3_GetWindowSizeInPixels);
+#endif
+
 		if (WW3D::Init( ApplicationHWnd ) != WW3D_ERROR_OK)
 			throw ERROR_INVALID_D3D;	//failed to initialize.  User probably doesn't have DX 8.1
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -45,6 +45,7 @@ static void drawFramerateBar();
 #include <SDL3/SDL.h> // For SDL_ShowWindow() on Linux
 #endif
 #include <time.h>
+#include <vector>
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
 #include "Common/FramePacer.h"
@@ -440,58 +441,53 @@ inline Bool isResolutionSupported(const ResolutionDescClass &res)
 	return res.Width >= DEFAULT_DISPLAY_WIDTH && res.BitDepth >= minBitDepth;
 }
 
-/*Return number of screen modes supported by the current device*/
+// Filtered resolution cache — built once, clamps widths to 4:3..16:9 and deduplicates.
+struct FilteredRes { Int w, h, bits; };
+static std::vector<FilteredRes> s_filteredResolutions;
+static bool s_filteredDirty = true;
+
+static void buildFilteredResolutions()
+{
+	s_filteredResolutions.clear();
+	const RenderDeviceDescClass &devDesc = WW3D::Get_Render_Device_Desc(0);
+	const DynamicVectorClass<ResolutionDescClass> &resolutions = devDesc.Enumerate_Resolutions();
+
+	int nativeW = 0, nativeH = 0;
+	float density = 1.0f;
+	DX8Wrapper::GetNativeDisplaySize(nativeW, nativeH, density);
+
+	for (int i = 0; i < resolutions.Count(); i++) {
+		if (!isResolutionSupported(resolutions[i])) continue;
+		Int w = resolutions[i].Width;
+		Int h = resolutions[i].Height;
+		Int bits = resolutions[i].BitDepth;
+		if (nativeH > 0 && h > nativeH) continue;
+		Int minW = h * 4 / 3;
+		Int maxW = h * 16 / 9;
+		if (w < minW) w = minW;
+		if (w > maxW) w = maxW;
+		bool duplicate = false;
+		for (const auto& e : s_filteredResolutions) {
+			if (e.w == w && e.h == h && e.bits == bits) { duplicate = true; break; }
+		}
+		if (!duplicate) s_filteredResolutions.push_back({w, h, bits});
+	}
+	s_filteredDirty = false;
+}
+
 Int W3DDisplay::getDisplayModeCount()
 {
-	const RenderDeviceDescClass &devDesc=WW3D::Get_Render_Device_Desc(0);
-	const DynamicVectorClass <ResolutionDescClass> &resolutions=devDesc.Enumerate_Resolutions();
-
-	Int numResolutions=0;
-/*	Bool needStencil=false;
-	Bool needDestinationAlpha=false;
-	Int minBitDepth=16;
-
-	//Walk through all resolutions and determine which ones are compatible with other settings
-	//chosen by user.  For example, 32-bit may be required for shadows, occlusion, soft water edge, etc.
-	if (TheGlobalData->m_useShadowVolumes || (TheGlobalData->m_enableBehindBuildingMarkers && TheGameLogic->getShowBehindBuildingMarkers()))
-		needStencil=true;
-
-	if (TheGlobalData->m_showSoftWaterEdge)
-	{	minBitDepth=32;
-	}
-*/
-	for (int res = 0; res < resolutions.Count ();  res ++)
-	{
-		// Is this the resolution we are looking for?
-		if (isResolutionSupported(resolutions[res]))
-		{
-			numResolutions++;
-		}
-	}
-
-	return numResolutions;
+	if (s_filteredDirty) buildFilteredResolutions();
+	return (Int)s_filteredResolutions.size();
 }
 
 void W3DDisplay::getDisplayModeDescription(Int modeIndex, Int *xres, Int *yres, Int *bitDepth)
 {
-	Int numResolutions=0;
-	const RenderDeviceDescClass &devDesc=WW3D::Get_Render_Device_Desc(0);
-	const DynamicVectorClass <ResolutionDescClass> &resolutions=devDesc.Enumerate_Resolutions();
-
-	for (int res = 0; res < resolutions.Count ();  res ++)
-	{
-		// Is this the resolution we are looking for?
-		if (isResolutionSupported(resolutions[res]))
-		{
-			if (numResolutions == modeIndex)
-			{	//found the mode
-				*xres=resolutions[res].Width;
-				*yres=resolutions[res].Height;
-				*bitDepth=resolutions[res].BitDepth;
-				return;
-			}
-			numResolutions++;
-		}
+	if (s_filteredDirty) buildFilteredResolutions();
+	if (modeIndex >= 0 && modeIndex < (Int)s_filteredResolutions.size()) {
+		*xres = s_filteredResolutions[modeIndex].w;
+		*yres = s_filteredResolutions[modeIndex].h;
+		*bitDepth = s_filteredResolutions[modeIndex].bits;
 	}
 }
 
@@ -524,6 +520,11 @@ Bool W3DDisplay::setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt
 	Render2DClass::Set_Screen_Resolution(RectClass(0, 0, oldWidth, oldHeight));
 	Display::setDisplayMode(oldWidth, oldHeight, oldBitDepth, oldWindowed);
 	return FALSE;	//did not change to a new mode.
+}
+
+Bool W3DDisplay::getViewportRect( Int& x, Int& y, Int& width, Int& height ) const
+{
+	return DX8Wrapper::Pillarbox_Get_Rect(x, y, width, height) ? TRUE : FALSE;
 }
 
 /** Set width of display */
@@ -1632,6 +1633,9 @@ void W3DDisplay::draw()
 {
 	//USE_PERF_TIMER(W3DDisplay_draw)
 
+	// GeneralsX @feature xxorza 15/04/2026 Process deferred window resize for pillarbox
+	DX8Wrapper::Pillarbox_Process_Resize();
+
 	extern HWND ApplicationHWnd;
 	if (ApplicationHWnd && ::IsIconic(ApplicationHWnd)) {
 		return;
@@ -1776,6 +1780,9 @@ AGAIN:
 			if (TheW3DProjectedShadowManager)
 				TheW3DProjectedShadowManager->updateRenderTargetTextures();
 		}
+
+		// Switch to offscreen RT AFTER pre-render (shadows/water) completes, BEFORE main render.
+		DX8Wrapper::Pillarbox_Begin();
 
 		Debug_Statistics::End_Statistics();	//record number of polygons rendered in RenderTargetTextures.
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -249,8 +249,11 @@ void DX8Wrapper::Pillarbox_End()
 	D3DDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
 	D3DDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_SELECTARG1);
 	D3DDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
-	D3DDevice->SetTextureStageState(0, D3DTSS_MINFILTER, D3DTEXF_LINEAR);
-	D3DDevice->SetTextureStageState(0, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
+	// Use point filtering when 1:1 pixel mapping to avoid sub-pixel blur
+	DWORD filterMode = (s_dstW == ResolutionWidth && s_dstH == ResolutionHeight)
+		? D3DTEXF_POINT : D3DTEXF_LINEAR;
+	D3DDevice->SetTextureStageState(0, D3DTSS_MINFILTER, filterMode);
+	D3DDevice->SetTextureStageState(0, D3DTSS_MAGFILTER, filterMode);
 
 	float x0 = (float)s_dstX, y0 = (float)s_dstY;
 	float x1 = (float)(s_dstX + s_dstW), y1 = (float)(s_dstY + s_dstH);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -110,6 +110,8 @@ DX8Wrapper::DisplaySizeFunc DX8Wrapper::s_getNativeDisplaySize = nullptr;
 DX8Wrapper::DisplaySizeFunc DX8Wrapper::s_getWindowSize = nullptr;
 bool DX8Wrapper::s_pillarboxEnabled = false;
 bool DX8Wrapper::s_pillarboxActive = false;
+int DX8Wrapper::s_bbW = 0;
+int DX8Wrapper::s_bbH = 0;
 int DX8Wrapper::s_dstX = 0;
 int DX8Wrapper::s_dstY = 0;
 int DX8Wrapper::s_dstW = 0;
@@ -177,9 +179,18 @@ bool DX8Wrapper::Pillarbox_Setup(int gameW, int gameH)
 		return false;
 	}
 
+	// Cache backbuffer size and compute aspect-correct fit rect once
+	s_bbW = bbW; s_bbH = bbH;
 	s_pixelDensity = density;
-	s_dstX = 0; s_dstY = 0;
-	s_dstW = bbW; s_dstH = bbH;
+	float gameAspect = (float)gameW / (float)gameH;
+	float bbAspect = (float)bbW / (float)bbH;
+	if (bbAspect > gameAspect) {
+		s_dstW = (int)(bbH * gameAspect); s_dstH = bbH;
+		s_dstX = (bbW - s_dstW) / 2; s_dstY = 0;
+	} else {
+		s_dstW = bbW; s_dstH = (int)(bbW / gameAspect);
+		s_dstX = 0; s_dstY = (bbH - s_dstH) / 2;
+	}
 	s_pillarboxEnabled = true;
 	fprintf(stderr, "INFO: Pillarbox: game=%dx%d, backbuffer=%dx%d, windowed=%d\n",
 		gameW, gameH, bbW, bbH, IsWindowed ? 1 : 0);
@@ -211,26 +222,8 @@ void DX8Wrapper::Pillarbox_End()
 	s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr;
 	if (s_savedDepth) { s_savedDepth->Release(); s_savedDepth = nullptr; }
 
-	IDirect3DSurface8* bb = nullptr;
-	D3DDevice->GetBackBuffer(0, D3DBACKBUFFER_TYPE_MONO, &bb);
-	int bbW = s_dstW, bbH = s_dstH;
-	if (bb) {
-		D3DSURFACE_DESC desc;
-		if (SUCCEEDED(bb->GetDesc(&desc))) { bbW = desc.Width; bbH = desc.Height; }
-		bb->Release();
-	}
-
-	float gameAspect = (float)ResolutionWidth / (float)ResolutionHeight;
-	float bbAspect = (float)bbW / (float)bbH;
-	if (bbAspect > gameAspect) {
-		s_dstW = (int)(bbH * gameAspect); s_dstH = bbH;
-		s_dstX = (bbW - s_dstW) / 2; s_dstY = 0;
-	} else {
-		s_dstW = bbW; s_dstH = (int)(bbW / gameAspect);
-		s_dstX = 0; s_dstY = (bbH - s_dstH) / 2;
-	}
-
-	D3DVIEWPORT8 vp = {0, 0, (DWORD)bbW, (DWORD)bbH, 0.0f, 1.0f};
+	// Blit offscreen texture centered onto backbuffer (fit rect cached in Pillarbox_Setup)
+	D3DVIEWPORT8 vp = {0, 0, (DWORD)s_bbW, (DWORD)s_bbH, 0.0f, 1.0f};
 	D3DDevice->SetViewport(&vp);
 	D3DDevice->Clear(0, nullptr, D3DCLEAR_TARGET, 0x00000000, 1.0f, 0);
 
@@ -249,14 +242,14 @@ void DX8Wrapper::Pillarbox_End()
 	D3DDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
 	D3DDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_SELECTARG1);
 	D3DDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
-	// Use point filtering when 1:1 pixel mapping to avoid sub-pixel blur
 	DWORD filterMode = (s_dstW == ResolutionWidth && s_dstH == ResolutionHeight)
 		? D3DTEXF_POINT : D3DTEXF_LINEAR;
 	D3DDevice->SetTextureStageState(0, D3DTSS_MINFILTER, filterMode);
 	D3DDevice->SetTextureStageState(0, D3DTSS_MAGFILTER, filterMode);
 
-	float x0 = (float)s_dstX, y0 = (float)s_dstY;
-	float x1 = (float)(s_dstX + s_dstW), y1 = (float)(s_dstY + s_dstH);
+	// D3D8 half-pixel offset: XYZRHW vertices need -0.5 for exact texel-to-pixel alignment
+	float x0 = (float)s_dstX - 0.5f, y0 = (float)s_dstY - 0.5f;
+	float x1 = (float)(s_dstX + s_dstW) - 0.5f, y1 = (float)(s_dstY + s_dstH) - 0.5f;
 	struct BV { float x, y, z, rhw; float u, v; };
 	BV quad[4] = {
 		{x0, y0, 0, 1, 0, 0}, {x1, y0, 0, 1, 1, 0},

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -227,25 +227,26 @@ void DX8Wrapper::Pillarbox_End()
 	D3DDevice->SetViewport(&vp);
 	D3DDevice->Clear(0, nullptr, D3DCLEAR_TARGET, 0x00000000, 1.0f, 0);
 
+	// Use DX8Wrapper's cached state setters so the cache stays in sync — no invalidation needed.
 	D3DDevice->SetTexture(0, s_offscreenTex);
-	D3DDevice->SetRenderState(D3DRS_ZENABLE, FALSE);
-	D3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
-	D3DDevice->SetRenderState(D3DRS_LIGHTING, FALSE);
-	D3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
-	D3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
-	D3DDevice->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
-	D3DDevice->SetRenderState(D3DRS_FOGENABLE, FALSE);
-	D3DDevice->SetRenderState(D3DRS_STENCILENABLE, FALSE);
-	D3DDevice->SetRenderState(D3DRS_COLORWRITEENABLE, 0xF);
-	D3DDevice->SetRenderState(D3DRS_CLIPPING, FALSE);
-	D3DDevice->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
-	D3DDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
-	D3DDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_SELECTARG1);
-	D3DDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
+	Set_DX8_Render_State(D3DRS_ZENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_ZWRITEENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_LIGHTING, FALSE);
+	Set_DX8_Render_State(D3DRS_ALPHABLENDENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_ALPHATESTENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_CULLMODE, D3DCULL_NONE);
+	Set_DX8_Render_State(D3DRS_FOGENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_STENCILENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_COLORWRITEENABLE, 0xF);
+	Set_DX8_Render_State(D3DRS_CLIPPING, FALSE);
+	Set_DX8_Texture_Stage_State(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
+	Set_DX8_Texture_Stage_State(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
+	Set_DX8_Texture_Stage_State(0, D3DTSS_COLOROP, D3DTOP_SELECTARG1);
+	Set_DX8_Texture_Stage_State(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
 	DWORD filterMode = (s_dstW == ResolutionWidth && s_dstH == ResolutionHeight)
 		? D3DTEXF_POINT : D3DTEXF_LINEAR;
-	D3DDevice->SetTextureStageState(0, D3DTSS_MINFILTER, filterMode);
-	D3DDevice->SetTextureStageState(0, D3DTSS_MAGFILTER, filterMode);
+	Set_DX8_Texture_Stage_State(0, D3DTSS_MINFILTER, filterMode);
+	Set_DX8_Texture_Stage_State(0, D3DTSS_MAGFILTER, filterMode);
 
 	// D3D8 half-pixel offset: XYZRHW vertices need -0.5 for exact texel-to-pixel alignment
 	float x0 = (float)s_dstX - 0.5f, y0 = (float)s_dstY - 0.5f;
@@ -258,8 +259,6 @@ void DX8Wrapper::Pillarbox_End()
 	D3DDevice->SetVertexShader(D3DFVF_XYZRHW | D3DFVF_TEX1);
 	D3DDevice->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, quad, sizeof(BV));
 	D3DDevice->SetTexture(0, nullptr);
-
-	Invalidate_Cached_Render_States();
 }
 
 bool DX8Wrapper::Pillarbox_Get_Rect(int& x, int& y, int& w, int& h)
@@ -698,6 +697,12 @@ void DX8Wrapper::Invalidate_Cached_Render_States()
 
 	// (gth) clear the matrix shadows too
 	memset(&DX8Transforms, 0, sizeof(DX8Transforms));
+}
+
+void DX8Wrapper::Set_Transform_Dirty()
+{
+	memset(&DX8Transforms, 0, sizeof(DX8Transforms));
+	render_state_changed |= (unsigned)(WORLD_CHANGED | VIEW_CHANGED);
 }
 
 void DX8Wrapper::Do_Onetime_Device_Dependent_Shutdowns()

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -55,6 +55,9 @@
 #include <dlfcn.h>
 #include <cxxabi.h>
 #endif
+#ifdef SAGE_USE_SDL3
+#include <SDL3/SDL.h>
+#endif
 // GeneralsX @bugfix fbraz3 20/03/2026 - Need typeinfo for unknown-exception type logging
 #include <typeinfo>
 // GeneralsX @build BenderAI 10/02/2026 - Embedded browser Windows-only (requires COM LPDISPATCH)
@@ -101,6 +104,197 @@ const int DEFAULT_RESOLUTION_HEIGHT = 480;
 const int DEFAULT_BIT_DEPTH = 32;
 const int DEFAULT_TEXTURE_BIT_DEPTH = 16;
 const D3DMULTISAMPLE_TYPE DEFAULT_MSAA = D3DMULTISAMPLE_NONE;
+
+static D3DPRESENT_PARAMETERS _PresentParameters;
+
+// --- Pillarbox: render game to offscreen RT, blit centered onto backbuffer ---
+// GeneralsX @feature xxorza 15/04/2026 Unified pillarbox for fullscreen and windowed
+bool DX8Wrapper::s_pillarboxEnabled = false;
+bool DX8Wrapper::s_pillarboxActive = false;
+int DX8Wrapper::s_dstX = 0;
+int DX8Wrapper::s_dstY = 0;
+int DX8Wrapper::s_dstW = 0;
+int DX8Wrapper::s_dstH = 0;
+float DX8Wrapper::s_pixelDensity = 1.0f;
+IDirect3DTexture8* DX8Wrapper::s_offscreenTex = nullptr;
+IDirect3DSurface8* DX8Wrapper::s_offscreenSurf = nullptr;
+IDirect3DSurface8* DX8Wrapper::s_depthSurf = nullptr;
+IDirect3DSurface8* DX8Wrapper::s_savedBackbuffer = nullptr;
+IDirect3DSurface8* DX8Wrapper::s_savedDepth = nullptr;
+
+bool DX8Wrapper::GetNativeDisplaySize(int& outW, int& outH, float& outDensity)
+{
+#ifdef SAGE_USE_SDL3
+	extern SDL_Window* TheSDL3Window;
+	if (!TheSDL3Window) return false;
+	SDL_DisplayID displayId = SDL_GetDisplayForWindow(TheSDL3Window);
+	const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(displayId);
+	if (!mode || mode->w <= 0 || mode->h <= 0) return false;
+	outDensity = mode->pixel_density > 0 ? mode->pixel_density : 1.0f;
+	outW = (int)(mode->w * outDensity);
+	outH = (int)(mode->h * outDensity);
+	return true;
+#else
+	return false;
+#endif
+}
+
+static bool GetWindowSizeInPixels(int& outW, int& outH, float& outDensity)
+{
+#ifdef SAGE_USE_SDL3
+	extern SDL_Window* TheSDL3Window;
+	if (!TheSDL3Window) return false;
+	int logW = 0, logH = 0, physW = 0, physH = 0;
+	SDL_GetWindowSize(TheSDL3Window, &logW, &logH);
+	SDL_GetWindowSizeInPixels(TheSDL3Window, &physW, &physH);
+	if (physW <= 0 || physH <= 0) return false;
+	outW = physW;
+	outH = physH;
+	outDensity = (logW > 0) ? (float)physW / (float)logW : 1.0f;
+	return true;
+#else
+	return false;
+#endif
+}
+
+void DX8Wrapper::Pillarbox_Cleanup()
+{
+	if (s_savedBackbuffer) { s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr; }
+	if (s_savedDepth) { s_savedDepth->Release(); s_savedDepth = nullptr; }
+	if (s_depthSurf) { s_depthSurf->Release(); s_depthSurf = nullptr; }
+	if (s_offscreenSurf) { s_offscreenSurf->Release(); s_offscreenSurf = nullptr; }
+	if (s_offscreenTex) { s_offscreenTex->Release(); s_offscreenTex = nullptr; }
+	s_pillarboxEnabled = false;
+	s_pillarboxActive = false;
+}
+
+bool DX8Wrapper::Pillarbox_Setup(int gameW, int gameH)
+{
+	Pillarbox_Cleanup();
+
+	int bbW, bbH;
+	float density;
+	if (!IsWindowed) {
+		if (!GetNativeDisplaySize(bbW, bbH, density)) return false;
+	} else {
+		if (!GetWindowSizeInPixels(bbW, bbH, density)) {
+			bbW = gameW; bbH = gameH; density = 1.0f;
+		}
+	}
+
+	if (bbW == gameW && bbH == gameH) return false;
+
+	HRESULT hr = D3DDevice->CreateTexture(gameW, gameH, 1, D3DUSAGE_RENDERTARGET,
+		D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &s_offscreenTex);
+	if (FAILED(hr)) return false;
+	s_offscreenTex->GetSurfaceLevel(0, &s_offscreenSurf);
+
+	hr = D3DDevice->CreateDepthStencilSurface(gameW, gameH,
+		_PresentParameters.AutoDepthStencilFormat, D3DMULTISAMPLE_NONE, &s_depthSurf);
+	if (FAILED(hr)) {
+		s_offscreenSurf->Release(); s_offscreenSurf = nullptr;
+		s_offscreenTex->Release(); s_offscreenTex = nullptr;
+		return false;
+	}
+
+	s_pixelDensity = density;
+	s_dstX = 0; s_dstY = 0;
+	s_dstW = bbW; s_dstH = bbH;
+	s_pillarboxEnabled = true;
+	fprintf(stderr, "INFO: Pillarbox: game=%dx%d, backbuffer=%dx%d, windowed=%d\n",
+		gameW, gameH, bbW, bbH, IsWindowed ? 1 : 0);
+	return true;
+}
+
+void DX8Wrapper::Pillarbox_Begin()
+{
+	if (!s_pillarboxEnabled || !s_offscreenSurf) return;
+	if (s_savedBackbuffer) { s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr; }
+	if (s_savedDepth) { s_savedDepth->Release(); s_savedDepth = nullptr; }
+	D3DDevice->GetRenderTarget(&s_savedBackbuffer);
+	D3DDevice->GetDepthStencilSurface(&s_savedDepth);
+	D3DDevice->SetRenderTarget(s_offscreenSurf, s_depthSurf);
+	D3DDevice->Clear(0, nullptr, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER | D3DCLEAR_STENCIL,
+		0x00000000, 1.0f, 0);
+	D3DDevice->SetRenderState(D3DRS_ZENABLE, TRUE);
+	D3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+	D3DDevice->SetRenderState(D3DRS_ZFUNC, D3DCMP_LESSEQUAL);
+	s_pillarboxActive = true;
+}
+
+void DX8Wrapper::Pillarbox_End()
+{
+	if (!s_pillarboxActive || !s_savedBackbuffer) return;
+	s_pillarboxActive = false;
+
+	D3DDevice->SetRenderTarget(s_savedBackbuffer, s_savedDepth);
+	s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr;
+	if (s_savedDepth) { s_savedDepth->Release(); s_savedDepth = nullptr; }
+
+	IDirect3DSurface8* bb = nullptr;
+	D3DDevice->GetBackBuffer(0, D3DBACKBUFFER_TYPE_MONO, &bb);
+	int bbW = s_dstW, bbH = s_dstH;
+	if (bb) {
+		D3DSURFACE_DESC desc;
+		if (SUCCEEDED(bb->GetDesc(&desc))) { bbW = desc.Width; bbH = desc.Height; }
+		bb->Release();
+	}
+
+	float gameAspect = (float)ResolutionWidth / (float)ResolutionHeight;
+	float bbAspect = (float)bbW / (float)bbH;
+	if (bbAspect > gameAspect) {
+		s_dstW = (int)(bbH * gameAspect); s_dstH = bbH;
+		s_dstX = (bbW - s_dstW) / 2; s_dstY = 0;
+	} else {
+		s_dstW = bbW; s_dstH = (int)(bbW / gameAspect);
+		s_dstX = 0; s_dstY = (bbH - s_dstH) / 2;
+	}
+
+	D3DVIEWPORT8 vp = {0, 0, (DWORD)bbW, (DWORD)bbH, 0.0f, 1.0f};
+	D3DDevice->SetViewport(&vp);
+	D3DDevice->Clear(0, nullptr, D3DCLEAR_TARGET, 0x00000000, 1.0f, 0);
+
+	D3DDevice->SetTexture(0, s_offscreenTex);
+	D3DDevice->SetRenderState(D3DRS_ZENABLE, FALSE);
+	D3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+	D3DDevice->SetRenderState(D3DRS_LIGHTING, FALSE);
+	D3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
+	D3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+	D3DDevice->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
+	D3DDevice->SetRenderState(D3DRS_FOGENABLE, FALSE);
+	D3DDevice->SetRenderState(D3DRS_STENCILENABLE, FALSE);
+	D3DDevice->SetRenderState(D3DRS_COLORWRITEENABLE, 0xF);
+	D3DDevice->SetRenderState(D3DRS_CLIPPING, FALSE);
+	D3DDevice->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
+	D3DDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
+	D3DDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_SELECTARG1);
+	D3DDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
+	D3DDevice->SetTextureStageState(0, D3DTSS_MINFILTER, D3DTEXF_LINEAR);
+	D3DDevice->SetTextureStageState(0, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
+
+	float x0 = (float)s_dstX, y0 = (float)s_dstY;
+	float x1 = (float)(s_dstX + s_dstW), y1 = (float)(s_dstY + s_dstH);
+	struct BV { float x, y, z, rhw; float u, v; };
+	BV quad[4] = {
+		{x0, y0, 0, 1, 0, 0}, {x1, y0, 0, 1, 1, 0},
+		{x0, y1, 0, 1, 0, 1}, {x1, y1, 0, 1, 1, 1},
+	};
+	D3DDevice->SetVertexShader(D3DFVF_XYZRHW | D3DFVF_TEX1);
+	D3DDevice->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, quad, sizeof(BV));
+	D3DDevice->SetTexture(0, nullptr);
+
+	Invalidate_Cached_Render_States();
+}
+
+bool DX8Wrapper::Pillarbox_Get_Rect(int& x, int& y, int& w, int& h)
+{
+	if (!s_pillarboxEnabled) return false;
+	x = (int)(s_dstX / s_pixelDensity);
+	y = (int)(s_dstY / s_pixelDensity);
+	w = (int)(s_dstW / s_pixelDensity);
+	h = (int)(s_dstH / s_pixelDensity);
+	return true;
+}
 
 DX8FrameStatistics DX8Wrapper::FrameStatistics;
 static DX8FrameStatistics LastFrameStatistics;
@@ -183,7 +377,6 @@ unsigned long DX8Wrapper::FrameCount = 0;
 
 bool								_DX8SingleThreaded										= false;
 
-static D3DPRESENT_PARAMETERS								_PresentParameters;
 static DynamicVectorClass<StringClass>					_RenderDeviceNameTable;
 static DynamicVectorClass<StringClass>					_RenderDeviceShortNameTable;
 static DynamicVectorClass<RenderDeviceDescClass>	_RenderDeviceDescriptionTable;
@@ -197,6 +390,33 @@ DX8_CleanupHook	 *DX8Wrapper::m_pCleanupHook=nullptr;
 #ifdef EXTENDED_STATS
 DX8_Stats	 DX8Wrapper::stats;
 #endif
+// Called once per frame from W3DDisplay::draw(). Checks if the window size
+// changed since last frame and reconfigures pillarbox accordingly.
+void DX8Wrapper::Pillarbox_Process_Resize()
+{
+	if (!IsWindowed || !D3DDevice) return;
+
+	int physW = 0, physH = 0;
+	float density = 1.0f;
+	if (!GetWindowSizeInPixels(physW, physH, density)) return;
+
+	if ((int)_PresentParameters.BackBufferWidth == physW &&
+		(int)_PresentParameters.BackBufferHeight == physH) return;
+
+	Pillarbox_Cleanup();
+	_PresentParameters.BackBufferWidth = physW;
+	_PresentParameters.BackBufferHeight = physH;
+
+	if (!Reset_Device()) {
+		_PresentParameters.BackBufferWidth = ResolutionWidth;
+		_PresentParameters.BackBufferHeight = ResolutionHeight;
+		Reset_Device();
+		return;
+	}
+
+	Pillarbox_Setup(ResolutionWidth, ResolutionHeight);
+}
+
 /***********************************************************************************
 **
 ** DX8Wrapper Implementation
@@ -709,6 +929,8 @@ bool DX8Wrapper::Reset_Device(bool reload_assets)
 
 void DX8Wrapper::Release_Device()
 {
+	Pillarbox_Cleanup();
+
 	if (D3DDevice) {
 
 		for (int a=0;a<MAX_TEXTURE_STAGES;++a)
@@ -1040,8 +1262,17 @@ bool DX8Wrapper::Set_Render_Device(int dev, int width, int height, int bits, int
 	*/
 	::ZeroMemory(&_PresentParameters, sizeof(D3DPRESENT_PARAMETERS));
 
+	// In fullscreen, set backbuffer to native display size for pillarbox rendering.
 	_PresentParameters.BackBufferWidth = ResolutionWidth;
 	_PresentParameters.BackBufferHeight = ResolutionHeight;
+	if (!IsWindowed) {
+		int nativeW, nativeH;
+		float density;
+		if (GetNativeDisplaySize(nativeW, nativeH, density)) {
+			_PresentParameters.BackBufferWidth = nativeW;
+			_PresentParameters.BackBufferHeight = nativeH;
+		}
+	}
 	_PresentParameters.BackBufferCount = IsWindowed ? 1 : 2;
 
 	_PresentParameters.MultiSampleType = D3DMULTISAMPLE_NONE;
@@ -1193,6 +1424,7 @@ bool DX8Wrapper::Set_Render_Device(int dev, int width, int height, int bits, int
 	if (ret)
 	{
 		Render2DClass::Set_Screen_Resolution( RectClass( 0, 0, ResolutionWidth, ResolutionHeight ) );
+		Pillarbox_Setup(ResolutionWidth, ResolutionHeight);
 	}
 
 	return ret;
@@ -1320,11 +1552,20 @@ bool DX8Wrapper::Set_Device_Resolution(int width,int height,int bits,int windowe
 {
 	if (D3DDevice != nullptr) {
 
-		if (width != -1) {
-			_PresentParameters.BackBufferWidth = ResolutionWidth = width;
-		}
-		if (height != -1) {
-			_PresentParameters.BackBufferHeight = ResolutionHeight = height;
+		if (width != -1) ResolutionWidth = width;
+		if (height != -1) ResolutionHeight = height;
+
+		_PresentParameters.BackBufferWidth = ResolutionWidth;
+		_PresentParameters.BackBufferHeight = ResolutionHeight;
+
+		Pillarbox_Cleanup();
+		if (!IsWindowed) {
+			int nativeW, nativeH;
+			float density;
+			if (GetNativeDisplaySize(nativeW, nativeH, density)) {
+				_PresentParameters.BackBufferWidth = nativeW;
+				_PresentParameters.BackBufferHeight = nativeH;
+			}
 		}
 		if (resize_window)
 		{
@@ -1332,7 +1573,9 @@ bool DX8Wrapper::Set_Device_Resolution(int width,int height,int bits,int windowe
 		}
 #pragma message("TODO: support changing windowed status and changing the bit depth")
 		WWDEBUG_SAY(("DX8Wrapper::Set_Device_Resolution is resetting the device."));
-		return Reset_Device();
+		bool ok = Reset_Device();
+		if (ok) Pillarbox_Setup(ResolutionWidth, ResolutionHeight);
+		return ok;
 	} else {
 		return false;
 	}
@@ -1748,6 +1991,11 @@ void DX8Wrapper::Begin_Scene()
 void DX8Wrapper::End_Scene(bool flip_frames)
 {
 	DX8_THREAD_ASSERT();
+
+	// Pillarbox: restore backbuffer + blit offscreen, all within the current scene
+	if (s_pillarboxActive && s_offscreenTex) {
+		Pillarbox_End();
+	}
 	DX8CALL(EndScene());
 
 	// GeneralsX @build BenderAI 10/02/2026 - Embedded browser Windows-only

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -55,9 +55,6 @@
 #include <dlfcn.h>
 #include <cxxabi.h>
 #endif
-#ifdef SAGE_USE_SDL3
-#include <SDL3/SDL.h>
-#endif
 // GeneralsX @bugfix fbraz3 20/03/2026 - Need typeinfo for unknown-exception type logging
 #include <typeinfo>
 // GeneralsX @build BenderAI 10/02/2026 - Embedded browser Windows-only (requires COM LPDISPATCH)
@@ -109,6 +106,8 @@ static D3DPRESENT_PARAMETERS _PresentParameters;
 
 // --- Pillarbox: render game to offscreen RT, blit centered onto backbuffer ---
 // GeneralsX @feature xxorza 15/04/2026 Unified pillarbox for fullscreen and windowed
+DX8Wrapper::DisplaySizeFunc DX8Wrapper::s_getNativeDisplaySize = nullptr;
+DX8Wrapper::DisplaySizeFunc DX8Wrapper::s_getWindowSize = nullptr;
 bool DX8Wrapper::s_pillarboxEnabled = false;
 bool DX8Wrapper::s_pillarboxActive = false;
 int DX8Wrapper::s_dstX = 0;
@@ -122,39 +121,20 @@ IDirect3DSurface8* DX8Wrapper::s_depthSurf = nullptr;
 IDirect3DSurface8* DX8Wrapper::s_savedBackbuffer = nullptr;
 IDirect3DSurface8* DX8Wrapper::s_savedDepth = nullptr;
 
-bool DX8Wrapper::GetNativeDisplaySize(int& outW, int& outH, float& outDensity)
+void DX8Wrapper::Set_Display_Size_Provider(DisplaySizeFunc nativeSize, DisplaySizeFunc windowSize)
 {
-#ifdef SAGE_USE_SDL3
-	extern SDL_Window* TheSDL3Window;
-	if (!TheSDL3Window) return false;
-	SDL_DisplayID displayId = SDL_GetDisplayForWindow(TheSDL3Window);
-	const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(displayId);
-	if (!mode || mode->w <= 0 || mode->h <= 0) return false;
-	outDensity = mode->pixel_density > 0 ? mode->pixel_density : 1.0f;
-	outW = (int)(mode->w * outDensity);
-	outH = (int)(mode->h * outDensity);
-	return true;
-#else
-	return false;
-#endif
+	s_getNativeDisplaySize = nativeSize;
+	s_getWindowSize = windowSize;
 }
 
-static bool GetWindowSizeInPixels(int& outW, int& outH, float& outDensity)
+bool DX8Wrapper::GetNativeDisplaySize(int& outW, int& outH, float& outDensity)
 {
-#ifdef SAGE_USE_SDL3
-	extern SDL_Window* TheSDL3Window;
-	if (!TheSDL3Window) return false;
-	int logW = 0, logH = 0, physW = 0, physH = 0;
-	SDL_GetWindowSize(TheSDL3Window, &logW, &logH);
-	SDL_GetWindowSizeInPixels(TheSDL3Window, &physW, &physH);
-	if (physW <= 0 || physH <= 0) return false;
-	outW = physW;
-	outH = physH;
-	outDensity = (logW > 0) ? (float)physW / (float)logW : 1.0f;
-	return true;
-#else
-	return false;
-#endif
+	return s_getNativeDisplaySize && s_getNativeDisplaySize(outW, outH, outDensity);
+}
+
+bool DX8Wrapper::GetWindowSize(int& outW, int& outH, float& outDensity)
+{
+	return s_getWindowSize && s_getWindowSize(outW, outH, outDensity);
 }
 
 void DX8Wrapper::Pillarbox_Cleanup()
@@ -177,7 +157,7 @@ bool DX8Wrapper::Pillarbox_Setup(int gameW, int gameH)
 	if (!IsWindowed) {
 		if (!GetNativeDisplaySize(bbW, bbH, density)) return false;
 	} else {
-		if (!GetWindowSizeInPixels(bbW, bbH, density)) {
+		if (!GetWindowSize(bbW, bbH, density)) {
 			bbW = gameW; bbH = gameH; density = 1.0f;
 		}
 	}
@@ -398,7 +378,7 @@ void DX8Wrapper::Pillarbox_Process_Resize()
 
 	int physW = 0, physH = 0;
 	float density = 1.0f;
-	if (!GetWindowSizeInPixels(physW, physH, density)) return;
+	if (!GetWindowSize(physW, physH, density)) return;
 
 	if ((int)_PresentParameters.BackBufferWidth == physW &&
 		(int)_PresentParameters.BackBufferHeight == physH) return;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -717,6 +717,7 @@ protected:
 	// Pillarbox state
 	static bool								s_pillarboxEnabled;
 	static bool								s_pillarboxActive;
+	static int								s_bbW, s_bbH;
 	static int								s_dstX, s_dstY, s_dstW, s_dstH;
 	static float							s_pixelDensity;
 	static IDirect3DTexture8*			s_offscreenTex;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -492,6 +492,13 @@ public:
 	static void					Set_Render_Target (IDirect3DSwapChain8 *swap_chain);
 	static bool					Is_Render_To_Texture() { return IsRenderToTexture; }
 
+	// Pillarbox: render game at chosen resolution, blit centered onto backbuffer
+	static bool					Pillarbox_Get_Rect(int& x, int& y, int& w, int& h);
+	static void					Pillarbox_Begin();
+	static void					Pillarbox_End();
+	static void					Pillarbox_Process_Resize();
+	static bool					GetNativeDisplaySize(int& outW, int& outH, float& outDensity);
+
 	// for depth map support KJM V
 	static void Create_Render_Target
 	(
@@ -697,6 +704,20 @@ protected:
 	static unsigned							DrawPolygonLowBoundLimit;
 
 	static bool								IsRenderToTexture;
+
+	// Pillarbox state
+	static bool								s_pillarboxEnabled;
+	static bool								s_pillarboxActive;
+	static int								s_dstX, s_dstY, s_dstW, s_dstH;
+	static float							s_pixelDensity;
+	static IDirect3DTexture8*			s_offscreenTex;
+	static IDirect3DSurface8*			s_offscreenSurf;
+	static IDirect3DSurface8*			s_depthSurf;
+	static IDirect3DSurface8*			s_savedBackbuffer;
+	static IDirect3DSurface8*			s_savedDepth;
+
+	static bool								Pillarbox_Setup(int gameW, int gameH);
+	static void								Pillarbox_Cleanup();
 
 	static int								ZBias;
 	static float							ZNear;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -492,12 +492,17 @@ public:
 	static void					Set_Render_Target (IDirect3DSwapChain8 *swap_chain);
 	static bool					Is_Render_To_Texture() { return IsRenderToTexture; }
 
+	// Platform display size provider — set by SDL3 layer at init
+	typedef bool (*DisplaySizeFunc)(int& outW, int& outH, float& outDensity);
+	static void					Set_Display_Size_Provider(DisplaySizeFunc nativeSize, DisplaySizeFunc windowSize);
+	static bool					GetNativeDisplaySize(int& outW, int& outH, float& outDensity);
+	static bool					GetWindowSize(int& outW, int& outH, float& outDensity);
+
 	// Pillarbox: render game at chosen resolution, blit centered onto backbuffer
 	static bool					Pillarbox_Get_Rect(int& x, int& y, int& w, int& h);
 	static void					Pillarbox_Begin();
 	static void					Pillarbox_End();
 	static void					Pillarbox_Process_Resize();
-	static bool					GetNativeDisplaySize(int& outW, int& outH, float& outDensity);
 
 	// for depth map support KJM V
 	static void Create_Render_Target
@@ -704,6 +709,10 @@ protected:
 	static unsigned							DrawPolygonLowBoundLimit;
 
 	static bool								IsRenderToTexture;
+
+	// Display size providers
+	static DisplaySizeFunc				s_getNativeDisplaySize;
+	static DisplaySizeFunc				s_getWindowSize;
 
 	// Pillarbox state
 	static bool								s_pillarboxEnabled;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -578,6 +578,7 @@ public:
 	static const char* Get_DX8_Blend_Op_Name(unsigned value);
 
 	static void Invalidate_Cached_Render_States();
+	static void Set_Transform_Dirty();
 
 	static void Set_Draw_Polygon_Low_Bound_Limit(unsigned n) { DrawPolygonLowBoundLimit=n; }
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -1107,10 +1107,11 @@ WW3DErrorType WW3D::End_Render(bool flip_frame)
 
 	Activate_Snapshot(false);
 
-	// (gth) I've found some cases where its not safe to rely on our "shadow" copy (of
-	// matrices for example) across multiple frames.  So even though this is slightly
-	// less "optimal", lets just reset the caches each frame.
-	DX8Wrapper::Invalidate_Cached_Render_States();
+	// (gth) Original code invalidated ALL cached render states every frame as a safety
+	// measure for matrix shadow copies. This is expensive (~33KB memset + texture unbinds).
+	// Instead, just mark matrices as dirty so they get re-sent next frame.
+	// Full invalidation still happens on device init, reset, and pillarbox blit.
+	DX8Wrapper::Set_Transform_Dirty();
 
 	return WW3D_ERROR_OK;
 }

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
@@ -80,6 +80,7 @@ public:
 	virtual UnsignedInt getBitDepth() { return m_bitDepth; }
 	virtual void setWindowed( Bool windowed ) { m_windowed = windowed; }  ///< set windowed/fullscreen flag
 	virtual Bool getWindowed() { return m_windowed; }				///< return widowed/fullscreen flag
+	virtual Bool getViewportRect( Int& x, Int& width, Int& height ) const { return FALSE; }  ///< pillarbox viewport in logical pixels
 	virtual Bool setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt bitdepth, Bool windowed );	///<sets screen resolution/mode
 	virtual Int getDisplayModeCount() {return 0;}	///<return number of display modes/resolutions supported by video card.
 	virtual void getDisplayModeDescription(Int modeIndex, Int *xres, Int *yres, Int *bitDepth) {}	///<return description of mode

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
@@ -80,7 +80,7 @@ public:
 	virtual UnsignedInt getBitDepth() { return m_bitDepth; }
 	virtual void setWindowed( Bool windowed ) { m_windowed = windowed; }  ///< set windowed/fullscreen flag
 	virtual Bool getWindowed() { return m_windowed; }				///< return widowed/fullscreen flag
-	virtual Bool getViewportRect( Int& x, Int& width, Int& height ) const { return FALSE; }  ///< pillarbox viewport in logical pixels
+	virtual Bool getViewportRect( Int& x, Int& y, Int& width, Int& height ) const { return FALSE; }  ///< pillarbox/letterbox viewport in logical pixels
 	virtual Bool setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt bitdepth, Bool windowed );	///<sets screen resolution/mode
 	virtual Int getDisplayModeCount() {return 0;}	///<return number of display modes/resolutions supported by video card.
 	virtual void getDisplayModeDescription(Int modeIndex, Int *xres, Int *yres, Int *bitDepth) {}	///<return description of mode

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -63,7 +63,7 @@ public:
 
 	virtual void setWidth( UnsignedInt width ) override;
 	virtual void setHeight( UnsignedInt height ) override;
-	virtual Bool getViewportRect( Int& x, Int& width, Int& height ) const override;
+	virtual Bool getViewportRect( Int& x, Int& y, Int& width, Int& height ) const override;
 	virtual Bool setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt bitdepth, Bool windowed ) override;
 	virtual Int getDisplayModeCount() override;	///<return number of display modes/resolutions supported by video card.
 	virtual void getDisplayModeDescription(Int modeIndex, Int *xres, Int *yres, Int *bitDepth) override;	///<return description of mode

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -63,6 +63,7 @@ public:
 
 	virtual void setWidth( UnsignedInt width ) override;
 	virtual void setHeight( UnsignedInt height ) override;
+	virtual Bool getViewportRect( Int& x, Int& width, Int& height ) const override;
 	virtual Bool setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt bitdepth, Bool windowed ) override;
 	virtual Int getDisplayModeCount() override;	///<return number of display modes/resolutions supported by video card.
 	virtual void getDisplayModeDescription(Int modeIndex, Int *xres, Int *yres, Int *bitDepth) override;	///<return description of mode

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -736,13 +736,16 @@ void SDL3Mouse::scaleMouseCoordinates(int rawX, int rawY, Uint32 windowID, int& 
 	int internalWidth  = TheDisplay->getWidth();
 	int internalHeight = TheDisplay->getHeight();
 
-	int pbX, pbW, pbH;
-	if (TheDisplay->getViewportRect(pbX, pbW, pbH)) {
+	int pbX, pbY, pbW, pbH;
+	if (TheDisplay->getViewportRect(pbX, pbY, pbW, pbH)) {
 		int clampedX = rawX - pbX;
 		if (clampedX < 0) clampedX = 0;
 		if (clampedX > pbW) clampedX = pbW;
+		int clampedY = rawY - pbY;
+		if (clampedY < 0) clampedY = 0;
+		if (clampedY > pbH) clampedY = pbH;
 		scaledX = static_cast<int>(clampedX * static_cast<float>(internalWidth) / static_cast<float>(pbW));
-		scaledY = static_cast<int>(rawY * static_cast<float>(internalHeight) / static_cast<float>(pbH));
+		scaledY = static_cast<int>(clampedY * static_cast<float>(internalHeight) / static_cast<float>(pbH));
 		return;
 	}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -145,11 +145,11 @@ SDL3Mouse::SDL3Mouse(SDL_Window* window)
 {
 	// GeneralsX @bugfix BenderAI 18/02/2026 Temporarily disable debug logging (Phase 1.8)
 	// fprintf(stderr, "DEBUG: SDL3Mouse::SDL3Mouse() created\n");
-	
+
 	// Initialize event buffer with SDL_EVENT_FIRST sentinel (means "empty" slot)
 	// GeneralsX @refactor felipebraz 16/02/2026 Fighter19 pattern
 	memset(m_eventBuffer, 0, sizeof(m_eventBuffer));
-	
+
 	m_LeftButtonDownPos.x = 0;
 	m_LeftButtonDownPos.y = 0;
 	m_RightButtonDownPos.x = 0;
@@ -205,7 +205,7 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 		delete[] file_buffer;
 		return NULL;
 	}
-	
+
 	DEBUG_LOG(("SDL3Mouse::loadCursorFromFile: loading %s", filepath));
 	AnimatedCursor* cursor = new AnimatedCursor();
 
@@ -297,7 +297,7 @@ void SDL3Mouse::init(void)
 {
 	// GeneralsX @bugfix BenderAI 18/02/2026 Temporarily disable debug logging (Phase 1.8)
 	// fprintf(stderr, "INFO: SDL3Mouse::init()\n");
-	
+
 	// Call parent init (loads cursor info from INI, etc.)
 	Mouse::init();
 
@@ -312,13 +312,13 @@ void SDL3Mouse::init(void)
 	// Show cursor by default
 	SDL_ShowCursor();
 	m_IsVisible = true;
-	
+
 	// Clear event buffer - Fighter19 pattern
 	// GeneralsX @refactor felipebraz 16/02/2026
 	memset(m_eventBuffer, 0, sizeof(m_eventBuffer));
 	m_nextFreeIndex = 0;
 	m_nextGetIndex = 0;
-	
+
 	// GeneralsX @bugfix BenderAI 18/02/2026 Temporarily disable debug logging (Phase 1.8)
 	// fprintf(stderr, "INFO: SDL3Mouse::init() complete\n");
 }
@@ -330,13 +330,13 @@ void SDL3Mouse::reset(void)
 {
 	// GeneralsX @bugfix BenderAI 18/02/2026 Temporarily disable debug logging (Phase 1.8)
 	// fprintf(stderr, "DEBUG: SDL3Mouse::reset()\n");
-	
+
 	Mouse::reset();
-	
+
 	releaseCapture();
 	SDL_ShowCursor();
 	m_IsVisible = true;
-	
+
 	// Clear event buffer - Fighter19 pattern
 	// GeneralsX @refactor felipebraz 16/02/2026
 	memset(m_eventBuffer, 0, sizeof(m_eventBuffer));
@@ -526,17 +526,17 @@ UnsignedByte SDL3Mouse::getMouseEvent(MouseIO *result, Bool flush)
 	if (m_eventBuffer[m_nextGetIndex].type == SDL_EVENT_FIRST) {
 		return MOUSE_NONE;
 	}
-	
+
 	// Translate SDL_Event to MouseIO
 	// GeneralsX @refactor felipebraz 16/02/2026 Use unified translateEvent()
 	translateEvent(m_nextGetIndex, result);
-	
+
 	// Mark this slot as empty (sentinel)
 	m_eventBuffer[m_nextGetIndex].type = SDL_EVENT_FIRST;
-	
+
 	// Advance read position (circular buffer)
 	m_nextGetIndex = (m_nextGetIndex + 1) % MAX_SDL3_MOUSE_EVENTS;
-	
+
 	return MOUSE_OK;
 }
 
@@ -596,7 +596,7 @@ void SDL3Mouse::translateMotionEvent(const SDL_MouseMotionEvent& event, MouseIO 
 	result->deltaPos.y = (Int)event.yrel;
 	// GeneralsX @bugfix felipebraz 18/02/2026 Normalize timestamp to milliseconds (SDL3 uses nanoseconds)
 	result->time = (Uint32)(event.timestamp / 1000000);
-	
+
 	// No button state change on motion
 	result->leftState = MBS_None;
 	result->rightState = MBS_None;
@@ -616,28 +616,28 @@ void SDL3Mouse::translateButtonEvent(const SDL_MouseButtonEvent& event, MouseIO 
 	// GeneralsX @bugfix felipebraz 18/02/2026 Normalize timestamp to milliseconds (SDL3 uses nanoseconds)
 	result->time = (Uint32)(event.timestamp / 1000000);
 	result->wheelPos = 0;
-	
+
 	// Initialize all button states to None
 	result->leftState = MBS_None;
 	result->rightState = MBS_None;
 	result->middleState = MBS_None;
-	
+
 	// GeneralsX @bugfix felipebraz 18/02/2026 Initialize frame tracking for replay determinism
 	result->leftFrame = 0;
 	result->rightFrame = 0;
 	result->middleFrame = 0;
-	
+
 	MouseButtonState state = event.down ? MBS_Down : MBS_Up;
-	
+
 	// GeneralsX @bugfix BenderAI 17/02/2026 Debug mouse button events
 	// GeneralsX @bugfix BenderAI 18/02/2026 Temporarily disable debug logging (Phase 1.8)
 	// fprintf(stderr, "[MOUSE] Button event: button=%d state=%s pos=(%d,%d)\n",
 	//	event.button, event.down ? "DOWN" : "UP", (Int)event.x, (Int)event.y);
-	
+
 	// Get current frame for replay determinism
 	// GeneralsX @bugfix felipebraz 18/02/2026 Use game frame instead of timestamp
 	UnsignedInt currentFrame = (TheGameLogic) ? TheGameLogic->getFrame() : 1;
-	
+
 	// Map SDL3 button to MouseIO button
 	switch (event.button) {
 		case SDL_BUTTON_LEFT:
@@ -652,7 +652,7 @@ void SDL3Mouse::translateButtonEvent(const SDL_MouseButtonEvent& event, MouseIO 
 			}
 			result->leftFrame = currentFrame;  // GeneralsX @bugfix felipebraz 18/02/2026 Track frame for replay
 			break;
-			
+
 		case SDL_BUTTON_RIGHT:
 			// GeneralsX @bugfix BenderAI 18/02/2026 Temporarily disable debug logging (Phase 1.8)
 			// fprintf(stderr, "[MOUSE] Right button: %s\n", event.down ? "DOWN" : "UP");
@@ -666,7 +666,7 @@ void SDL3Mouse::translateButtonEvent(const SDL_MouseButtonEvent& event, MouseIO 
 			}
 			result->rightFrame = currentFrame;  // GeneralsX @bugfix felipebraz 18/02/2026 Track frame for replay
 			break;
-			
+
 		case SDL_BUTTON_MIDDLE:
 			// GeneralsX @bugfix felipebraz 18/02/2026 Support double-click for middle button
 			if (event.down && event.clicks >= 2) {
@@ -687,18 +687,18 @@ void SDL3Mouse::translateWheelEvent(const SDL_MouseWheelEvent& event, MouseIO *r
 	// SDL3 mouse position not provided in wheel event, get current position
 	float mouseX, mouseY;
 	SDL_GetMouseState(&mouseX, &mouseY);
-	
+
 	result->pos.x = (Int)mouseX;
 	result->pos.y = (Int)mouseY;
 	result->deltaPos.x = 0;
 	result->deltaPos.y = 0;
 	// GeneralsX @bugfix felipebraz 18/02/2026 Normalize timestamp to milliseconds (SDL3 uses nanoseconds)
 	result->time = (Uint32)(event.timestamp / 1000000);
-	
+
 	// SDL3 wheel: positive = up/away, negative = down/toward user
 	// Multiply by MOUSE_WHEEL_DELTA (120) to match Windows behavior
 	result->wheelPos = (Int)(event.y * MOUSE_WHEEL_DELTA);
-	
+
 	result->leftState = MBS_None;
 	result->rightState = MBS_None;
 	result->middleState = MBS_None;
@@ -736,6 +736,16 @@ void SDL3Mouse::scaleMouseCoordinates(int rawX, int rawY, Uint32 windowID, int& 
 	int internalWidth  = TheDisplay->getWidth();
 	int internalHeight = TheDisplay->getHeight();
 
+	int pbX, pbW, pbH;
+	if (TheDisplay->getViewportRect(pbX, pbW, pbH)) {
+		int clampedX = rawX - pbX;
+		if (clampedX < 0) clampedX = 0;
+		if (clampedX > pbW) clampedX = pbW;
+		scaledX = static_cast<int>(clampedX * static_cast<float>(internalWidth) / static_cast<float>(pbW));
+		scaledY = static_cast<int>(rawY * static_cast<float>(internalHeight) / static_cast<float>(pbH));
+		return;
+	}
+
 	float factorX = static_cast<float>(internalWidth)  / static_cast<float>(windowWidth);
 	float factorY = static_cast<float>(internalHeight) / static_cast<float>(windowHeight);
 
@@ -757,7 +767,7 @@ void SDL3Mouse::addSDLEvent(SDL_Event *event)
 	if (!event) {
 		return;
 	}
-	
+
 	// Filter only mouse-related events
 	if (event->type != SDL_EVENT_MOUSE_MOTION &&
 	    event->type != SDL_EVENT_MOUSE_BUTTON_DOWN &&
@@ -765,7 +775,7 @@ void SDL3Mouse::addSDLEvent(SDL_Event *event)
 	    event->type != SDL_EVENT_MOUSE_WHEEL) {
 		return;  // Not a mouse event, ignore
 	}
-	
+
 	// Check if buffer is full
 	UnsignedInt nextFreeIndex = (m_nextFreeIndex + 1) % MAX_SDL3_MOUSE_EVENTS;
 	if (nextFreeIndex == m_nextGetIndex) {
@@ -773,13 +783,13 @@ void SDL3Mouse::addSDLEvent(SDL_Event *event)
 		// fprintf(stderr, "WARNING: SDL3Mouse::addSDLEvent() buffer full (dropped event)\n");
 		return;
 	}
-	
+
 	// Copy entire event to buffer
 	m_eventBuffer[m_nextFreeIndex] = *event;
-	
+
 	// GeneralsX @bugfix BenderAI 18/02/2026 Temporarily disable debug logging (Phase 1.8)
 	// fprintf(stderr, "DEBUG: SDL3Mouse::addSDLEvent() type=%u index=%u\n", event->type, m_nextFreeIndex);
-	
+
 	// Advance write position (circular buffer)
 	m_nextFreeIndex = nextFreeIndex;
 }
@@ -798,7 +808,7 @@ void SDL3Mouse::translateEvent(UnsignedInt eventIndex, MouseIO *result)
 	if (eventIndex >= MAX_SDL3_MOUSE_EVENTS || !result) {
 		return;
 	}
-	
+
 	const SDL_Event& event = m_eventBuffer[eventIndex];
 
 	// Raw window-pixel coordinates and window ID, extracted per event type

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3GameEngine.cpp
@@ -47,7 +47,6 @@
 #include "W3DDevice/GameClient/W3DWebBrowser.h"
 #include "StdDevice/Common/StdLocalFileSystem.h"
 #include "StdDevice/Common/StdBIGFileSystem.h"
-#include "dx8wrapper.h"
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_vulkan.h>
 #include <cstdio>
@@ -465,12 +464,8 @@ void SDL3GameEngine::handleMouseWheelEvent(const SDL_MouseWheelEvent& event)
 /**
  * Handle window event (resize, etc.)
  */
-// GeneralsX @feature xxorza 15/04/2026 Handle window resize for pillarbox
 void SDL3GameEngine::handleWindowEvent(const SDL_WindowEvent& event)
 {
-	if (event.type == SDL_EVENT_WINDOW_RESIZED) {
-		DX8Wrapper::Pillarbox_Notify_Resize();
-	}
 }
 
 /**

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3GameEngine.cpp
@@ -466,6 +466,8 @@ void SDL3GameEngine::handleMouseWheelEvent(const SDL_MouseWheelEvent& event)
  */
 void SDL3GameEngine::handleWindowEvent(const SDL_WindowEvent& event)
 {
+	// TODO: Phase 2 - Handle window resize, notify graphics subsystem
+	// fprintf(stderr, "DEBUG: Window event (type=%d)\n", event.type);
 }
 
 /**

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3GameEngine.cpp
@@ -469,7 +469,7 @@ void SDL3GameEngine::handleMouseWheelEvent(const SDL_MouseWheelEvent& event)
 void SDL3GameEngine::handleWindowEvent(const SDL_WindowEvent& event)
 {
 	if (event.type == SDL_EVENT_WINDOW_RESIZED) {
-		DX8Wrapper::Pillarbox_Handle_Resize(event.data1, event.data2);
+		DX8Wrapper::Pillarbox_Notify_Resize();
 	}
 }
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3GameEngine.cpp
@@ -47,6 +47,7 @@
 #include "W3DDevice/GameClient/W3DWebBrowser.h"
 #include "StdDevice/Common/StdLocalFileSystem.h"
 #include "StdDevice/Common/StdBIGFileSystem.h"
+#include "dx8wrapper.h"
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_vulkan.h>
 #include <cstdio>
@@ -464,10 +465,12 @@ void SDL3GameEngine::handleMouseWheelEvent(const SDL_MouseWheelEvent& event)
 /**
  * Handle window event (resize, etc.)
  */
+// GeneralsX @feature xxorza 15/04/2026 Handle window resize for pillarbox
 void SDL3GameEngine::handleWindowEvent(const SDL_WindowEvent& event)
 {
-	// TODO: Phase 2 - Handle window resize, notify graphics subsystem
-	// fprintf(stderr, "DEBUG: Window event (type=%d)\n", event.type);
+	if (event.type == SDL_EVENT_WINDOW_RESIZED) {
+		DX8Wrapper::Pillarbox_Handle_Resize(event.data1, event.data2);
+	}
 }
 
 /**

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -45,6 +45,7 @@ static void drawFramerateBar();
 #include <SDL3/SDL.h> // For SDL_ShowWindow() on Linux
 #endif
 #include <time.h>
+#include <vector>
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
 #include "Common/FramePacer.h"
@@ -491,58 +492,53 @@ inline Bool isResolutionSupported(const ResolutionDescClass &res)
 	return res.Width >= DEFAULT_DISPLAY_WIDTH && res.BitDepth >= minBitDepth;
 }
 
-/*Return number of screen modes supported by the current device*/
+// Filtered resolution cache — built once, clamps widths to 4:3..16:9 and deduplicates.
+struct FilteredRes { Int w, h, bits; };
+static std::vector<FilteredRes> s_filteredResolutions;
+static bool s_filteredDirty = true;
+
+static void buildFilteredResolutions()
+{
+	s_filteredResolutions.clear();
+	const RenderDeviceDescClass &devDesc = WW3D::Get_Render_Device_Desc(0);
+	const DynamicVectorClass<ResolutionDescClass> &resolutions = devDesc.Enumerate_Resolutions();
+
+	int nativeW = 0, nativeH = 0;
+	float density = 1.0f;
+	DX8Wrapper::GetNativeDisplaySize(nativeW, nativeH, density);
+
+	for (int i = 0; i < resolutions.Count(); i++) {
+		if (!isResolutionSupported(resolutions[i])) continue;
+		Int w = resolutions[i].Width;
+		Int h = resolutions[i].Height;
+		Int bits = resolutions[i].BitDepth;
+		if (nativeH > 0 && h > nativeH) continue;
+		Int minW = h * 4 / 3;
+		Int maxW = h * 16 / 9;
+		if (w < minW) w = minW;
+		if (w > maxW) w = maxW;
+		bool duplicate = false;
+		for (const auto& e : s_filteredResolutions) {
+			if (e.w == w && e.h == h && e.bits == bits) { duplicate = true; break; }
+		}
+		if (!duplicate) s_filteredResolutions.push_back({w, h, bits});
+	}
+	s_filteredDirty = false;
+}
+
 Int W3DDisplay::getDisplayModeCount()
 {
-	const RenderDeviceDescClass &devDesc=WW3D::Get_Render_Device_Desc(0);
-	const DynamicVectorClass <ResolutionDescClass> &resolutions=devDesc.Enumerate_Resolutions();
-
-	Int numResolutions=0;
-/*	Bool needStencil=false;
-	Bool needDestinationAlpha=false;
-	Int minBitDepth=16;
-
-	//Walk through all resolutions and determine which ones are compatible with other settings
-	//chosen by user.  For example, 32-bit may be required for shadows, occlusion, soft water edge, etc.
-	if (TheGlobalData->m_useShadowVolumes || (TheGlobalData->m_enableBehindBuildingMarkers && TheGameLogic->getShowBehindBuildingMarkers()))
-		needStencil=true;
-
-	if (TheGlobalData->m_showSoftWaterEdge)
-	{	minBitDepth=32;
-	}
-*/
-	for (int res = 0; res < resolutions.Count ();  res ++)
-	{
-		// Is this the resolution we are looking for?
-		if (isResolutionSupported(resolutions[res]))
-		{
-			numResolutions++;
-		}
-	}
-
-	return numResolutions;
+	if (s_filteredDirty) buildFilteredResolutions();
+	return (Int)s_filteredResolutions.size();
 }
 
 void W3DDisplay::getDisplayModeDescription(Int modeIndex, Int *xres, Int *yres, Int *bitDepth)
 {
-	Int numResolutions=0;
-	const RenderDeviceDescClass &devDesc=WW3D::Get_Render_Device_Desc(0);
-	const DynamicVectorClass <ResolutionDescClass> &resolutions=devDesc.Enumerate_Resolutions();
-
-	for (int res = 0; res < resolutions.Count ();  res ++)
-	{
-		// Is this the resolution we are looking for?
-		if (isResolutionSupported(resolutions[res]))
-		{
-			if (numResolutions == modeIndex)
-			{	//found the mode
-				*xres=resolutions[res].Width;
-				*yres=resolutions[res].Height;
-				*bitDepth=resolutions[res].BitDepth;
-				return;
-			}
-			numResolutions++;
-		}
+	if (s_filteredDirty) buildFilteredResolutions();
+	if (modeIndex >= 0 && modeIndex < (Int)s_filteredResolutions.size()) {
+		*xres = s_filteredResolutions[modeIndex].w;
+		*yres = s_filteredResolutions[modeIndex].h;
+		*bitDepth = s_filteredResolutions[modeIndex].bits;
 	}
 }
 
@@ -575,6 +571,11 @@ Bool W3DDisplay::setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt
 	Render2DClass::Set_Screen_Resolution(RectClass(0, 0, oldWidth, oldHeight));
 	Display::setDisplayMode(oldWidth, oldHeight, oldBitDepth, oldWindowed);
 	return FALSE;	//did not change to a new mode.
+}
+
+Bool W3DDisplay::getViewportRect( Int& x, Int& width, Int& height ) const
+{
+	return DX8Wrapper::Pillarbox_Get_Rect(x, width, height) ? TRUE : FALSE;
 }
 
 /** Set width of display */
@@ -720,15 +721,15 @@ void W3DDisplay::init()
 		{
 			SortingRendererClass::SetMinVertexBufferSize(1);
 		}
-		
+
 		// GeneralsX @bugfix felipebraz 16/02/2026 Add detailed WW3D init logging
 		fprintf(stderr, "DEBUG: About to call WW3D::Init() with ApplicationHWnd=%p\n", ApplicationHWnd);
 		WW3DErrorType ww3d_result = WW3D::Init( ApplicationHWnd );
-		
+
 		// Decode error type
 		const char* error_names[] = {
 			"WW3D_ERROR_OK",
-			"WW3D_ERROR_GENERIC", 
+			"WW3D_ERROR_GENERIC",
 			"WW3D_ERROR_LOAD_FAILED",
 			"WW3D_ERROR_SAVE_FAILED",
 			"WW3D_ERROR_WINDOW_NOT_OPEN",
@@ -736,7 +737,7 @@ void W3DDisplay::init()
 		};
 		const char* error_name = (ww3d_result >= 0 && ww3d_result <= 5) ? error_names[ww3d_result] : "UNKNOWN";
 		fprintf(stderr, "DEBUG: WW3D::Init() returned: %d (%s)\n", ww3d_result, error_name);
-		
+
 		if (ww3d_result != WW3D_ERROR_OK) {
 			fprintf(stderr, "ERROR: WW3D::Init() failed with %s - DirectX8/DXVK initialization error\n", error_name);
 			throw ERROR_INVALID_D3D;	//failed to initialize.  User probably doesn't have DX 8.1
@@ -1875,6 +1876,9 @@ AGAIN:
 			if (TheW3DProjectedShadowManager)
 				TheW3DProjectedShadowManager->updateRenderTargetTextures();
 		}
+
+		// Switch to offscreen RT AFTER pre-render (shadows/water) completes, BEFORE main render.
+		DX8Wrapper::Pillarbox_Begin();
 
 		Debug_Statistics::End_Statistics();	//record number of polygons rendered in RenderTargetTextures.
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1725,7 +1725,7 @@ void W3DDisplay::draw()
 	//USE_PERF_TIMER(W3DDisplay_draw)
 
 	// GeneralsX @feature xxorza 15/04/2026 Process deferred window resize for pillarbox
-	DX8Wrapper::Pillarbox_Handle_Resize(0, 0);
+	DX8Wrapper::Pillarbox_Process_Resize();
 
 	extern HWND ApplicationHWnd;
 	if (ApplicationHWnd && ::IsIconic(ApplicationHWnd)) {

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -573,9 +573,9 @@ Bool W3DDisplay::setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt
 	return FALSE;	//did not change to a new mode.
 }
 
-Bool W3DDisplay::getViewportRect( Int& x, Int& width, Int& height ) const
+Bool W3DDisplay::getViewportRect( Int& x, Int& y, Int& width, Int& height ) const
 {
-	return DX8Wrapper::Pillarbox_Get_Rect(x, width, height) ? TRUE : FALSE;
+	return DX8Wrapper::Pillarbox_Get_Rect(x, y, width, height) ? TRUE : FALSE;
 }
 
 /** Set width of display */
@@ -1723,6 +1723,9 @@ void W3DDisplay::step()
 void W3DDisplay::draw()
 {
 	//USE_PERF_TIMER(W3DDisplay_draw)
+
+	// GeneralsX @feature xxorza 15/04/2026 Process deferred window resize for pillarbox
+	DX8Wrapper::Pillarbox_Handle_Resize(0, 0);
 
 	extern HWND ApplicationHWnd;
 	if (ApplicationHWnd && ::IsIconic(ApplicationHWnd)) {

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -492,6 +492,36 @@ inline Bool isResolutionSupported(const ResolutionDescClass &res)
 	return res.Width >= DEFAULT_DISPLAY_WIDTH && res.BitDepth >= minBitDepth;
 }
 
+// SDL3 display size providers for DX8Wrapper pillarbox (registered at init)
+#ifdef SAGE_USE_SDL3
+static bool SDL3_GetNativeDisplaySize(int& outW, int& outH, float& outDensity)
+{
+	extern SDL_Window* TheSDL3Window;
+	if (!TheSDL3Window) return false;
+	SDL_DisplayID displayId = SDL_GetDisplayForWindow(TheSDL3Window);
+	const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(displayId);
+	if (!mode || mode->w <= 0 || mode->h <= 0) return false;
+	outDensity = mode->pixel_density > 0 ? mode->pixel_density : 1.0f;
+	outW = (int)(mode->w * outDensity);
+	outH = (int)(mode->h * outDensity);
+	return true;
+}
+
+static bool SDL3_GetWindowSizeInPixels(int& outW, int& outH, float& outDensity)
+{
+	extern SDL_Window* TheSDL3Window;
+	if (!TheSDL3Window) return false;
+	int logW = 0, logH = 0, physW = 0, physH = 0;
+	SDL_GetWindowSize(TheSDL3Window, &logW, &logH);
+	SDL_GetWindowSizeInPixels(TheSDL3Window, &physW, &physH);
+	if (physW <= 0 || physH <= 0) return false;
+	outW = physW;
+	outH = physH;
+	outDensity = (logW > 0) ? (float)physW / (float)logW : 1.0f;
+	return true;
+}
+#endif
+
 // Filtered resolution cache — built once, clamps widths to 4:3..16:9 and deduplicates.
 struct FilteredRes { Int w, h, bits; };
 static std::vector<FilteredRes> s_filteredResolutions;
@@ -721,6 +751,11 @@ void W3DDisplay::init()
 		{
 			SortingRendererClass::SetMinVertexBufferSize(1);
 		}
+
+		// Register SDL3 display size providers for pillarbox before device init
+#ifdef SAGE_USE_SDL3
+		DX8Wrapper::Set_Display_Size_Provider(SDL3_GetNativeDisplaySize, SDL3_GetWindowSizeInPixels);
+#endif
 
 		// GeneralsX @bugfix felipebraz 16/02/2026 Add detailed WW3D init logging
 		fprintf(stderr, "DEBUG: About to call WW3D::Init() with ApplicationHWnd=%p\n", ApplicationHWnd);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -105,12 +105,13 @@ const int DEFAULT_BIT_DEPTH = 32;
 const int DEFAULT_TEXTURE_BIT_DEPTH = 16;
 const D3DMULTISAMPLE_TYPE DEFAULT_MSAA = D3DMULTISAMPLE_NONE;
 
-// --- Pillarbox static member initialization ---
+static D3DPRESENT_PARAMETERS _PresentParameters;
+
+// --- Pillarbox: render game to offscreen RT, blit centered onto backbuffer ---
+// GeneralsX @feature xxorza 15/04/2026 Unified pillarbox for fullscreen and windowed
 bool DX8Wrapper::s_pillarboxEnabled = false;
 bool DX8Wrapper::s_pillarboxActive = false;
 bool DX8Wrapper::s_resizePending = false;
-int DX8Wrapper::s_nativeW = 0;
-int DX8Wrapper::s_nativeH = 0;
 int DX8Wrapper::s_dstX = 0;
 int DX8Wrapper::s_dstY = 0;
 int DX8Wrapper::s_dstW = 0;
@@ -118,9 +119,9 @@ int DX8Wrapper::s_dstH = 0;
 float DX8Wrapper::s_pixelDensity = 1.0f;
 IDirect3DTexture8* DX8Wrapper::s_offscreenTex = nullptr;
 IDirect3DSurface8* DX8Wrapper::s_offscreenSurf = nullptr;
-IDirect3DSurface8* DX8Wrapper::s_customDepth = nullptr;
+IDirect3DSurface8* DX8Wrapper::s_depthSurf = nullptr;
 IDirect3DSurface8* DX8Wrapper::s_savedBackbuffer = nullptr;
-IDirect3DSurface8* DX8Wrapper::s_savedAutoDepth = nullptr;
+IDirect3DSurface8* DX8Wrapper::s_savedDepth = nullptr;
 
 bool DX8Wrapper::GetNativeDisplaySize(int& outW, int& outH, float& outDensity)
 {
@@ -137,17 +138,6 @@ bool DX8Wrapper::GetNativeDisplaySize(int& outW, int& outH, float& outDensity)
 #else
 	return false;
 #endif
-}
-
-void DX8Wrapper::Pillarbox_Cleanup()
-{
-	if (s_savedBackbuffer) { s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr; }
-	if (s_savedAutoDepth) { s_savedAutoDepth->Release(); s_savedAutoDepth = nullptr; }
-	if (s_customDepth) { s_customDepth->Release(); s_customDepth = nullptr; }
-	if (s_offscreenSurf) { s_offscreenSurf->Release(); s_offscreenSurf = nullptr; }
-	if (s_offscreenTex) { s_offscreenTex->Release(); s_offscreenTex = nullptr; }
-	s_pillarboxEnabled = false;
-	s_pillarboxActive = false;
 }
 
 static bool GetWindowSizeInPixels(int& outW, int& outH, float& outDensity)
@@ -168,58 +158,102 @@ static bool GetWindowSizeInPixels(int& outW, int& outH, float& outDensity)
 #endif
 }
 
+void DX8Wrapper::Pillarbox_Cleanup()
+{
+	if (s_savedBackbuffer) { s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr; }
+	if (s_savedDepth) { s_savedDepth->Release(); s_savedDepth = nullptr; }
+	if (s_depthSurf) { s_depthSurf->Release(); s_depthSurf = nullptr; }
+	if (s_offscreenSurf) { s_offscreenSurf->Release(); s_offscreenSurf = nullptr; }
+	if (s_offscreenTex) { s_offscreenTex->Release(); s_offscreenTex = nullptr; }
+	s_pillarboxEnabled = false;
+	s_pillarboxActive = false;
+}
+
 bool DX8Wrapper::Pillarbox_Setup(int gameW, int gameH)
 {
 	Pillarbox_Cleanup();
 
-	if (IsWindowed) return false;  // Windowed pillarbox enabled on resize via Pillarbox_Handle_Resize
-	if (!GetNativeDisplaySize(s_nativeW, s_nativeH, s_pixelDensity)) return false;
+	// Determine backbuffer dimensions
+	int bbW, bbH;
+	float density;
+	if (!IsWindowed) {
+		if (!GetNativeDisplaySize(bbW, bbH, density)) return false;
+	} else {
+		if (!GetWindowSizeInPixels(bbW, bbH, density)) {
+			bbW = gameW; bbH = gameH; density = 1.0f;
+		}
+	}
 
-	// Initial dest rect (will be recomputed dynamically in Pillarbox_Blit)
-	s_dstX = 0; s_dstY = 0;
-	s_dstW = s_nativeW; s_dstH = s_nativeH;
+	// No pillarbox needed if backbuffer matches game resolution
+	if (bbW == gameW && bbH == gameH) return false;
 
+	// Create offscreen render target at game resolution
 	HRESULT hr = D3DDevice->CreateTexture(gameW, gameH, 1, D3DUSAGE_RENDERTARGET,
 		D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &s_offscreenTex);
 	if (FAILED(hr)) return false;
 	s_offscreenTex->GetSurfaceLevel(0, &s_offscreenSurf);
 
+	// Create dedicated depth stencil at game resolution
+	hr = D3DDevice->CreateDepthStencilSurface(gameW, gameH,
+		_PresentParameters.AutoDepthStencilFormat, D3DMULTISAMPLE_NONE, &s_depthSurf);
+	if (FAILED(hr)) {
+		s_offscreenSurf->Release(); s_offscreenSurf = nullptr;
+		s_offscreenTex->Release(); s_offscreenTex = nullptr;
+		return false;
+	}
+
+	s_pixelDensity = density;
+	s_dstX = 0; s_dstY = 0;
+	s_dstW = bbW; s_dstH = bbH;
 	s_pillarboxEnabled = true;
-	fprintf(stderr, "INFO: Pillarbox: game=%dx%d, backbuffer=%dx%d, density=%.1f\n",
-		gameW, gameH, s_nativeW, s_nativeH, s_pixelDensity);
+	fprintf(stderr, "INFO: Pillarbox: game=%dx%d, backbuffer=%dx%d, windowed=%d\n",
+		gameW, gameH, bbW, bbH, IsWindowed ? 1 : 0);
 	return true;
 }
 
-void DX8Wrapper::Pillarbox_Blit()
+void DX8Wrapper::Pillarbox_Begin()
 {
-	// Get actual backbuffer size (may differ from s_nativeW/H in windowed mode after resize)
+	if (!s_pillarboxEnabled || !s_offscreenSurf) return;
+	if (s_savedBackbuffer) { s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr; }
+	if (s_savedDepth) { s_savedDepth->Release(); s_savedDepth = nullptr; }
+	D3DDevice->GetRenderTarget(&s_savedBackbuffer);
+	D3DDevice->GetDepthStencilSurface(&s_savedDepth);
+	D3DDevice->SetRenderTarget(s_offscreenSurf, s_depthSurf);
+	D3DDevice->SetRenderState(D3DRS_ZENABLE, TRUE);
+	D3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+	D3DDevice->SetRenderState(D3DRS_ZFUNC, D3DCMP_LESSEQUAL);
+	s_pillarboxActive = true;
+}
+
+void DX8Wrapper::Pillarbox_End()
+{
+	if (!s_pillarboxActive || !s_savedBackbuffer) return;
+	s_pillarboxActive = false;
+
+	// Restore backbuffer (still inside active scene)
+	D3DDevice->SetRenderTarget(s_savedBackbuffer, s_savedDepth);
+	s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr;
+	if (s_savedDepth) { s_savedDepth->Release(); s_savedDepth = nullptr; }
+
+	// Blit offscreen texture centered onto backbuffer
 	IDirect3DSurface8* bb = nullptr;
 	D3DDevice->GetBackBuffer(0, D3DBACKBUFFER_TYPE_MONO, &bb);
-	int bbW = s_nativeW, bbH = s_nativeH;
+	int bbW = s_dstW, bbH = s_dstH;
 	if (bb) {
 		D3DSURFACE_DESC desc;
 		if (SUCCEEDED(bb->GetDesc(&desc))) { bbW = desc.Width; bbH = desc.Height; }
 		bb->Release();
 	}
 
-	// Compute aspect-correct fit rect (pillarbox OR letterbox depending on shape)
 	float gameAspect = (float)ResolutionWidth / (float)ResolutionHeight;
 	float bbAspect = (float)bbW / (float)bbH;
 	if (bbAspect > gameAspect) {
-		// Wider than game — pillarbox (bars on sides)
-		s_dstW = (int)(bbH * gameAspect);
-		s_dstH = bbH;
-		s_dstX = (bbW - s_dstW) / 2;
-		s_dstY = 0;
+		s_dstW = (int)(bbH * gameAspect); s_dstH = bbH;
+		s_dstX = (bbW - s_dstW) / 2; s_dstY = 0;
 	} else {
-		// Taller than game — letterbox (bars on top/bottom)
-		s_dstW = bbW;
-		s_dstH = (int)(bbW / gameAspect);
-		s_dstX = 0;
-		s_dstY = (bbH - s_dstH) / 2;
+		s_dstW = bbW; s_dstH = (int)(bbW / gameAspect);
+		s_dstX = 0; s_dstY = (bbH - s_dstH) / 2;
 	}
-	s_nativeW = bbW;
-	s_nativeH = bbH;
 
 	D3DVIEWPORT8 vp = {0, 0, (DWORD)bbW, (DWORD)bbH, 0.0f, 1.0f};
 	D3DDevice->SetViewport(&vp);
@@ -253,33 +287,8 @@ void DX8Wrapper::Pillarbox_Blit()
 	D3DDevice->SetVertexShader(D3DFVF_XYZRHW | D3DFVF_TEX1);
 	D3DDevice->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, quad, sizeof(BV));
 	D3DDevice->SetTexture(0, nullptr);
-}
 
-void DX8Wrapper::Pillarbox_Begin()
-{
-	if (!s_pillarboxEnabled || !s_offscreenSurf) return;
-	// Save backbuffer + depth for restoration in Pillarbox_End
-	if (s_savedBackbuffer) { s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr; }
-	if (s_savedAutoDepth) { s_savedAutoDepth->Release(); s_savedAutoDepth = nullptr; }
-	D3DDevice->GetRenderTarget(&s_savedBackbuffer);
-	D3DDevice->GetDepthStencilSurface(&s_savedAutoDepth);
-	// Use custom depth if available (windowed: game-res depth), else auto depth (fullscreen)
-	IDirect3DSurface8* depthForOffscreen = s_customDepth ? s_customDepth : s_savedAutoDepth;
-	D3DDevice->SetRenderTarget(s_offscreenSurf, depthForOffscreen);
-	// Force depth states after RT switch. The blit from the previous frame set
-	// ZENABLE=FALSE directly on D3D, bypassing DX8Wrapper's cache.
-	D3DDevice->SetRenderState(D3DRS_ZENABLE, TRUE);
-	D3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
-	D3DDevice->SetRenderState(D3DRS_ZFUNC, D3DCMP_LESSEQUAL);
-	s_pillarboxActive = true;
-}
-
-void DX8Wrapper::Pillarbox_End()
-{
-	if (!s_pillarboxEnabled || !s_savedBackbuffer) return;
-	D3DDevice->SetRenderTarget(s_savedBackbuffer, s_savedAutoDepth);
-	s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr;
-	if (s_savedAutoDepth) { s_savedAutoDepth->Release(); s_savedAutoDepth = nullptr; }
+	Invalidate_Cached_Render_States();
 }
 
 bool DX8Wrapper::Pillarbox_Get_Rect(int& x, int& y, int& w, int& h)
@@ -290,6 +299,11 @@ bool DX8Wrapper::Pillarbox_Get_Rect(int& x, int& y, int& w, int& h)
 	w = (int)(s_dstW / s_pixelDensity);
 	h = (int)(s_dstH / s_pixelDensity);
 	return true;
+}
+
+void DX8Wrapper::Pillarbox_Notify_Resize()
+{
+	if (IsWindowed) s_resizePending = true;
 }
 
 DX8FrameStatistics DX8Wrapper::FrameStatistics;
@@ -373,7 +387,6 @@ unsigned long DX8Wrapper::FrameCount = 0;
 
 bool								_DX8SingleThreaded										= false;
 
-static D3DPRESENT_PARAMETERS								_PresentParameters;
 static DynamicVectorClass<StringClass>					_RenderDeviceNameTable;
 static DynamicVectorClass<StringClass>					_RenderDeviceShortNameTable;
 static DynamicVectorClass<RenderDeviceDescClass>	_RenderDeviceDescriptionTable;
@@ -387,32 +400,20 @@ DX8_CleanupHook	 *DX8Wrapper::m_pCleanupHook=nullptr;
 #ifdef EXTENDED_STATS
 DX8_Stats	 DX8Wrapper::stats;
 #endif
-// GeneralsX @feature xxorza 15/04/2026 Pillarbox resize handling for windowed mode
-void DX8Wrapper::Pillarbox_Handle_Resize(int windowW, int windowH)
+void DX8Wrapper::Pillarbox_Process_Resize()
 {
-	if (!IsWindowed || !D3DDevice) return;
-
-	// When called from SDL event handler (windowW > 0), just mark pending
-	if (windowW > 0) {
-		s_resizePending = true;
-		return;
-	}
-
-	// When called from draw loop (windowW == 0), process pending resize
-	if (!s_resizePending) return;
+	if (!s_resizePending || !IsWindowed || !D3DDevice) return;
 	s_resizePending = false;
 
 	int physW = 0, physH = 0;
 	float density = 1.0f;
 	if (!GetWindowSizeInPixels(physW, physH, density)) return;
 
-	// Skip if backbuffer already matches
 	if (s_pillarboxEnabled &&
 		(int)_PresentParameters.BackBufferWidth == physW &&
 		(int)_PresentParameters.BackBufferHeight == physH) return;
 
 	Pillarbox_Cleanup();
-
 	_PresentParameters.BackBufferWidth = physW;
 	_PresentParameters.BackBufferHeight = physH;
 
@@ -423,32 +424,7 @@ void DX8Wrapper::Pillarbox_Handle_Resize(int windowW, int windowH)
 		return;
 	}
 
-	// Create offscreen RT at game resolution with its own depth stencil.
-	// The auto depth stencil is window-sized (possibly smaller than game res),
-	// so we create a separate depth surface at game resolution.
-	s_nativeW = physW;
-	s_nativeH = physH;
-	s_pixelDensity = density;
-	s_dstX = 0; s_dstY = 0;
-	s_dstW = physW; s_dstH = physH;
-
-	HRESULT hr = D3DDevice->CreateTexture(ResolutionWidth, ResolutionHeight, 1,
-		D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &s_offscreenTex);
-	if (FAILED(hr)) return;
-	s_offscreenTex->GetSurfaceLevel(0, &s_offscreenSurf);
-
-	hr = D3DDevice->CreateDepthStencilSurface(ResolutionWidth, ResolutionHeight,
-		_PresentParameters.AutoDepthStencilFormat, D3DMULTISAMPLE_NONE, &s_customDepth);
-	if (FAILED(hr)) {
-		fprintf(stderr, "WARN: Pillarbox: CreateDepthStencilSurface failed hr=0x%lx\n", (unsigned long)hr);
-		s_offscreenSurf->Release(); s_offscreenSurf = nullptr;
-		s_offscreenTex->Release(); s_offscreenTex = nullptr;
-		return;
-	}
-
-	s_pillarboxEnabled = true;
-	fprintf(stderr, "INFO: Pillarbox windowed: game=%dx%d, backbuffer=%dx%d, density=%.1f\n",
-		ResolutionWidth, ResolutionHeight, physW, physH, density);
+	Pillarbox_Setup(ResolutionWidth, ResolutionHeight);
 }
 
 /***********************************************************************************
@@ -1583,10 +1559,7 @@ bool DX8Wrapper::Set_Device_Resolution(int width,int height,int bits,int windowe
 #pragma message("TODO: support changing windowed status and changing the bit depth")
 		WWDEBUG_SAY(("DX8Wrapper::Set_Device_Resolution is resetting the device."));
 		bool ok = Reset_Device();
-		if (ok) {
-			Pillarbox_Setup(ResolutionWidth, ResolutionHeight);
-			if (IsWindowed) s_resizePending = true;  // re-trigger windowed pillarbox
-		}
+		if (ok) Pillarbox_Setup(ResolutionWidth, ResolutionHeight);
 		return ok;
 	} else {
 		return false;
@@ -2004,20 +1977,11 @@ void DX8Wrapper::End_Scene(bool flip_frames)
 {
 	DX8_THREAD_ASSERT();
 
-	// Pillarbox: blit offscreen RT centered onto backbuffer (only during main render pass)
+	// Pillarbox: restore backbuffer + blit offscreen, all within the current scene
 	if (s_pillarboxActive && s_offscreenTex) {
-		s_pillarboxActive = false;
-		Pillarbox_End();
-		DX8CALL(EndScene());
-		DX8CALL(BeginScene());
-		Pillarbox_Blit();
-		DX8CALL(EndScene());
-		// The blit changed D3D render states (ZENABLE=FALSE, etc.) directly,
-		// bypassing DX8Wrapper's cache. Invalidate so next frame resends all states.
-		Invalidate_Cached_Render_States();
-	} else {
-		DX8CALL(EndScene());
+		Pillarbox_End();  // restores backbuffer, blits, invalidates cache
 	}
+	DX8CALL(EndScene());
 
 	// GeneralsX @build BenderAI 10/02/2026 - Embedded browser Windows-only
 #ifdef _WIN32

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -111,7 +111,6 @@ static D3DPRESENT_PARAMETERS _PresentParameters;
 // GeneralsX @feature xxorza 15/04/2026 Unified pillarbox for fullscreen and windowed
 bool DX8Wrapper::s_pillarboxEnabled = false;
 bool DX8Wrapper::s_pillarboxActive = false;
-bool DX8Wrapper::s_resizePending = false;
 int DX8Wrapper::s_dstX = 0;
 int DX8Wrapper::s_dstY = 0;
 int DX8Wrapper::s_dstW = 0;
@@ -306,10 +305,6 @@ bool DX8Wrapper::Pillarbox_Get_Rect(int& x, int& y, int& w, int& h)
 	return true;
 }
 
-void DX8Wrapper::Pillarbox_Notify_Resize()
-{
-	if (IsWindowed) s_resizePending = true;
-}
 
 DX8FrameStatistics DX8Wrapper::FrameStatistics;
 static DX8FrameStatistics LastFrameStatistics;
@@ -405,17 +400,18 @@ DX8_CleanupHook	 *DX8Wrapper::m_pCleanupHook=nullptr;
 #ifdef EXTENDED_STATS
 DX8_Stats	 DX8Wrapper::stats;
 #endif
+// Called once per frame from W3DDisplay::draw(). Checks if the window size
+// changed since last frame and reconfigures pillarbox accordingly.
 void DX8Wrapper::Pillarbox_Process_Resize()
 {
-	if (!s_resizePending || !IsWindowed || !D3DDevice) return;
-	s_resizePending = false;
+	if (!IsWindowed || !D3DDevice) return;
 
 	int physW = 0, physH = 0;
 	float density = 1.0f;
 	if (!GetWindowSizeInPixels(physW, physH, density)) return;
 
-	if (s_pillarboxEnabled &&
-		(int)_PresentParameters.BackBufferWidth == physW &&
+	// Nothing to do if backbuffer already matches window
+	if ((int)_PresentParameters.BackBufferWidth == physW &&
 		(int)_PresentParameters.BackBufferHeight == physH) return;
 
 	Pillarbox_Cleanup();
@@ -1566,10 +1562,7 @@ bool DX8Wrapper::Set_Device_Resolution(int width,int height,int bits,int windowe
 #pragma message("TODO: support changing windowed status and changing the bit depth")
 		WWDEBUG_SAY(("DX8Wrapper::Set_Device_Resolution is resetting the device."));
 		bool ok = Reset_Device();
-		if (ok) {
-			Pillarbox_Setup(ResolutionWidth, ResolutionHeight);
-			if (IsWindowed) s_resizePending = true;
-		}
+		if (ok) Pillarbox_Setup(ResolutionWidth, ResolutionHeight);
 		return ok;
 	} else {
 		return false;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -235,25 +235,26 @@ void DX8Wrapper::Pillarbox_End()
 	D3DDevice->SetViewport(&vp);
 	D3DDevice->Clear(0, nullptr, D3DCLEAR_TARGET, 0x00000000, 1.0f, 0);
 
+	// Use DX8Wrapper's cached state setters so the cache stays in sync — no invalidation needed.
 	D3DDevice->SetTexture(0, s_offscreenTex);
-	D3DDevice->SetRenderState(D3DRS_ZENABLE, FALSE);
-	D3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
-	D3DDevice->SetRenderState(D3DRS_LIGHTING, FALSE);
-	D3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
-	D3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
-	D3DDevice->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
-	D3DDevice->SetRenderState(D3DRS_FOGENABLE, FALSE);
-	D3DDevice->SetRenderState(D3DRS_STENCILENABLE, FALSE);
-	D3DDevice->SetRenderState(D3DRS_COLORWRITEENABLE, 0xF);
-	D3DDevice->SetRenderState(D3DRS_CLIPPING, FALSE);
-	D3DDevice->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
-	D3DDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
-	D3DDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_SELECTARG1);
-	D3DDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
+	Set_DX8_Render_State(D3DRS_ZENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_ZWRITEENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_LIGHTING, FALSE);
+	Set_DX8_Render_State(D3DRS_ALPHABLENDENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_ALPHATESTENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_CULLMODE, D3DCULL_NONE);
+	Set_DX8_Render_State(D3DRS_FOGENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_STENCILENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_COLORWRITEENABLE, 0xF);
+	Set_DX8_Render_State(D3DRS_CLIPPING, FALSE);
+	Set_DX8_Texture_Stage_State(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
+	Set_DX8_Texture_Stage_State(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
+	Set_DX8_Texture_Stage_State(0, D3DTSS_COLOROP, D3DTOP_SELECTARG1);
+	Set_DX8_Texture_Stage_State(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
 	DWORD filterMode = (s_dstW == ResolutionWidth && s_dstH == ResolutionHeight)
 		? D3DTEXF_POINT : D3DTEXF_LINEAR;
-	D3DDevice->SetTextureStageState(0, D3DTSS_MINFILTER, filterMode);
-	D3DDevice->SetTextureStageState(0, D3DTSS_MAGFILTER, filterMode);
+	Set_DX8_Texture_Stage_State(0, D3DTSS_MINFILTER, filterMode);
+	Set_DX8_Texture_Stage_State(0, D3DTSS_MAGFILTER, filterMode);
 
 	// D3D8 half-pixel offset: XYZRHW vertices need -0.5 for exact texel-to-pixel alignment
 	float x0 = (float)s_dstX - 0.5f, y0 = (float)s_dstY - 0.5f;
@@ -266,8 +267,6 @@ void DX8Wrapper::Pillarbox_End()
 	D3DDevice->SetVertexShader(D3DFVF_XYZRHW | D3DFVF_TEX1);
 	D3DDevice->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, quad, sizeof(BV));
 	D3DDevice->SetTexture(0, nullptr);
-
-	Invalidate_Cached_Render_States();
 }
 
 bool DX8Wrapper::Pillarbox_Get_Rect(int& x, int& y, int& w, int& h)
@@ -688,6 +687,12 @@ void DX8Wrapper::Invalidate_Cached_Render_States()
 
 	// (gth) clear the matrix shadows too
 	memset(&DX8Transforms, 0, sizeof(DX8Transforms));
+}
+
+void DX8Wrapper::Set_Transform_Dirty()
+{
+	memset(&DX8Transforms, 0, sizeof(DX8Transforms));
+	render_state_changed |= (unsigned)(WORLD_CHANGED | VIEW_CHANGED);
 }
 
 void DX8Wrapper::Do_Onetime_Device_Dependent_Shutdowns()

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -57,6 +57,9 @@
 #ifndef _WIN32
 #include <dlfcn.h>
 #endif
+#ifdef SAGE_USE_SDL3
+#include <SDL3/SDL.h>
+#endif
 // GeneralsX @build BenderAI 10/02/2026 - Embedded browser Windows-only (requires COM LPDISPATCH)
 #ifdef _WIN32
 #include "dx8webbrowser.h"
@@ -101,6 +104,169 @@ const int DEFAULT_RESOLUTION_HEIGHT = 480;
 const int DEFAULT_BIT_DEPTH = 32;
 const int DEFAULT_TEXTURE_BIT_DEPTH = 16;
 const D3DMULTISAMPLE_TYPE DEFAULT_MSAA = D3DMULTISAMPLE_NONE;
+
+// --- Pillarbox static member initialization ---
+bool DX8Wrapper::s_pillarboxEnabled = false;
+bool DX8Wrapper::s_pillarboxActive = false;
+int DX8Wrapper::s_nativeW = 0;
+int DX8Wrapper::s_nativeH = 0;
+int DX8Wrapper::s_dstX = 0;
+int DX8Wrapper::s_dstY = 0;
+int DX8Wrapper::s_dstW = 0;
+int DX8Wrapper::s_dstH = 0;
+float DX8Wrapper::s_pixelDensity = 1.0f;
+IDirect3DTexture8* DX8Wrapper::s_offscreenTex = nullptr;
+IDirect3DSurface8* DX8Wrapper::s_offscreenSurf = nullptr;
+IDirect3DSurface8* DX8Wrapper::s_savedBackbuffer = nullptr;
+IDirect3DSurface8* DX8Wrapper::s_savedAutoDepth = nullptr;
+
+bool DX8Wrapper::GetNativeDisplaySize(int& outW, int& outH, float& outDensity)
+{
+#ifdef SAGE_USE_SDL3
+	extern SDL_Window* TheSDL3Window;
+	if (!TheSDL3Window) return false;
+	SDL_DisplayID displayId = SDL_GetDisplayForWindow(TheSDL3Window);
+	const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(displayId);
+	if (!mode || mode->w <= 0 || mode->h <= 0) return false;
+	outDensity = mode->pixel_density > 0 ? mode->pixel_density : 1.0f;
+	outW = (int)(mode->w * outDensity);
+	outH = (int)(mode->h * outDensity);
+	return true;
+#else
+	return false;
+#endif
+}
+
+void DX8Wrapper::Pillarbox_Cleanup()
+{
+	if (s_savedBackbuffer) { s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr; }
+	if (s_savedAutoDepth) { s_savedAutoDepth->Release(); s_savedAutoDepth = nullptr; }
+	if (s_offscreenSurf) { s_offscreenSurf->Release(); s_offscreenSurf = nullptr; }
+	if (s_offscreenTex) { s_offscreenTex->Release(); s_offscreenTex = nullptr; }
+	s_pillarboxEnabled = false;
+	s_pillarboxActive = false;
+}
+
+bool DX8Wrapper::Pillarbox_Setup(int gameW, int gameH)
+{
+	Pillarbox_Cleanup();
+
+	if (IsWindowed) return false;  // windowed mode: user controls window shape
+	if (!GetNativeDisplaySize(s_nativeW, s_nativeH, s_pixelDensity)) return false;
+
+	// Initial dest rect (will be recomputed dynamically in Pillarbox_Blit)
+	s_dstX = 0; s_dstY = 0;
+	s_dstW = s_nativeW; s_dstH = s_nativeH;
+
+	HRESULT hr = D3DDevice->CreateTexture(gameW, gameH, 1, D3DUSAGE_RENDERTARGET,
+		D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &s_offscreenTex);
+	if (FAILED(hr)) return false;
+	s_offscreenTex->GetSurfaceLevel(0, &s_offscreenSurf);
+
+	s_pillarboxEnabled = true;
+	fprintf(stderr, "INFO: Pillarbox: game=%dx%d, backbuffer=%dx%d, density=%.1f\n",
+		gameW, gameH, s_nativeW, s_nativeH, s_pixelDensity);
+	return true;
+}
+
+void DX8Wrapper::Pillarbox_Blit()
+{
+	// Get actual backbuffer size (may differ from s_nativeW/H in windowed mode after resize)
+	IDirect3DSurface8* bb = nullptr;
+	D3DDevice->GetBackBuffer(0, D3DBACKBUFFER_TYPE_MONO, &bb);
+	int bbW = s_nativeW, bbH = s_nativeH;
+	if (bb) {
+		D3DSURFACE_DESC desc;
+		if (SUCCEEDED(bb->GetDesc(&desc))) { bbW = desc.Width; bbH = desc.Height; }
+		bb->Release();
+	}
+
+	// Compute aspect-correct fit rect (pillarbox OR letterbox depending on shape)
+	float gameAspect = (float)ResolutionWidth / (float)ResolutionHeight;
+	float bbAspect = (float)bbW / (float)bbH;
+	if (bbAspect > gameAspect) {
+		// Wider than game — pillarbox (bars on sides)
+		s_dstW = (int)(bbH * gameAspect);
+		s_dstH = bbH;
+		s_dstX = (bbW - s_dstW) / 2;
+		s_dstY = 0;
+	} else {
+		// Taller than game — letterbox (bars on top/bottom)
+		s_dstW = bbW;
+		s_dstH = (int)(bbW / gameAspect);
+		s_dstX = 0;
+		s_dstY = (bbH - s_dstH) / 2;
+	}
+	s_nativeW = bbW;
+	s_nativeH = bbH;
+
+	D3DVIEWPORT8 vp = {0, 0, (DWORD)bbW, (DWORD)bbH, 0.0f, 1.0f};
+	D3DDevice->SetViewport(&vp);
+	D3DDevice->Clear(0, nullptr, D3DCLEAR_TARGET, 0x00000000, 1.0f, 0);
+
+	D3DDevice->SetTexture(0, s_offscreenTex);
+	D3DDevice->SetRenderState(D3DRS_ZENABLE, FALSE);
+	D3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+	D3DDevice->SetRenderState(D3DRS_LIGHTING, FALSE);
+	D3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
+	D3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+	D3DDevice->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
+	D3DDevice->SetRenderState(D3DRS_FOGENABLE, FALSE);
+	D3DDevice->SetRenderState(D3DRS_STENCILENABLE, FALSE);
+	D3DDevice->SetRenderState(D3DRS_COLORWRITEENABLE, 0xF);
+	D3DDevice->SetRenderState(D3DRS_CLIPPING, FALSE);
+	D3DDevice->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
+	D3DDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
+	D3DDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_SELECTARG1);
+	D3DDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
+	D3DDevice->SetTextureStageState(0, D3DTSS_MINFILTER, D3DTEXF_LINEAR);
+	D3DDevice->SetTextureStageState(0, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
+
+	float x0 = (float)s_dstX, y0 = (float)s_dstY;
+	float x1 = (float)(s_dstX + s_dstW), y1 = (float)(s_dstY + s_dstH);
+	struct BV { float x, y, z, rhw; float u, v; };
+	BV quad[4] = {
+		{x0, y0, 0, 1, 0, 0}, {x1, y0, 0, 1, 1, 0},
+		{x0, y1, 0, 1, 0, 1}, {x1, y1, 0, 1, 1, 1},
+	};
+	D3DDevice->SetVertexShader(D3DFVF_XYZRHW | D3DFVF_TEX1);
+	D3DDevice->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, quad, sizeof(BV));
+	D3DDevice->SetTexture(0, nullptr);
+}
+
+void DX8Wrapper::Pillarbox_Begin()
+{
+	if (!s_pillarboxEnabled || !s_offscreenSurf) return;
+	// Save backbuffer + depth for restoration in Pillarbox_End
+	if (s_savedBackbuffer) { s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr; }
+	if (s_savedAutoDepth) { s_savedAutoDepth->Release(); s_savedAutoDepth = nullptr; }
+	D3DDevice->GetRenderTarget(&s_savedBackbuffer);
+	D3DDevice->GetDepthStencilSurface(&s_savedAutoDepth);
+	D3DDevice->SetRenderTarget(s_offscreenSurf, s_savedAutoDepth);
+	// Force depth states after RT switch. The blit from the previous frame set
+	// ZENABLE=FALSE directly on D3D, bypassing DX8Wrapper's cache.
+	D3DDevice->SetRenderState(D3DRS_ZENABLE, TRUE);
+	D3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+	D3DDevice->SetRenderState(D3DRS_ZFUNC, D3DCMP_LESSEQUAL);
+	s_pillarboxActive = true;
+}
+
+void DX8Wrapper::Pillarbox_End()
+{
+	if (!s_pillarboxEnabled || !s_savedBackbuffer) return;
+	D3DDevice->SetRenderTarget(s_savedBackbuffer, s_savedAutoDepth);
+	s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr;
+	if (s_savedAutoDepth) { s_savedAutoDepth->Release(); s_savedAutoDepth = nullptr; }
+}
+
+bool DX8Wrapper::Pillarbox_Get_Rect(int& x, int& w, int& h)
+{
+	if (!s_pillarboxEnabled) return false;
+	x = (int)(s_dstX / s_pixelDensity);
+	w = (int)(s_dstW / s_pixelDensity);
+	h = (int)(s_dstH / s_pixelDensity);
+	return true;
+}
 
 DX8FrameStatistics DX8Wrapper::FrameStatistics;
 static DX8FrameStatistics LastFrameStatistics;
@@ -1017,8 +1183,17 @@ bool DX8Wrapper::Set_Render_Device(int dev, int width, int height, int bits, int
 	*/
 	::ZeroMemory(&_PresentParameters, sizeof(D3DPRESENT_PARAMETERS));
 
+	// In fullscreen, set backbuffer to native display size for pillarbox rendering.
 	_PresentParameters.BackBufferWidth = ResolutionWidth;
 	_PresentParameters.BackBufferHeight = ResolutionHeight;
+	if (!IsWindowed) {
+		int nativeW, nativeH;
+		float density;
+		if (GetNativeDisplaySize(nativeW, nativeH, density)) {
+			_PresentParameters.BackBufferWidth = nativeW;
+			_PresentParameters.BackBufferHeight = nativeH;
+		}
+	}
 	_PresentParameters.BackBufferCount = IsWindowed ? 1 : 2;
 
 	//I changed this to discard all the time (even when full-screen) since that the most efficient. 07-16-03 MW:
@@ -1162,6 +1337,7 @@ bool DX8Wrapper::Set_Render_Device(int dev, int width, int height, int bits, int
 	if (ret)
 	{
 		Render2DClass::Set_Screen_Resolution( RectClass( 0, 0, ResolutionWidth, ResolutionHeight ) );
+		Pillarbox_Setup(ResolutionWidth, ResolutionHeight);
 	}
 
 	return ret;
@@ -1289,11 +1465,21 @@ bool DX8Wrapper::Set_Device_Resolution(int width,int height,int bits,int windowe
 {
 	if (D3DDevice != nullptr) {
 
-		if (width != -1) {
-			_PresentParameters.BackBufferWidth = ResolutionWidth = width;
-		}
-		if (height != -1) {
-			_PresentParameters.BackBufferHeight = ResolutionHeight = height;
+		if (width != -1) ResolutionWidth = width;
+		if (height != -1) ResolutionHeight = height;
+
+		_PresentParameters.BackBufferWidth = ResolutionWidth;
+		_PresentParameters.BackBufferHeight = ResolutionHeight;
+
+		// Release pillarbox RT before device reset
+		Pillarbox_Cleanup();
+		if (!IsWindowed) {
+			int nativeW, nativeH;
+			float density;
+			if (GetNativeDisplaySize(nativeW, nativeH, density)) {
+				_PresentParameters.BackBufferWidth = nativeW;
+				_PresentParameters.BackBufferHeight = nativeH;
+			}
 		}
 		if (resize_window)
 		{
@@ -1301,7 +1487,9 @@ bool DX8Wrapper::Set_Device_Resolution(int width,int height,int bits,int windowe
 		}
 #pragma message("TODO: support changing windowed status and changing the bit depth")
 		WWDEBUG_SAY(("DX8Wrapper::Set_Device_Resolution is resetting the device."));
-		return Reset_Device();
+		bool ok = Reset_Device();
+		if (ok) Pillarbox_Setup(ResolutionWidth, ResolutionHeight);
+		return ok;
 	} else {
 		return false;
 	}
@@ -1717,7 +1905,21 @@ void DX8Wrapper::Begin_Scene()
 void DX8Wrapper::End_Scene(bool flip_frames)
 {
 	DX8_THREAD_ASSERT();
-	DX8CALL(EndScene());
+
+	// Pillarbox: blit offscreen RT centered onto backbuffer (only during main render pass)
+	if (s_pillarboxActive && s_offscreenTex) {
+		s_pillarboxActive = false;
+		Pillarbox_End();
+		DX8CALL(EndScene());
+		DX8CALL(BeginScene());
+		Pillarbox_Blit();
+		DX8CALL(EndScene());
+		// The blit changed D3D render states (ZENABLE=FALSE, etc.) directly,
+		// bypassing DX8Wrapper's cache. Invalidate so next frame resends all states.
+		Invalidate_Cached_Render_States();
+	} else {
+		DX8CALL(EndScene());
+	}
 
 	// GeneralsX @build BenderAI 10/02/2026 - Embedded browser Windows-only
 #ifdef _WIN32

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -57,9 +57,6 @@
 #ifndef _WIN32
 #include <dlfcn.h>
 #endif
-#ifdef SAGE_USE_SDL3
-#include <SDL3/SDL.h>
-#endif
 // GeneralsX @build BenderAI 10/02/2026 - Embedded browser Windows-only (requires COM LPDISPATCH)
 #ifdef _WIN32
 #include "dx8webbrowser.h"
@@ -109,6 +106,8 @@ static D3DPRESENT_PARAMETERS _PresentParameters;
 
 // --- Pillarbox: render game to offscreen RT, blit centered onto backbuffer ---
 // GeneralsX @feature xxorza 15/04/2026 Unified pillarbox for fullscreen and windowed
+DX8Wrapper::DisplaySizeFunc DX8Wrapper::s_getNativeDisplaySize = nullptr;
+DX8Wrapper::DisplaySizeFunc DX8Wrapper::s_getWindowSize = nullptr;
 bool DX8Wrapper::s_pillarboxEnabled = false;
 bool DX8Wrapper::s_pillarboxActive = false;
 int DX8Wrapper::s_dstX = 0;
@@ -122,39 +121,20 @@ IDirect3DSurface8* DX8Wrapper::s_depthSurf = nullptr;
 IDirect3DSurface8* DX8Wrapper::s_savedBackbuffer = nullptr;
 IDirect3DSurface8* DX8Wrapper::s_savedDepth = nullptr;
 
-bool DX8Wrapper::GetNativeDisplaySize(int& outW, int& outH, float& outDensity)
+void DX8Wrapper::Set_Display_Size_Provider(DisplaySizeFunc nativeSize, DisplaySizeFunc windowSize)
 {
-#ifdef SAGE_USE_SDL3
-	extern SDL_Window* TheSDL3Window;
-	if (!TheSDL3Window) return false;
-	SDL_DisplayID displayId = SDL_GetDisplayForWindow(TheSDL3Window);
-	const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(displayId);
-	if (!mode || mode->w <= 0 || mode->h <= 0) return false;
-	outDensity = mode->pixel_density > 0 ? mode->pixel_density : 1.0f;
-	outW = (int)(mode->w * outDensity);
-	outH = (int)(mode->h * outDensity);
-	return true;
-#else
-	return false;
-#endif
+	s_getNativeDisplaySize = nativeSize;
+	s_getWindowSize = windowSize;
 }
 
-static bool GetWindowSizeInPixels(int& outW, int& outH, float& outDensity)
+bool DX8Wrapper::GetNativeDisplaySize(int& outW, int& outH, float& outDensity)
 {
-#ifdef SAGE_USE_SDL3
-	extern SDL_Window* TheSDL3Window;
-	if (!TheSDL3Window) return false;
-	int logW = 0, logH = 0, physW = 0, physH = 0;
-	SDL_GetWindowSize(TheSDL3Window, &logW, &logH);
-	SDL_GetWindowSizeInPixels(TheSDL3Window, &physW, &physH);
-	if (physW <= 0 || physH <= 0) return false;
-	outW = physW;
-	outH = physH;
-	outDensity = (logW > 0) ? (float)physW / (float)logW : 1.0f;
-	return true;
-#else
-	return false;
-#endif
+	return s_getNativeDisplaySize && s_getNativeDisplaySize(outW, outH, outDensity);
+}
+
+bool DX8Wrapper::GetWindowSize(int& outW, int& outH, float& outDensity)
+{
+	return s_getWindowSize && s_getWindowSize(outW, outH, outDensity);
 }
 
 void DX8Wrapper::Pillarbox_Cleanup()
@@ -178,7 +158,7 @@ bool DX8Wrapper::Pillarbox_Setup(int gameW, int gameH)
 	if (!IsWindowed) {
 		if (!GetNativeDisplaySize(bbW, bbH, density)) return false;
 	} else {
-		if (!GetWindowSizeInPixels(bbW, bbH, density)) {
+		if (!GetWindowSize(bbW, bbH, density)) {
 			bbW = gameW; bbH = gameH; density = 1.0f;
 		}
 	}
@@ -408,7 +388,7 @@ void DX8Wrapper::Pillarbox_Process_Resize()
 
 	int physW = 0, physH = 0;
 	float density = 1.0f;
-	if (!GetWindowSizeInPixels(physW, physH, density)) return;
+	if (!GetWindowSize(physW, physH, density)) return;
 
 	// Nothing to do if backbuffer already matches window
 	if ((int)_PresentParameters.BackBufferWidth == physW &&

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -110,6 +110,8 @@ DX8Wrapper::DisplaySizeFunc DX8Wrapper::s_getNativeDisplaySize = nullptr;
 DX8Wrapper::DisplaySizeFunc DX8Wrapper::s_getWindowSize = nullptr;
 bool DX8Wrapper::s_pillarboxEnabled = false;
 bool DX8Wrapper::s_pillarboxActive = false;
+int DX8Wrapper::s_bbW = 0;
+int DX8Wrapper::s_bbH = 0;
 int DX8Wrapper::s_dstX = 0;
 int DX8Wrapper::s_dstY = 0;
 int DX8Wrapper::s_dstW = 0;
@@ -181,9 +183,18 @@ bool DX8Wrapper::Pillarbox_Setup(int gameW, int gameH)
 		return false;
 	}
 
+	// Cache backbuffer size and compute aspect-correct fit rect once
+	s_bbW = bbW; s_bbH = bbH;
 	s_pixelDensity = density;
-	s_dstX = 0; s_dstY = 0;
-	s_dstW = bbW; s_dstH = bbH;
+	float gameAspect = (float)gameW / (float)gameH;
+	float bbAspect = (float)bbW / (float)bbH;
+	if (bbAspect > gameAspect) {
+		s_dstW = (int)(bbH * gameAspect); s_dstH = bbH;
+		s_dstX = (bbW - s_dstW) / 2; s_dstY = 0;
+	} else {
+		s_dstW = bbW; s_dstH = (int)(bbW / gameAspect);
+		s_dstX = 0; s_dstY = (bbH - s_dstH) / 2;
+	}
 	s_pillarboxEnabled = true;
 	fprintf(stderr, "INFO: Pillarbox: game=%dx%d, backbuffer=%dx%d, windowed=%d\n",
 		gameW, gameH, bbW, bbH, IsWindowed ? 1 : 0);
@@ -219,27 +230,8 @@ void DX8Wrapper::Pillarbox_End()
 	s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr;
 	if (s_savedDepth) { s_savedDepth->Release(); s_savedDepth = nullptr; }
 
-	// Blit offscreen texture centered onto backbuffer
-	IDirect3DSurface8* bb = nullptr;
-	D3DDevice->GetBackBuffer(0, D3DBACKBUFFER_TYPE_MONO, &bb);
-	int bbW = s_dstW, bbH = s_dstH;
-	if (bb) {
-		D3DSURFACE_DESC desc;
-		if (SUCCEEDED(bb->GetDesc(&desc))) { bbW = desc.Width; bbH = desc.Height; }
-		bb->Release();
-	}
-
-	float gameAspect = (float)ResolutionWidth / (float)ResolutionHeight;
-	float bbAspect = (float)bbW / (float)bbH;
-	if (bbAspect > gameAspect) {
-		s_dstW = (int)(bbH * gameAspect); s_dstH = bbH;
-		s_dstX = (bbW - s_dstW) / 2; s_dstY = 0;
-	} else {
-		s_dstW = bbW; s_dstH = (int)(bbW / gameAspect);
-		s_dstX = 0; s_dstY = (bbH - s_dstH) / 2;
-	}
-
-	D3DVIEWPORT8 vp = {0, 0, (DWORD)bbW, (DWORD)bbH, 0.0f, 1.0f};
+	// Blit offscreen texture centered onto backbuffer (fit rect cached in Pillarbox_Setup)
+	D3DVIEWPORT8 vp = {0, 0, (DWORD)s_bbW, (DWORD)s_bbH, 0.0f, 1.0f};
 	D3DDevice->SetViewport(&vp);
 	D3DDevice->Clear(0, nullptr, D3DCLEAR_TARGET, 0x00000000, 1.0f, 0);
 
@@ -258,14 +250,14 @@ void DX8Wrapper::Pillarbox_End()
 	D3DDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
 	D3DDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_SELECTARG1);
 	D3DDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
-	// Use point filtering when 1:1 pixel mapping to avoid sub-pixel blur
 	DWORD filterMode = (s_dstW == ResolutionWidth && s_dstH == ResolutionHeight)
 		? D3DTEXF_POINT : D3DTEXF_LINEAR;
 	D3DDevice->SetTextureStageState(0, D3DTSS_MINFILTER, filterMode);
 	D3DDevice->SetTextureStageState(0, D3DTSS_MAGFILTER, filterMode);
 
-	float x0 = (float)s_dstX, y0 = (float)s_dstY;
-	float x1 = (float)(s_dstX + s_dstW), y1 = (float)(s_dstY + s_dstH);
+	// D3D8 half-pixel offset: XYZRHW vertices need -0.5 for exact texel-to-pixel alignment
+	float x0 = (float)s_dstX - 0.5f, y0 = (float)s_dstY - 0.5f;
+	float x1 = (float)(s_dstX + s_dstW) - 0.5f, y1 = (float)(s_dstY + s_dstH) - 0.5f;
 	struct BV { float x, y, z, rhw; float u, v; };
 	BV quad[4] = {
 		{x0, y0, 0, 1, 0, 0}, {x1, y0, 0, 1, 1, 0},
@@ -287,7 +279,6 @@ bool DX8Wrapper::Pillarbox_Get_Rect(int& x, int& y, int& w, int& h)
 	h = (int)(s_dstH / s_pixelDensity);
 	return true;
 }
-
 
 DX8FrameStatistics DX8Wrapper::FrameStatistics;
 static DX8FrameStatistics LastFrameStatistics;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -258,8 +258,11 @@ void DX8Wrapper::Pillarbox_End()
 	D3DDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
 	D3DDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_SELECTARG1);
 	D3DDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
-	D3DDevice->SetTextureStageState(0, D3DTSS_MINFILTER, D3DTEXF_LINEAR);
-	D3DDevice->SetTextureStageState(0, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
+	// Use point filtering when 1:1 pixel mapping to avoid sub-pixel blur
+	DWORD filterMode = (s_dstW == ResolutionWidth && s_dstH == ResolutionHeight)
+		? D3DTEXF_POINT : D3DTEXF_LINEAR;
+	D3DDevice->SetTextureStageState(0, D3DTSS_MINFILTER, filterMode);
+	D3DDevice->SetTextureStageState(0, D3DTSS_MAGFILTER, filterMode);
 
 	float x0 = (float)s_dstX, y0 = (float)s_dstY;
 	float x1 = (float)(s_dstX + s_dstW), y1 = (float)(s_dstY + s_dstH);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -108,6 +108,7 @@ const D3DMULTISAMPLE_TYPE DEFAULT_MSAA = D3DMULTISAMPLE_NONE;
 // --- Pillarbox static member initialization ---
 bool DX8Wrapper::s_pillarboxEnabled = false;
 bool DX8Wrapper::s_pillarboxActive = false;
+bool DX8Wrapper::s_resizePending = false;
 int DX8Wrapper::s_nativeW = 0;
 int DX8Wrapper::s_nativeH = 0;
 int DX8Wrapper::s_dstX = 0;
@@ -117,6 +118,7 @@ int DX8Wrapper::s_dstH = 0;
 float DX8Wrapper::s_pixelDensity = 1.0f;
 IDirect3DTexture8* DX8Wrapper::s_offscreenTex = nullptr;
 IDirect3DSurface8* DX8Wrapper::s_offscreenSurf = nullptr;
+IDirect3DSurface8* DX8Wrapper::s_customDepth = nullptr;
 IDirect3DSurface8* DX8Wrapper::s_savedBackbuffer = nullptr;
 IDirect3DSurface8* DX8Wrapper::s_savedAutoDepth = nullptr;
 
@@ -141,17 +143,36 @@ void DX8Wrapper::Pillarbox_Cleanup()
 {
 	if (s_savedBackbuffer) { s_savedBackbuffer->Release(); s_savedBackbuffer = nullptr; }
 	if (s_savedAutoDepth) { s_savedAutoDepth->Release(); s_savedAutoDepth = nullptr; }
+	if (s_customDepth) { s_customDepth->Release(); s_customDepth = nullptr; }
 	if (s_offscreenSurf) { s_offscreenSurf->Release(); s_offscreenSurf = nullptr; }
 	if (s_offscreenTex) { s_offscreenTex->Release(); s_offscreenTex = nullptr; }
 	s_pillarboxEnabled = false;
 	s_pillarboxActive = false;
 }
 
+static bool GetWindowSizeInPixels(int& outW, int& outH, float& outDensity)
+{
+#ifdef SAGE_USE_SDL3
+	extern SDL_Window* TheSDL3Window;
+	if (!TheSDL3Window) return false;
+	int logW = 0, logH = 0, physW = 0, physH = 0;
+	SDL_GetWindowSize(TheSDL3Window, &logW, &logH);
+	SDL_GetWindowSizeInPixels(TheSDL3Window, &physW, &physH);
+	if (physW <= 0 || physH <= 0) return false;
+	outW = physW;
+	outH = physH;
+	outDensity = (logW > 0) ? (float)physW / (float)logW : 1.0f;
+	return true;
+#else
+	return false;
+#endif
+}
+
 bool DX8Wrapper::Pillarbox_Setup(int gameW, int gameH)
 {
 	Pillarbox_Cleanup();
 
-	if (IsWindowed) return false;  // windowed mode: user controls window shape
+	if (IsWindowed) return false;  // Windowed pillarbox enabled on resize via Pillarbox_Handle_Resize
 	if (!GetNativeDisplaySize(s_nativeW, s_nativeH, s_pixelDensity)) return false;
 
 	// Initial dest rect (will be recomputed dynamically in Pillarbox_Blit)
@@ -242,7 +263,9 @@ void DX8Wrapper::Pillarbox_Begin()
 	if (s_savedAutoDepth) { s_savedAutoDepth->Release(); s_savedAutoDepth = nullptr; }
 	D3DDevice->GetRenderTarget(&s_savedBackbuffer);
 	D3DDevice->GetDepthStencilSurface(&s_savedAutoDepth);
-	D3DDevice->SetRenderTarget(s_offscreenSurf, s_savedAutoDepth);
+	// Use custom depth if available (windowed: game-res depth), else auto depth (fullscreen)
+	IDirect3DSurface8* depthForOffscreen = s_customDepth ? s_customDepth : s_savedAutoDepth;
+	D3DDevice->SetRenderTarget(s_offscreenSurf, depthForOffscreen);
 	// Force depth states after RT switch. The blit from the previous frame set
 	// ZENABLE=FALSE directly on D3D, bypassing DX8Wrapper's cache.
 	D3DDevice->SetRenderState(D3DRS_ZENABLE, TRUE);
@@ -259,10 +282,11 @@ void DX8Wrapper::Pillarbox_End()
 	if (s_savedAutoDepth) { s_savedAutoDepth->Release(); s_savedAutoDepth = nullptr; }
 }
 
-bool DX8Wrapper::Pillarbox_Get_Rect(int& x, int& w, int& h)
+bool DX8Wrapper::Pillarbox_Get_Rect(int& x, int& y, int& w, int& h)
 {
 	if (!s_pillarboxEnabled) return false;
 	x = (int)(s_dstX / s_pixelDensity);
+	y = (int)(s_dstY / s_pixelDensity);
 	w = (int)(s_dstW / s_pixelDensity);
 	h = (int)(s_dstH / s_pixelDensity);
 	return true;
@@ -363,6 +387,70 @@ DX8_CleanupHook	 *DX8Wrapper::m_pCleanupHook=nullptr;
 #ifdef EXTENDED_STATS
 DX8_Stats	 DX8Wrapper::stats;
 #endif
+// GeneralsX @feature xxorza 15/04/2026 Pillarbox resize handling for windowed mode
+void DX8Wrapper::Pillarbox_Handle_Resize(int windowW, int windowH)
+{
+	if (!IsWindowed || !D3DDevice) return;
+
+	// When called from SDL event handler (windowW > 0), just mark pending
+	if (windowW > 0) {
+		s_resizePending = true;
+		return;
+	}
+
+	// When called from draw loop (windowW == 0), process pending resize
+	if (!s_resizePending) return;
+	s_resizePending = false;
+
+	int physW = 0, physH = 0;
+	float density = 1.0f;
+	if (!GetWindowSizeInPixels(physW, physH, density)) return;
+
+	// Skip if backbuffer already matches
+	if (s_pillarboxEnabled &&
+		(int)_PresentParameters.BackBufferWidth == physW &&
+		(int)_PresentParameters.BackBufferHeight == physH) return;
+
+	Pillarbox_Cleanup();
+
+	_PresentParameters.BackBufferWidth = physW;
+	_PresentParameters.BackBufferHeight = physH;
+
+	if (!Reset_Device()) {
+		_PresentParameters.BackBufferWidth = ResolutionWidth;
+		_PresentParameters.BackBufferHeight = ResolutionHeight;
+		Reset_Device();
+		return;
+	}
+
+	// Create offscreen RT at game resolution with its own depth stencil.
+	// The auto depth stencil is window-sized (possibly smaller than game res),
+	// so we create a separate depth surface at game resolution.
+	s_nativeW = physW;
+	s_nativeH = physH;
+	s_pixelDensity = density;
+	s_dstX = 0; s_dstY = 0;
+	s_dstW = physW; s_dstH = physH;
+
+	HRESULT hr = D3DDevice->CreateTexture(ResolutionWidth, ResolutionHeight, 1,
+		D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &s_offscreenTex);
+	if (FAILED(hr)) return;
+	s_offscreenTex->GetSurfaceLevel(0, &s_offscreenSurf);
+
+	hr = D3DDevice->CreateDepthStencilSurface(ResolutionWidth, ResolutionHeight,
+		_PresentParameters.AutoDepthStencilFormat, D3DMULTISAMPLE_NONE, &s_customDepth);
+	if (FAILED(hr)) {
+		fprintf(stderr, "WARN: Pillarbox: CreateDepthStencilSurface failed hr=0x%lx\n", (unsigned long)hr);
+		s_offscreenSurf->Release(); s_offscreenSurf = nullptr;
+		s_offscreenTex->Release(); s_offscreenTex = nullptr;
+		return;
+	}
+
+	s_pillarboxEnabled = true;
+	fprintf(stderr, "INFO: Pillarbox windowed: game=%dx%d, backbuffer=%dx%d, density=%.1f\n",
+		ResolutionWidth, ResolutionHeight, physW, physH, density);
+}
+
 /***********************************************************************************
 **
 ** DX8Wrapper Implementation
@@ -1495,7 +1583,10 @@ bool DX8Wrapper::Set_Device_Resolution(int width,int height,int bits,int windowe
 #pragma message("TODO: support changing windowed status and changing the bit depth")
 		WWDEBUG_SAY(("DX8Wrapper::Set_Device_Resolution is resetting the device."));
 		bool ok = Reset_Device();
-		if (ok) Pillarbox_Setup(ResolutionWidth, ResolutionHeight);
+		if (ok) {
+			Pillarbox_Setup(ResolutionWidth, ResolutionHeight);
+			if (IsWindowed) s_resizePending = true;  // re-trigger windowed pillarbox
+		}
 		return ok;
 	} else {
 		return false;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -219,6 +219,11 @@ void DX8Wrapper::Pillarbox_Begin()
 	D3DDevice->GetRenderTarget(&s_savedBackbuffer);
 	D3DDevice->GetDepthStencilSurface(&s_savedDepth);
 	D3DDevice->SetRenderTarget(s_offscreenSurf, s_depthSurf);
+	// Clear the offscreen RT and its depth buffer. The Begin_Render clear targeted
+	// the backbuffer before we switched, so without this the offscreen would carry
+	// stale depth from the previous frame.
+	D3DDevice->Clear(0, nullptr, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER | D3DCLEAR_STENCIL,
+		0x00000000, 1.0f, 0);
 	D3DDevice->SetRenderState(D3DRS_ZENABLE, TRUE);
 	D3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
 	D3DDevice->SetRenderState(D3DRS_ZFUNC, D3DCMP_LESSEQUAL);
@@ -923,6 +928,8 @@ bool DX8Wrapper::Reset_Device(bool reload_assets)
 
 void DX8Wrapper::Release_Device()
 {
+	Pillarbox_Cleanup();
+
 	if (D3DDevice) {
 
 		for (int a=0;a<MAX_TEXTURE_STAGES;++a)
@@ -1559,7 +1566,10 @@ bool DX8Wrapper::Set_Device_Resolution(int width,int height,int bits,int windowe
 #pragma message("TODO: support changing windowed status and changing the bit depth")
 		WWDEBUG_SAY(("DX8Wrapper::Set_Device_Resolution is resetting the device."));
 		bool ok = Reset_Device();
-		if (ok) Pillarbox_Setup(ResolutionWidth, ResolutionHeight);
+		if (ok) {
+			Pillarbox_Setup(ResolutionWidth, ResolutionHeight);
+			if (IsWindowed) s_resizePending = true;
+		}
 		return ok;
 	} else {
 		return false;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -597,6 +597,7 @@ public:
 	static const char* Get_DX8_Blend_Op_Name(unsigned value);
 
 	static void Invalidate_Cached_Render_States();
+	static void Set_Transform_Dirty();
 
 	static void Set_Draw_Polygon_Low_Bound_Limit(unsigned n) { DrawPolygonLowBoundLimit=n; }
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -511,12 +511,17 @@ public:
 	static void					Set_Render_Target (IDirect3DSwapChain8 *swap_chain);
 	static bool					Is_Render_To_Texture() { return IsRenderToTexture; }
 
+	// Platform display size provider — set by SDL3 layer at init
+	typedef bool (*DisplaySizeFunc)(int& outW, int& outH, float& outDensity);
+	static void					Set_Display_Size_Provider(DisplaySizeFunc nativeSize, DisplaySizeFunc windowSize);
+	static bool					GetNativeDisplaySize(int& outW, int& outH, float& outDensity);
+	static bool					GetWindowSize(int& outW, int& outH, float& outDensity);
+
 	// Pillarbox: render game at chosen resolution, blit centered onto backbuffer
 	static bool					Pillarbox_Get_Rect(int& x, int& y, int& w, int& h);
 	static void					Pillarbox_Begin();
 	static void					Pillarbox_End();
 	static void					Pillarbox_Process_Resize();
-	static bool					GetNativeDisplaySize(int& outW, int& outH, float& outDensity);
 
 	// for depth map support KJM V
 	static void Create_Render_Target
@@ -727,6 +732,10 @@ protected:
 	static unsigned							DrawPolygonLowBoundLimit;
 
 	static bool								IsRenderToTexture;
+
+	// Display size providers (set by SDL3 layer, called by pillarbox)
+	static DisplaySizeFunc				s_getNativeDisplaySize;
+	static DisplaySizeFunc				s_getWindowSize;
 
 	// Pillarbox state
 	static bool								s_pillarboxEnabled;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -511,10 +511,11 @@ public:
 	static void					Set_Render_Target (IDirect3DSwapChain8 *swap_chain);
 	static bool					Is_Render_To_Texture() { return IsRenderToTexture; }
 
-	// Pillarbox for ultrawide monitors
-	static bool					Pillarbox_Get_Rect(int& x, int& w, int& h);
+	// Pillarbox for ultrawide/resized windows
+	static bool					Pillarbox_Get_Rect(int& x, int& y, int& w, int& h);
 	static void					Pillarbox_Begin();
 	static void					Pillarbox_End();
+	static void					Pillarbox_Handle_Resize(int windowW, int windowH);
 	static bool					GetNativeDisplaySize(int& outW, int& outH, float& outDensity);
 
 	// for depth map support KJM V
@@ -733,8 +734,10 @@ protected:
 	static int								s_nativeW, s_nativeH;
 	static int								s_dstX, s_dstY, s_dstW, s_dstH;
 	static float							s_pixelDensity;
+	static bool								s_resizePending;
 	static IDirect3DTexture8*			s_offscreenTex;
 	static IDirect3DSurface8*			s_offscreenSurf;
+	static IDirect3DSurface8*			s_customDepth;
 	static IDirect3DSurface8*			s_savedBackbuffer;
 	static IDirect3DSurface8*			s_savedAutoDepth;
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -740,6 +740,7 @@ protected:
 	// Pillarbox state
 	static bool								s_pillarboxEnabled;
 	static bool								s_pillarboxActive;
+	static int								s_bbW, s_bbH;
 	static int								s_dstX, s_dstY, s_dstW, s_dstH;
 	static float							s_pixelDensity;
 	static IDirect3DTexture8*			s_offscreenTex;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -511,6 +511,12 @@ public:
 	static void					Set_Render_Target (IDirect3DSwapChain8 *swap_chain);
 	static bool					Is_Render_To_Texture() { return IsRenderToTexture; }
 
+	// Pillarbox for ultrawide monitors
+	static bool					Pillarbox_Get_Rect(int& x, int& w, int& h);
+	static void					Pillarbox_Begin();
+	static void					Pillarbox_End();
+	static bool					GetNativeDisplaySize(int& outW, int& outH, float& outDensity);
+
 	// for depth map support KJM V
 	static void Create_Render_Target
 	(
@@ -720,6 +726,21 @@ protected:
 	static unsigned							DrawPolygonLowBoundLimit;
 
 	static bool								IsRenderToTexture;
+
+	// Pillarbox state
+	static bool								s_pillarboxEnabled;
+	static bool								s_pillarboxActive;
+	static int								s_nativeW, s_nativeH;
+	static int								s_dstX, s_dstY, s_dstW, s_dstH;
+	static float							s_pixelDensity;
+	static IDirect3DTexture8*			s_offscreenTex;
+	static IDirect3DSurface8*			s_offscreenSurf;
+	static IDirect3DSurface8*			s_savedBackbuffer;
+	static IDirect3DSurface8*			s_savedAutoDepth;
+
+	static bool								Pillarbox_Setup(int gameW, int gameH);
+	static void								Pillarbox_Cleanup();
+	static void								Pillarbox_Blit();
 
 	static int								ZBias;
 	static float							ZNear;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -511,11 +511,12 @@ public:
 	static void					Set_Render_Target (IDirect3DSwapChain8 *swap_chain);
 	static bool					Is_Render_To_Texture() { return IsRenderToTexture; }
 
-	// Pillarbox for ultrawide/resized windows
+	// Pillarbox: render game at chosen resolution, blit centered onto backbuffer
 	static bool					Pillarbox_Get_Rect(int& x, int& y, int& w, int& h);
 	static void					Pillarbox_Begin();
 	static void					Pillarbox_End();
-	static void					Pillarbox_Handle_Resize(int windowW, int windowH);
+	static void					Pillarbox_Notify_Resize();
+	static void					Pillarbox_Process_Resize();
 	static bool					GetNativeDisplaySize(int& outW, int& outH, float& outDensity);
 
 	// for depth map support KJM V
@@ -731,19 +732,17 @@ protected:
 	// Pillarbox state
 	static bool								s_pillarboxEnabled;
 	static bool								s_pillarboxActive;
-	static int								s_nativeW, s_nativeH;
+	static bool								s_resizePending;
 	static int								s_dstX, s_dstY, s_dstW, s_dstH;
 	static float							s_pixelDensity;
-	static bool								s_resizePending;
 	static IDirect3DTexture8*			s_offscreenTex;
 	static IDirect3DSurface8*			s_offscreenSurf;
-	static IDirect3DSurface8*			s_customDepth;
+	static IDirect3DSurface8*			s_depthSurf;
 	static IDirect3DSurface8*			s_savedBackbuffer;
-	static IDirect3DSurface8*			s_savedAutoDepth;
+	static IDirect3DSurface8*			s_savedDepth;
 
 	static bool								Pillarbox_Setup(int gameW, int gameH);
 	static void								Pillarbox_Cleanup();
-	static void								Pillarbox_Blit();
 
 	static int								ZBias;
 	static float							ZNear;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -515,7 +515,6 @@ public:
 	static bool					Pillarbox_Get_Rect(int& x, int& y, int& w, int& h);
 	static void					Pillarbox_Begin();
 	static void					Pillarbox_End();
-	static void					Pillarbox_Notify_Resize();
 	static void					Pillarbox_Process_Resize();
 	static bool					GetNativeDisplaySize(int& outW, int& outH, float& outDensity);
 
@@ -732,7 +731,6 @@ protected:
 	// Pillarbox state
 	static bool								s_pillarboxEnabled;
 	static bool								s_pillarboxActive;
-	static bool								s_resizePending;
 	static int								s_dstX, s_dstY, s_dstW, s_dstH;
 	static float							s_pixelDensity;
 	static IDirect3DTexture8*			s_offscreenTex;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -1111,10 +1111,11 @@ WW3DErrorType WW3D::End_Render(bool flip_frame)
 
 	Activate_Snapshot(false);
 
-	// (gth) I've found some cases where its not safe to rely on our "shadow" copy (of
-	// matrices for example) across multiple frames.  So even though this is slightly
-	// less "optimal", lets just reset the caches each frame.
-	DX8Wrapper::Invalidate_Cached_Render_States();
+	// (gth) Original code invalidated ALL cached render states every frame as a safety
+	// measure for matrix shadow copies. This is expensive (~33KB memset + texture unbinds).
+	// Instead, just mark matrices as dirty so they get re-sent next frame.
+	// Full invalidation still happens on device init, reset, and pillarbox blit.
+	DX8Wrapper::Set_Transform_Dirty();
 
 	return WW3D_ERROR_OK;
 }


### PR DESCRIPTION
## Summary

- Renders game at its chosen resolution to an offscreen render target, then blits it centered onto the native-resolution backbuffer with black bars (pillarbox/letterbox)
- Works in both fullscreen (ultrawide displays) and windowed mode (on window resize)
- Filters available resolutions to the 4:3–16:9 range, deduplicates
- Adjusts mouse input coordinates for the viewport offset
- Adds `getViewportRect` to the Display abstraction so mouse handling doesn't depend on the renderer directly

## Approach

Offscreen RT at game resolution + dedicated depth stencil. In fullscreen the backbuffer is set to native display size; in windowed mode a deferred device reset resizes the backbuffer to match the window. The blit in `Pillarbox_End` computes an aspect-correct fit rect each frame and draws a textured quad.

## Test plan

- [x] Fullscreen on ultrawide: black bars on sides
- [x] Windowed: resize wider than 16:9 → pillarbox, taller than 4:3 → letterbox
- [x] Resolution change in options menu re-activates pillarbox
- [x] Mouse clicks map correctly inside the viewport
- [x] No regression on standard 16:9 displays (pillarbox skipped when sizes match)
- [ ] macOS


<img width="7679" height="2159" alt="generals zh fullscreen" src="https://github.com/user-attachments/assets/3c24f6f4-ce4f-4677-9385-50ae93d8657b" />


[generals  window resize 2.webm](https://github.com/user-attachments/assets/a3b0cdcf-dca7-471d-9fc0-97fe1c524199)
