### PR TITLE
fix(overlord-contain): restore Overlord upgrades on POSIX port (macOS/Linux)

### DIFF
--- a/.github/instructions/git-commit.instructions.md
+++ b/.github/instructions/git-commit.instructions.md
@@ -126,6 +126,14 @@ docs: update macOS build instructions for Vulkan SDK setup
 | `perf` | Performance optimization |
 | `style` | Formatting, spacing (no logic changes) |
 
+## Pull request guidelines
+
+- PR title should follow the same format as commit messages
+- the PR description should provide context and link to related issues
+- PR targes must be against main branch of `fbraz3/GeneralsX` repo, unless it's a user instruction to do otherwise (e.g., "Merge to `develop` branch" or "Merge to `feature/xyz` branch")
+- There is a subproject called `dxvk-macos` located under `references/fbraz3-dxvk` folder, which is a fork of the original DXVK project. Commits related to that subproject should be made in that repository and follow the same commit message standards.
+- `fbraz3-dxvk` subproject PRs should target the `generalsx-macos-v2.6` branch of `fbraz3/dxvk` repository, and follow the same commit message standards.
+
 ---
 
 **Note**: For GeneralsX code changes, also see `.github/copilot-instructions.md` for the code annotation standard (`// GeneralsX @keyword author DD/MM/YYYY Description`), which complements commit message discipline.

--- a/.github/instructions/git-commit.instructions.md
+++ b/.github/instructions/git-commit.instructions.md
@@ -130,7 +130,7 @@ docs: update macOS build instructions for Vulkan SDK setup
 
 - PR title should follow the same format as commit messages
 - the PR description should provide context and link to related issues
-- PR targes must be against main branch of `fbraz3/GeneralsX` repo, unless it's a user instruction to do otherwise (e.g., "Merge to `develop` branch" or "Merge to `feature/xyz` branch")
+- PR targets must be against main branch of `fbraz3/GeneralsX` repo, unless it's a user instruction to do otherwise (e.g., "Merge to `develop` branch" or "Merge to `feature/xyz` branch")
 - There is a subproject called `dxvk-macos` located under `references/fbraz3-dxvk` folder, which is a fork of the original DXVK project. Commits related to that subproject should be made in that repository and follow the same commit message standards.
 - `fbraz3-dxvk` subproject PRs should target the `generalsx-macos-v2.6` branch of `fbraz3/dxvk` repository, and follow the same commit message standards.
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -71,6 +71,8 @@ public:
 	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
 	virtual UpdateSleepTime update() override;
 	virtual void containReactToTransformChange() override;
+	// GeneralsX @bugfix copilot 21/04/2026 Issue #95: avoid fire-point redeploy for PORTABLE_STRUCTURE riders.
+	virtual void redeployOccupants() override;
 	virtual Bool isSpecificRiderFreeToExit(Object* obj) override;
 	virtual void exitObjectViaDoor(Object* exitObj, ExitDoorType exitDoor) override;
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -72,6 +72,7 @@ public:
 	virtual UpdateSleepTime update() override;
 	virtual void containReactToTransformChange() override;
 	virtual Bool isSpecificRiderFreeToExit(Object* obj) override;
+	virtual void exitObjectViaDoor(Object* exitObj, ExitDoorType exitDoor) override;
 
 	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
 	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -69,6 +69,9 @@ public:
 	// Contain stuff we need to override to redirect on a condition
 	virtual void onContaining( Object *obj ) override;		///< object now contains 'obj'
 	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
+	virtual UpdateSleepTime update() override;
+	virtual void containReactToTransformChange() override;
+	virtual Bool isSpecificRiderFreeToExit(Object* obj) override;
 
 	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
 	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list
@@ -101,6 +104,7 @@ private:
 	ContainModuleInterface *getRedirectedContain() const; ///< And this gets what are redirecting to.
 	void activateRedirectedContain();///< I need to shut this off since I can talk directly to my bunker, but he can never directly see me
 	void deactivateRedirectedContain();
+	void syncPortablePosition();  ///< Sync portable rider position/orientation to the host Overlord.
 
 	Bool m_redirectionActivated;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -80,7 +80,7 @@ OverlordContain::~OverlordContain()
 
 }
 
-UpdateSleepTime OverlordContain::update()
+void OverlordContain::syncPortablePosition()
 {
 	Object* portable = (m_containListSize > 0) ? m_containList.front() : nullptr;
 	if (portable && portable->isKindOf(KINDOF_PORTABLE_STRUCTURE))
@@ -89,8 +89,31 @@ UpdateSleepTime OverlordContain::update()
 		portable->setPosition(getObject()->getPosition());
 		portable->setOrientation(getObject()->getOrientation());
 	}
+}
 
+UpdateSleepTime OverlordContain::update()
+{
+	syncPortablePosition();
 	return TransportContain::update();
+}
+
+void OverlordContain::containReactToTransformChange()
+{
+	OpenContain::containReactToTransformChange();
+	// GeneralsX @bugfix copilot 19/04/2026 Immediately correct portable position after transform;
+	// bone queries return wrong world coords on POSIX, so override with the host tank's position.
+	syncPortablePosition();
+}
+
+// GeneralsX @bugfix copilot 19/04/2026 Prevent portable structures from ever exiting the Overlord.
+// On Windows/VC6, DISABLED_HELD caused getCurLocomotor() to return null, blocking exit naturally.
+// On POSIX the locomotor is still present even when HELD, so portables could exit when commanded
+// (e.g., force-attack). Portables are permanent upgrades and must never leave the Overlord.
+Bool OverlordContain::isSpecificRiderFreeToExit(Object* obj)
+{
+	if (obj && obj->isKindOf(KINDOF_PORTABLE_STRUCTURE))
+		return FALSE;
+	return TransportContain::isSpecificRiderFreeToExit(obj);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -105,6 +105,30 @@ void OverlordContain::containReactToTransformChange()
 	syncPortablePosition();
 }
 
+// GeneralsX @bugfix copilot 21/04/2026 Issue #95: redeployOccupants calls putObjAtNextFirePoint on
+// PORTABLE_STRUCTURE riders which triggers Object::reactToTransformChange and destroys them.
+// The portable position is managed exclusively by syncPortablePosition().
+// Non-portable occupants (if any) are still redeployed via the parent.
+void OverlordContain::redeployOccupants()
+{
+	// In practice the Overlord's own contain list only ever has a single portable upgrade,
+	// so this is effectively a no-op -- but guarded correctly for safety.
+	bool hasNonPortable = false;
+	const ContainedItemsList& list = getContainList();
+	for (ContainedItemsList::const_iterator it = list.begin(); it != list.end(); ++it)
+	{
+		Object* obj = *it;
+		if (obj && !obj->isKindOf(KINDOF_PORTABLE_STRUCTURE))
+		{
+			hasNonPortable = true;
+			break;
+		}
+	}
+	if (hasNonPortable)
+		TransportContain::redeployOccupants();
+	// Portables are repositioned by syncPortablePosition() called from containReactToTransformChange().
+}
+
 // GeneralsX @bugfix copilot 19/04/2026 Prevent portable structures from ever exiting the Overlord.
 // On Windows/VC6, DISABLED_HELD caused getCurLocomotor() to return null, blocking exit naturally.
 // On POSIX the locomotor is still present even when HELD, so portables could exit when commanded

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -338,9 +338,6 @@ void OverlordContain::onContaining( Object *obj )
 	{
 		TransportContain::onContaining( obj );
 
-		if( obj->isKindOf( KINDOF_PORTABLE_STRUCTURE ) )
-		{
-		}
 		activateRedirectedContain();//Am now carrying something
 		return;
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -80,6 +80,19 @@ OverlordContain::~OverlordContain()
 
 }
 
+UpdateSleepTime OverlordContain::update()
+{
+	Object* portable = (m_containListSize > 0) ? m_containList.front() : nullptr;
+	if (portable && portable->isKindOf(KINDOF_PORTABLE_STRUCTURE))
+	{
+		// GeneralsX @bugfix copilot 19/04/2026 Keep Overlord portable structures spatially synced with the host tank.
+		portable->setPosition(getObject()->getPosition());
+		portable->setOrientation(getObject()->getOrientation());
+	}
+
+	return TransportContain::update();
+}
+
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 void OverlordContain::onBodyDamageStateChange( const DamageInfo* damageInfo,
@@ -289,6 +302,17 @@ void OverlordContain::onContaining( Object *obj )
 	if( getRedirectedContain() == nullptr )
 	{
 		TransportContain::onContaining( obj );
+
+		if( obj->isKindOf( KINDOF_PORTABLE_STRUCTURE ) )
+		{
+			ContainModuleInterface* riderContain = obj->getContain();
+			const Bool isGarrisonablePortable = riderContain && riderContain->isGarrisonable();
+			if (!isGarrisonablePortable)
+			{
+				// GeneralsX @bugfix copilot 19/04/2026 Keep non-garrisonable Overlord upgrades active after attach.
+				obj->clearDisabled( DISABLED_HELD );
+			}
+		}
 		activateRedirectedContain();//Am now carrying something
 		return;
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -116,6 +116,18 @@ Bool OverlordContain::isSpecificRiderFreeToExit(Object* obj)
 	return TransportContain::isSpecificRiderFreeToExit(obj);
 }
 
+// GeneralsX @bugfix copilot 19/04/2026 Block instant-exit path for portable structures.
+// AIExitInstantlyState::onEnter() calls exitObjectViaDoor(obj, DOOR_1) directly, bypassing
+// reserveDoorForExit and isSpecificRiderFreeToExit entirely. The Gatling Cannon enters
+// AI_EXIT_INSTANTLY when force-attacking empty terrain: attack state machine transitions
+// through CHASE_TARGET (ContinueState) -> EXIT_MACHINE_WITH_FAILURE -> AI_EXIT_INSTANTLY.
+void OverlordContain::exitObjectViaDoor(Object* exitObj, ExitDoorType exitDoor)
+{
+	if (exitObj && exitObj->isKindOf(KINDOF_PORTABLE_STRUCTURE))
+		return;
+	TransportContain::exitObjectViaDoor(exitObj, exitDoor);
+}
+
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 void OverlordContain::onBodyDamageStateChange( const DamageInfo* damageInfo,

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -305,13 +305,6 @@ void OverlordContain::onContaining( Object *obj )
 
 		if( obj->isKindOf( KINDOF_PORTABLE_STRUCTURE ) )
 		{
-			ContainModuleInterface* riderContain = obj->getContain();
-			const Bool isGarrisonablePortable = riderContain && riderContain->isGarrisonable();
-			if (!isGarrisonablePortable)
-			{
-				// GeneralsX @bugfix copilot 19/04/2026 Keep non-garrisonable Overlord upgrades active after attach.
-				obj->clearDisabled( DISABLED_HELD );
-			}
 		}
 		activateRedirectedContain();//Am now carrying something
 		return;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -85,6 +85,7 @@ public:
 	// Contain stuff we need to override to redirect on a condition
 	virtual void onContaining( Object *obj, Bool wasSelected ) override;		///< object now contains 'obj'
 	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
+	virtual UpdateSleepTime update() override;
 
 	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
 	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -86,6 +86,11 @@ public:
 	virtual void onContaining( Object *obj, Bool wasSelected ) override;		///< object now contains 'obj'
 	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
 	virtual UpdateSleepTime update() override;
+	virtual void containReactToTransformChange() override;
+
+private:
+	void syncPortablePosition();  ///< Sync portable rider position/orientation to the host Overlord.
+
 
 	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
 	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -89,6 +89,8 @@ public:
 	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
 	virtual UpdateSleepTime update() override;
 	virtual void containReactToTransformChange() override;
+	// GeneralsX @bugfix copilot 20/04/2026 Issue #95: skip redeployOccupants for PORTABLE_STRUCTURE riders
+	virtual void redeployOccupants() override;
 
 private:
 	void syncPortablePosition();  ///< Sync portable rider position/orientation to the host Overlord.

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -75,6 +75,7 @@ public:
 	virtual Bool isImmuneToClearBuildingAttacks() const override { return true; }
   virtual Bool isSpecialOverlordStyleContainer() const override {return TRUE;}
 	virtual Bool isPassengerAllowedToFire( ObjectID id = INVALID_ID ) const override;	///< Hey, can I shoot out of this container?
+	virtual Bool isSpecificRiderFreeToExit(Object* obj) override;
 
 
 	virtual void onDie( const DamageInfo *damageInfo ) override;  ///< the die callback

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -76,6 +76,7 @@ public:
   virtual Bool isSpecialOverlordStyleContainer() const override {return TRUE;}
 	virtual Bool isPassengerAllowedToFire( ObjectID id = INVALID_ID ) const override;	///< Hey, can I shoot out of this container?
 	virtual Bool isSpecificRiderFreeToExit(Object* obj) override;
+	virtual void exitObjectViaDoor(Object* exitObj, ExitDoorType exitDoor) override;
 
 
 	virtual void onDie( const DamageInfo *damageInfo ) override;  ///< the die callback

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -47,11 +47,10 @@
 #include "GameLogic/PartitionManager.h"
 
 // GeneralsX @bugfix copilot 19/04/2026 Instrumentation for issue #95 (Gatling force-attack exit).
-// Re-enable by removing the early return below. Search for GX_OVERLORD_TRACE to find all call sites.
+// Re-enable by defining GX_OVERLORD_TRACE at compile time. Search for GX_OVERLORD_TRACE to find all call sites.
+#if defined(GX_OVERLORD_TRACE)
 static void logOverlordPortableEvent(const char* phase, const Object* host, const Object* obj)
 {
-	return; // instrumentation disabled -- see https://github.com/fbraz3/GeneralsX/issues/95
-
 	if (host == nullptr || obj == nullptr)
 		return;
 
@@ -76,6 +75,9 @@ static void logOverlordPortableEvent(const char* phase, const Object* host, cons
 		containedBy ? 1 : 0,
 		containedByTemplate ? containedByTemplate->getName().str() : "<none>");
 }
+#else
+static inline void logOverlordPortableEvent(const char* /*phase*/, const Object* /*host*/, const Object* /*obj*/) {}
+#endif
 
 
 
@@ -657,11 +659,10 @@ void OverlordContain::clientVisibleContainedFlashAsSelected()
 Bool OverlordContain::isPassengerAllowedToFire( ObjectID id ) const
 {
 	Object *passenger = TheGameLogic->findObjectByID(id);
-	Bool logPassenger = FALSE;
-	if (passenger != nullptr)
-	{
-		logPassenger = passenger->isKindOf(KINDOF_PORTABLE_STRUCTURE) || passenger->isKindOf(KINDOF_INFANTRY);
-	}
+	// logPassenger is true for any non-null passenger so all rejection paths are traceable
+	// when GX_OVERLORD_TRACE is enabled (previously only set for portable/infantry, making
+	// the rejectKind trace unreachable since that path fires for non-portable/non-infantry).
+	Bool logPassenger = (passenger != nullptr);
 
 	if(passenger != nullptr)
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -46,8 +46,12 @@
 #include "GameLogic/Object.h"
 #include "GameLogic/PartitionManager.h"
 
+// GeneralsX @bugfix copilot 19/04/2026 Instrumentation for issue #95 (Gatling force-attack exit).
+// Re-enable by removing the early return below. Search for GX_OVERLORD_TRACE to find all call sites.
 static void logOverlordPortableEvent(const char* phase, const Object* host, const Object* obj)
 {
+	return; // instrumentation disabled -- see https://github.com/fbraz3/GeneralsX/issues/95
+
 	if (host == nullptr || obj == nullptr)
 		return;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -136,7 +136,7 @@ void OverlordContain::onObjectCreated()
   OverlordContain::createPayload();
 }
 
-UpdateSleepTime OverlordContain::update()
+void OverlordContain::syncPortablePosition()
 {
 	Object* portable = (m_containListSize > 0) ? m_containList.front() : nullptr;
 	if (portable && portable->isKindOf(KINDOF_PORTABLE_STRUCTURE))
@@ -145,8 +145,21 @@ UpdateSleepTime OverlordContain::update()
 		portable->setPosition(getObject()->getPosition());
 		portable->setOrientation(getObject()->getOrientation());
 	}
+}
 
+UpdateSleepTime OverlordContain::update()
+{
+	syncPortablePosition();
 	return TransportContain::update();
+}
+
+void OverlordContain::containReactToTransformChange()
+{
+	// Let the base class run redeployOccupants() (bone-based placement).
+	OpenContain::containReactToTransformChange();
+	// GeneralsX @bugfix copilot 19/04/2026 Immediately correct portable position after transform;
+	// bone queries return wrong world coords on POSIX, so override with the host tank's position.
+	syncPortablePosition();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -46,6 +46,33 @@
 #include "GameLogic/Object.h"
 #include "GameLogic/PartitionManager.h"
 
+static void logOverlordPortableEvent(const char* phase, const Object* host, const Object* obj)
+{
+	if (host == nullptr || obj == nullptr)
+		return;
+
+	const ThingTemplate* hostTemplate = host->getTemplate();
+	const ThingTemplate* riderTemplate = obj->getTemplate();
+	const Object* containedBy = obj->getContainedBy();
+	const ThingTemplate* containedByTemplate = containedBy ? containedBy->getTemplate() : nullptr;
+
+	fprintf(
+		stderr,
+		"[GX_OVERLORD_TRACE] phase=%s hostTpl=%s host=%s(%d) riderTpl=%s rider=%s(%d) portable=%d infantry=%d held=%d containedBy=%d containedByTpl=%s\n",
+		phase,
+		hostTemplate ? hostTemplate->getName().str() : "<null>",
+		host->getName().str(),
+		host->getID(),
+		riderTemplate ? riderTemplate->getName().str() : "<null>",
+		obj->getName().str(),
+		obj->getID(),
+		obj->isKindOf(KINDOF_PORTABLE_STRUCTURE) ? 1 : 0,
+		obj->isKindOf(KINDOF_INFANTRY) ? 1 : 0,
+		obj->isDisabledByType(DISABLED_HELD) ? 1 : 0,
+		containedBy ? 1 : 0,
+		containedByTemplate ? containedByTemplate->getName().str() : "<none>");
+}
+
 
 
 
@@ -107,6 +134,19 @@ OverlordContain::~OverlordContain()
 void OverlordContain::onObjectCreated()
 {
   OverlordContain::createPayload();
+}
+
+UpdateSleepTime OverlordContain::update()
+{
+	Object* portable = (m_containListSize > 0) ? m_containList.front() : nullptr;
+	if (portable && portable->isKindOf(KINDOF_PORTABLE_STRUCTURE))
+	{
+		// GeneralsX @bugfix copilot 19/04/2026 Keep Overlord portable structures spatially synced with the host tank.
+		portable->setPosition(getObject()->getPosition());
+		portable->setOrientation(getObject()->getOrientation());
+	}
+
+	return TransportContain::update();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -364,9 +404,25 @@ void OverlordContain::onContaining( Object *obj, Bool wasSelected )
 	{
 		TransportContain::onContaining( obj, wasSelected );
 
+		logOverlordPortableEvent("onContaining-afterTransport", getObject(), obj);
+
 
     if ( obj->isKindOf( KINDOF_PORTABLE_STRUCTURE ) )
     {
+			ContainModuleInterface* riderContain = obj->getContain();
+			const Bool isGarrisonablePortable = riderContain && riderContain->isGarrisonable();
+
+			if (!isGarrisonablePortable)
+			{
+				// GeneralsX @bugfix copilot 19/04/2026 Keep non-garrisonable Overlord upgrades active after attach.
+				obj->clearDisabled( DISABLED_HELD );
+				logOverlordPortableEvent("onContaining-afterClearHeld", getObject(), obj);
+			}
+			else
+			{
+				logOverlordPortableEvent("onContaining-keepHeldGarrisonable", getObject(), obj);
+			}
+
   		activateRedirectedContain();//Am now carrying something
 
 			// And this contain style explicitly sucks XP from our little friend.
@@ -572,19 +628,46 @@ void OverlordContain::clientVisibleContainedFlashAsSelected()
 Bool OverlordContain::isPassengerAllowedToFire( ObjectID id ) const
 {
 	Object *passenger = TheGameLogic->findObjectByID(id);
+	Bool logPassenger = FALSE;
+	if (passenger != nullptr)
+	{
+		logPassenger = passenger->isKindOf(KINDOF_PORTABLE_STRUCTURE) || passenger->isKindOf(KINDOF_INFANTRY);
+	}
 
 	if(passenger != nullptr)
 	{
 		//only allow infantry, and turrets and such.  no vehicles.
 		if(passenger->isKindOf(KINDOF_INFANTRY) == FALSE && passenger->isKindOf(KINDOF_PORTABLE_STRUCTURE) == FALSE)
+		{
+			if (logPassenger)
+			{
+				logOverlordPortableEvent("isPassengerAllowedToFire-rejectKind", getObject(), passenger);
+			}
 			return FALSE;
+		}
 	}
 
 
   if ( getObject() && getObject()->getContainedBy() ) // nested containment voids firing, always
+	{
+		if (passenger != nullptr && logPassenger)
+		{
+			logOverlordPortableEvent("isPassengerAllowedToFire-rejectNested", getObject(), passenger);
+		}
     return FALSE;
+	}
 
-  return TransportContain::isPassengerAllowedToFire();
+	Bool allowed = TransportContain::isPassengerAllowedToFire();
+
+	if (passenger != nullptr && logPassenger)
+	{
+		logOverlordPortableEvent(
+			allowed ? "isPassengerAllowedToFire-allow" : "isPassengerAllowedToFire-rejectTransport",
+			getObject(),
+			passenger);
+	}
+
+	return allowed;
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -162,6 +162,17 @@ void OverlordContain::containReactToTransformChange()
 	syncPortablePosition();
 }
 
+// GeneralsX @bugfix copilot 19/04/2026 Prevent portable structures from ever exiting the Overlord.
+// On Windows/VC6, DISABLED_HELD caused getCurLocomotor() to return null, blocking exit naturally.
+// On POSIX the locomotor is still present even when HELD, so portables could exit when commanded
+// (e.g., force-attack). Portables are permanent upgrades and must never leave the Overlord.
+Bool OverlordContain::isSpecificRiderFreeToExit(Object* obj)
+{
+	if (obj && obj->isKindOf(KINDOF_PORTABLE_STRUCTURE))
+		return FALSE;
+	return TransportContain::isSpecificRiderFreeToExit(obj);
+}
+
 //-------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
 void OverlordContain::createPayload()

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -422,19 +422,7 @@ void OverlordContain::onContaining( Object *obj, Bool wasSelected )
 
     if ( obj->isKindOf( KINDOF_PORTABLE_STRUCTURE ) )
     {
-			ContainModuleInterface* riderContain = obj->getContain();
-			const Bool isGarrisonablePortable = riderContain && riderContain->isGarrisonable();
-
-			if (!isGarrisonablePortable)
-			{
-				// GeneralsX @bugfix copilot 19/04/2026 Keep non-garrisonable Overlord upgrades active after attach.
-				obj->clearDisabled( DISABLED_HELD );
-				logOverlordPortableEvent("onContaining-afterClearHeld", getObject(), obj);
-			}
-			else
-			{
-				logOverlordPortableEvent("onContaining-keepHeldGarrisonable", getObject(), obj);
-			}
+			logOverlordPortableEvent("onContaining-portable", getObject(), obj);
 
   		activateRedirectedContain();//Am now carrying something
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -46,41 +46,7 @@
 #include "GameLogic/Object.h"
 #include "GameLogic/PartitionManager.h"
 
-// GeneralsX @bugfix copilot 19/04/2026 Instrumentation for issue #95 (Gatling force-attack exit).
-// Re-enable by defining GX_OVERLORD_TRACE at compile time. Search for GX_OVERLORD_TRACE to find all call sites.
-#if defined(GX_OVERLORD_TRACE)
-static void logOverlordPortableEvent(const char* phase, const Object* host, const Object* obj)
-{
-	if (host == nullptr || obj == nullptr)
-		return;
-
-	const ThingTemplate* hostTemplate = host->getTemplate();
-	const ThingTemplate* riderTemplate = obj->getTemplate();
-	const Object* containedBy = obj->getContainedBy();
-	const ThingTemplate* containedByTemplate = containedBy ? containedBy->getTemplate() : nullptr;
-
-	fprintf(
-		stderr,
-		"[GX_OVERLORD_TRACE] phase=%s hostTpl=%s host=%s(%d) riderTpl=%s rider=%s(%d) portable=%d infantry=%d held=%d containedBy=%d containedByTpl=%s\n",
-		phase,
-		hostTemplate ? hostTemplate->getName().str() : "<null>",
-		host->getName().str(),
-		host->getID(),
-		riderTemplate ? riderTemplate->getName().str() : "<null>",
-		obj->getName().str(),
-		obj->getID(),
-		obj->isKindOf(KINDOF_PORTABLE_STRUCTURE) ? 1 : 0,
-		obj->isKindOf(KINDOF_INFANTRY) ? 1 : 0,
-		obj->isDisabledByType(DISABLED_HELD) ? 1 : 0,
-		containedBy ? 1 : 0,
-		containedByTemplate ? containedByTemplate->getName().str() : "<none>");
-}
-#else
-static inline void logOverlordPortableEvent(const char* /*phase*/, const Object* /*host*/, const Object* /*obj*/) {}
-#endif
-
-
-
+ 
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
@@ -185,6 +151,30 @@ Bool OverlordContain::isSpecificRiderFreeToExit(Object* obj)
 // AI_EXIT_INSTANTLY because it has attack weapons and its attack state machine transitions
 // through CHASE_TARGET (ContinueState) -> EXIT_MACHINE_WITH_FAILURE -> AI_EXIT_INSTANTLY
 // when force-attacking empty terrain. Propaganda Tower never hits this path (no weapons).
+// GeneralsX @bugfix copilot 20/04/2026 Issue #95: redeployOccupants calls putObjAtNextFirePoint on
+// PORTABLE_STRUCTURE riders which triggers Object::reactToTransformChange and destroys them.
+// The portable position is managed exclusively by syncPortablePosition().
+// Non-portable occupants (if any) are still redeployed via the parent.
+void OverlordContain::redeployOccupants()
+{
+	// In practice the Overlord's own contain list only ever has a single portable upgrade,
+	// so this is effectively a no-op — but guarded correctly for safety.
+	bool hasNonPortable = false;
+	const ContainedItemsList& list = getContainList();
+	for (ContainedItemsList::const_iterator it = list.begin(); it != list.end(); ++it)
+	{
+		Object* obj = *it;
+		if (obj && !obj->isKindOf(KINDOF_PORTABLE_STRUCTURE))
+		{
+			hasNonPortable = true;
+			break;
+		}
+	}
+	if (hasNonPortable)
+		TransportContain::redeployOccupants();
+	// Portables are repositioned by syncPortablePosition() called from containReactToTransformChange().
+}
+
 void OverlordContain::exitObjectViaDoor(Object* exitObj, ExitDoorType exitDoor)
 {
 	if (exitObj && exitObj->isKindOf(KINDOF_PORTABLE_STRUCTURE))
@@ -447,13 +437,8 @@ void OverlordContain::onContaining( Object *obj, Bool wasSelected )
 	{
 		TransportContain::onContaining( obj, wasSelected );
 
-		logOverlordPortableEvent("onContaining-afterTransport", getObject(), obj);
-
-
     if ( obj->isKindOf( KINDOF_PORTABLE_STRUCTURE ) )
     {
-			logOverlordPortableEvent("onContaining-portable", getObject(), obj);
-
   		activateRedirectedContain();//Am now carrying something
 
 			// And this contain style explicitly sucks XP from our little friend.
@@ -659,45 +644,21 @@ void OverlordContain::clientVisibleContainedFlashAsSelected()
 Bool OverlordContain::isPassengerAllowedToFire( ObjectID id ) const
 {
 	Object *passenger = TheGameLogic->findObjectByID(id);
-	// logPassenger is true for any non-null passenger so all rejection paths are traceable
-	// when GX_OVERLORD_TRACE is enabled (previously only set for portable/infantry, making
-	// the rejectKind trace unreachable since that path fires for non-portable/non-infantry).
-	Bool logPassenger = (passenger != nullptr);
 
 	if(passenger != nullptr)
 	{
 		//only allow infantry, and turrets and such.  no vehicles.
 		if(passenger->isKindOf(KINDOF_INFANTRY) == FALSE && passenger->isKindOf(KINDOF_PORTABLE_STRUCTURE) == FALSE)
-		{
-			if (logPassenger)
-			{
-				logOverlordPortableEvent("isPassengerAllowedToFire-rejectKind", getObject(), passenger);
-			}
 			return FALSE;
-		}
 	}
 
 
   if ( getObject() && getObject()->getContainedBy() ) // nested containment voids firing, always
 	{
-		if (passenger != nullptr && logPassenger)
-		{
-			logOverlordPortableEvent("isPassengerAllowedToFire-rejectNested", getObject(), passenger);
-		}
     return FALSE;
 	}
 
-	Bool allowed = TransportContain::isPassengerAllowedToFire();
-
-	if (passenger != nullptr && logPassenger)
-	{
-		logOverlordPortableEvent(
-			allowed ? "isPassengerAllowedToFire-allow" : "isPassengerAllowedToFire-rejectTransport",
-			getObject(),
-			passenger);
-	}
-
-	return allowed;
+	return TransportContain::isPassengerAllowedToFire();
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -173,6 +173,19 @@ Bool OverlordContain::isSpecificRiderFreeToExit(Object* obj)
 	return TransportContain::isSpecificRiderFreeToExit(obj);
 }
 
+// GeneralsX @bugfix copilot 19/04/2026 Block instant-exit path for portable structures.
+// AIExitInstantlyState::onEnter() calls exitObjectViaDoor(obj, DOOR_1) directly, bypassing
+// reserveDoorForExit and isSpecificRiderFreeToExit entirely. The Gatling Cannon enters
+// AI_EXIT_INSTANTLY because it has attack weapons and its attack state machine transitions
+// through CHASE_TARGET (ContinueState) -> EXIT_MACHINE_WITH_FAILURE -> AI_EXIT_INSTANTLY
+// when force-attacking empty terrain. Propaganda Tower never hits this path (no weapons).
+void OverlordContain::exitObjectViaDoor(Object* exitObj, ExitDoorType exitDoor)
+{
+	if (exitObj && exitObj->isKindOf(KINDOF_PORTABLE_STRUCTURE))
+		return;
+	TransportContain::exitObjectViaDoor(exitObj, exitDoor);
+}
+
 //-------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
 void OverlordContain::createPayload()

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,6 +2,25 @@
 
 ---
 
+## 2026-04-20 (SESSION CURRENT): Fix issue #95 portable upgrade destruction on Overlord turret rotation
+
+Confirmed and fixed the remaining intermittent portable-upgrade loss on Overlord after force-attack/turret rotation scenarios.
+
+What was done:
+- re-enabled focused tracing temporarily in `OverlordContain` to capture portable removal paths.
+- validated that end-of-match removal events were normal cleanup (`GameLogic::reset` / `clearGameData`) and not gameplay regression.
+- identified gameplay root cause from trace backtrace:
+  - `TurretAIAimTurretState::update` -> `Object::reactToTurretChange` -> `OverlordContain::containReactToTransformChange`
+  - `OpenContain::redeployOccupants` -> `OpenContain::putObjAtNextFirePoint` -> `Thing::setTransformMatrix`
+  - portable rider `Object::reactToTransformChange` -> `GameLogic::destroyObject`
+- implemented `OverlordContain::redeployOccupants()` override to skip redeploy for `KINDOF_PORTABLE_STRUCTURE` riders while preserving base redeploy for non-portable occupants.
+- kept portable world synchronization through `syncPortablePosition()`.
+- removed temporary trace instrumentation after validation.
+
+Validation:
+- local macOS `z_generals` build completed (warnings only, no new errors).
+- gameplay retest reported stable behavior with Overlord upgrades during repeated turret turning/force-attack.
+
 ## 2026-04-15 (SESSION CURRENT): Fix Linux build break in INI::scanType after upstream sync
 
 Addressed Linux and Flatpak build failures caused by a bad merge in the shared INI parser template.

--- a/docs/WORKDIR/lessons/2026-04-LESSONS.md
+++ b/docs/WORKDIR/lessons/2026-04-LESSONS.md
@@ -1,5 +1,20 @@
 # 2026-04 Lessons Learned
 
+## Session 2026-04-20 - Overlord portable riders must not go through fire-point redeploy on turret rotation
+
+- Problem: Overlord portable upgrades (Gattling Cannon, Propaganda Tower, BattleBunker) could disappear intermittently during force-attack / heavy turret turning on macOS.
+- Root cause:
+	- `OverlordContain::containReactToTransformChange()` executes on turret orientation changes.
+	- Base `OpenContain::redeployOccupants()` moved portable riders through fire points (`putObjAtNextFirePoint`).
+	- Portable `setTransformMatrix` triggered rider `reactToTransformChange`, which could route into `GameLogic::destroyObject`.
+	- BattleBunker loss cascaded to its contained infantry, making the issue appear broader than only one upgrade type.
+- Fix:
+	- Added `OverlordContain::redeployOccupants()` override to skip fire-point redeploy for `KINDOF_PORTABLE_STRUCTURE` riders.
+	- Kept portable transform sync in `syncPortablePosition()` after transform updates.
+	- Preserved base redeploy behavior for non-portable occupants.
+- Validation insight: Removal traces observed during score/reset were expected cleanup (`GameLogic::reset`/`clearGameData`) and should not be treated as gameplay regression.
+- Prevention: For Overlord portable upgrades, never route rider positioning through generic occupant fire-point redeploy; keep portable movement tied to host transform synchronization only.
+
 ## Session 2026-04-19 - Wide printf `%s`/`%S` mismatch causes one-character UI and replay metadata truncation on POSIX
 
 - Problem: Multiple UI texts on macOS/Linux showed only the first character (construction requirements, under-construction/completed labels, replay list fields such as date/time/version).

--- a/docs/WORKDIR/lessons/2026-04-LESSONS.md
+++ b/docs/WORKDIR/lessons/2026-04-LESSONS.md
@@ -2,7 +2,7 @@
 
 ## Session 2026-04-20 - Overlord portable riders must not go through fire-point redeploy on turret rotation
 
-- Problem: Overlord portable upgrades (Gattling Cannon, Propaganda Tower, BattleBunker) could disappear intermittently during force-attack / heavy turret turning on macOS.
+- Problem: Overlord portable upgrades (Gatling Cannon, Propaganda Tower, BattleBunker) could disappear intermittently during force-attack / heavy turret turning on macOS.
 - Root cause:
 	- `OverlordContain::containReactToTransformChange()` executes on turret orientation changes.
 	- Base `OpenContain::redeployOccupants()` moved portable riders through fire points (`putObjAtNextFirePoint`).


### PR DESCRIPTION
## Summary

Fixes Overlord tank upgrades (Gatling Cannon, Propaganda Tower, BattleBunker) on the macOS/Linux POSIX port.

On POSIX builds, portable riders were able to hit engine paths that should never apply to permanent Overlord upgrades. This PR restores expected behavior by hard-blocking portable exit paths and preventing portable fire-point redeploy during turret transform updates.

Closes #95

## Root Cause

Two behavior differences combined to break upgrade permanence on POSIX:

1. Exit path mismatch:
- On Windows/VC6, `DISABLED_HELD` effectively blocked rider exits via locomotor state.
- On POSIX, locomotor state remained available in cases where legacy code expected a block, allowing portable riders to leave through AI-driven exit flows.

2. Turret-rotation redeploy path:
- During turret turning, `OverlordContain::containReactToTransformChange()` triggered base `OpenContain::redeployOccupants()`.
- That path used `putObjAtNextFirePoint()` on portable riders, which called `setTransformMatrix()` and then rider `reactToTransformChange()`.
- Portable riders could then be destroyed by normal object-destruction flow (`GameLogic::destroyObject`).

## Final Changes

### `GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp`
- Added `syncPortablePosition()` and wired it into:
  - `update()`
  - `containReactToTransformChange()`
- Added portable exit guards:
  - `isSpecificRiderFreeToExit()` returns `FALSE` for `KINDOF_PORTABLE_STRUCTURE`
  - `exitObjectViaDoor()` early-returns for `KINDOF_PORTABLE_STRUCTURE`
- Added `redeployOccupants()` override:
  - skips fire-point redeploy for `KINDOF_PORTABLE_STRUCTURE` riders
  - keeps base redeploy behavior for non-portable occupants
- Removed erroneous `clearDisabled(DISABLED_HELD)` from `onContaining()`
- Temporary `GX_OVERLORD_TRACE` instrumentation used for diagnosis was removed after validation

### `GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h`
- Added declarations for:
  - `update()`
  - `containReactToTransformChange()`
  - `isSpecificRiderFreeToExit()`
  - `exitObjectViaDoor()`
  - `redeployOccupants()`
  - `syncPortablePosition()`

### `Generals/` mirror changes
- Equivalent fixes were kept in the base-game path for consistency where behavior is shared.

## Session 2026-04-20 Validation

Platform: macOS ARM64 (`macos-vulkan` preset)

Observed in gameplay:
- Gatling Cannon upgrade remains attached and firing during force-attack/turret rotation
- Propaganda Tower remains attached and healing
- BattleBunker remains attached and retains occupants
- No gameplay-time portable removal events in the final trace window
- Removal events observed at match reset/score transition map to expected cleanup (`GameLogic::reset` / `clearGameData`)

Build validation:
- `cmake --build build/macos-vulkan --target z_generals` completed (warnings only, no new errors)

## Notes

This fix keeps the determinism-sensitive gameplay model intact by constraining behavior inside `OverlordContain` (backend/platform adaptation layer), without introducing gameplay feature changes.