### PR TITLE
ci(workflows): consolidate build and release workflows

### DIFF
--- a/.github/workflows/build-linux-flatpak.yml
+++ b/.github/workflows/build-linux-flatpak.yml
@@ -21,8 +21,8 @@ on:
         default: linux64-deploy
 
 jobs:
-  build-flatpak:
-    name: flatpak-${{ matrix.game.id }}@${{ inputs.preset }}
+  build-linux-flatpak:
+    name: ${{ matrix.game.id }}@${{ inputs.preset }}
     runs-on: ubuntu-latest
     timeout-minutes: 150
     strategy:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -46,8 +46,8 @@ on:
         default: appimage
 
 jobs:
-  build:
-    name: ${{ inputs.game }}@${{ inputs.preset }}
+  build-linux:
+    name: ${{ inputs.game }}-${{ inputs.package_format }}@${{ inputs.preset }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -12,6 +12,11 @@ on:
         type: string
         default: "linux64-deploy"
         description: "CMake preset for Linux"
+      package_format:
+        required: false
+        type: string
+        default: "gzip"
+        description: "Artifact packaging format: gzip, appimage, or 'gzip + appimage'"
   workflow_dispatch:
     inputs:
       preset:
@@ -21,6 +26,14 @@ on:
           - linux64-deploy
           - linux64-testing
         default: linux64-deploy
+      package_format:
+        type: choice
+        description: "Artifact packaging format"
+        options:
+          - gzip
+          - appimage
+          - gzip + appimage
+        default: gzip
 
 jobs:
   build-linux:
@@ -41,7 +54,8 @@ jobs:
             target: g_generals
             output: GeneralsX
             log_suffix: generals
-        package_format: [appimage, gzip]
+        # GeneralsX @tweak GitHubCopilot 16/04/2026 Allow dispatch-time package selection while keeping matrix expansion deterministic.
+        package_format: ${{ fromJSON(inputs.package_format == 'gzip + appimage' && '["gzip","appimage"]' || format('["{0}"]', inputs.package_format)) }}
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -7,29 +7,13 @@ permissions:
 on:
   workflow_call:
     inputs:
-      game:
-        required: true
-        type: string
-        description: "Game to build (GeneralsMD, Generals)"
       preset:
         required: false
         type: string
         default: "linux64-deploy"
         description: "CMake preset for Linux"
-      package_format:
-        required: false
-        type: string
-        default: "appimage"
-        description: "Artifact packaging format: appimage (default) or gzip"
   workflow_dispatch:
     inputs:
-      game:
-        type: choice
-        description: "Game to build"
-        options:
-          - GeneralsMD
-          - Generals
-        default: GeneralsMD
       preset:
         type: choice
         description: "CMake preset for Linux"
@@ -37,42 +21,33 @@ on:
           - linux64-deploy
           - linux64-testing
         default: linux64-deploy
-      package_format:
-        type: choice
-        description: "Artifact packaging format"
-        options:
-          - appimage
-          - gzip
-        default: appimage
 
 jobs:
   build-linux:
-    name: ${{ inputs.game }}-${{ inputs.package_format }}@${{ inputs.preset }}
+    name: ${{ matrix.game.value }}-${{ matrix.package_format }}@${{ inputs.preset }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        game:
+          - id: generalsxzh
+            value: GeneralsMD
+            target: z_generals
+            output: GeneralsXZH
+            log_suffix: zh
+          - id: generalsx
+            value: Generals
+            target: g_generals
+            output: GeneralsX
+            log_suffix: generals
+        package_format: [appimage, gzip]
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Normalize package format
-        id: package-format
-        shell: bash
-        run: |
-          # GeneralsX @bugfix GitHubCopilot 10/04/2026 Normalize invalid package_format to appimage to keep workflow resilient.
-          FORMAT="${{ inputs.package_format }}"
-          case "${FORMAT}" in
-            appimage|gzip)
-              echo "package_format is valid: ${FORMAT}"
-              ;;
-            *)
-              echo "WARNING: Invalid package_format '${FORMAT}'. Falling back to 'appimage'."
-              FORMAT="appimage"
-              ;;
-          esac
-          echo "value=${FORMAT}" >> "$GITHUB_OUTPUT"
 
       - name: Cache vcpkg
         id: cache-vcpkg
@@ -174,30 +149,17 @@ jobs:
           cmake --preset ${{ inputs.preset }} 2>&1 | tee logs/configure_linux.log
           echo "CMake configuration complete."
 
-      - name: Build ${{ inputs.game }}
+      - name: Build ${{ matrix.game.value }}
         run: |
           mkdir -p logs
-          if [ "${{ inputs.game }}" = "GeneralsMD" ]; then
-            cmake --build build/${{ inputs.preset }} --target z_generals 2>&1 | tee logs/build_zh_linux.log
-          else
-            cmake --build build/${{ inputs.preset }} --target g_generals 2>&1 | tee logs/build_generals_linux.log
-          fi
+          cmake --build build/${{ inputs.preset }} --target ${{ matrix.game.target }} 2>&1 | tee logs/build_${{ matrix.game.log_suffix }}_linux.log
           echo "Build complete."
 
       - name: Verify Build Artifacts
         run: |
-          if [ "${{ inputs.game }}" = "GeneralsMD" ]; then
-            BINARY="build/${{ inputs.preset }}/GeneralsMD/GeneralsXZH"
-            DISPLAY_NAME="GeneralsXZH"
-            GAME_DIR="GeneralsMD"
-          else
-            BINARY="build/${{ inputs.preset }}/Generals/GeneralsX"
-            DISPLAY_NAME="GeneralsX"
-            GAME_DIR="Generals"
-          fi
-          
+          BINARY="build/${{ inputs.preset }}/${{ matrix.game.value }}/${{ matrix.game.output }}"
           if [ -f "$BINARY" ]; then
-            echo "✅ Binary built: $DISPLAY_NAME ($BINARY)"
+            echo "✅ Binary built: ${{ matrix.game.output }} ($BINARY)"
             file "$BINARY"
             ls -lh "$BINARY"
           else
@@ -207,11 +169,11 @@ jobs:
 
       # GeneralsX @build GitHubCopilot 10/04/2026 Package as AppImage (self-contained, no FUSE needed for appimagetool in CI via APPIMAGE_EXTRACT_AND_RUN).
       - name: Package as AppImage
-        if: success() && steps.package-format.outputs.value == 'appimage'
+        if: success() && matrix.package_format == 'appimage'
         env:
           APPIMAGE_EXTRACT_AND_RUN: "1"
         run: |
-          if [ "${{ inputs.game }}" = "GeneralsMD" ]; then
+          if [ "${{ matrix.game.value }}" = "GeneralsMD" ]; then
             ./scripts/build/linux/build-linux-appimage-zh.sh ${{ inputs.preset }}
           else
             ./scripts/build/linux/build-linux-appimage-generals.sh ${{ inputs.preset }}
@@ -219,15 +181,10 @@ jobs:
 
       # GeneralsX @build GitHubCopilot 10/04/2026 Legacy gzip bundle kept as opt-in fallback for CI/testing.
       - name: Package as gzip bundle
-        if: success() && steps.package-format.outputs.value == 'gzip'
+        if: success() && matrix.package_format == 'gzip'
         run: |
-          if [ "${{ inputs.game }}" = "GeneralsMD" ]; then
-            BINARY="build/${{ inputs.preset }}/GeneralsMD/GeneralsXZH"
-          else
-            BINARY="build/${{ inputs.preset }}/Generals/GeneralsX"
-          fi
-
-          RUNTIME_DIR="/tmp/GeneralsX-${{ inputs.game }}-deploy"
+          BINARY="build/${{ inputs.preset }}/${{ matrix.game.value }}/${{ matrix.game.output }}"
+          RUNTIME_DIR="/tmp/GeneralsX-${{ matrix.game.value }}-deploy"
           mkdir -p "${RUNTIME_DIR}"
 
           echo "Creating deployment bundle at: ${RUNTIME_DIR}"
@@ -272,8 +229,8 @@ jobs:
           echo "Bundle ready at: ${RUNTIME_DIR}"
           ls -lh "${RUNTIME_DIR}/"
 
-          BUNDLE_TAR="/tmp/GeneralsX-${{ inputs.game }}-${{ inputs.preset }}.tar"
-          tar -C "/tmp" -cf "${BUNDLE_TAR}" "GeneralsX-${{ inputs.game }}-deploy/"
+          BUNDLE_TAR="/tmp/GeneralsX-${{ matrix.game.value }}-${{ inputs.preset }}.tar"
+          tar -C "/tmp" -cf "${BUNDLE_TAR}" "GeneralsX-${{ matrix.game.value }}-deploy/"
           echo "Archive ready: ${BUNDLE_TAR}"
 
       - name: Set artifact metadata
@@ -281,22 +238,16 @@ jobs:
         if: success()
         run: |
           PRESET="${{ inputs.preset }}"
-          FORMAT="${{ steps.package-format.outputs.value }}"
-          GAME_SLUG="${{ inputs.game == 'GeneralsMD' && 'generalsxzh' || 'generalsx' }}"
+          FORMAT="${{ matrix.package_format }}"
+          GAME_SLUG="${{ matrix.game.id }}"
           PRESET_SLUG="${{ inputs.preset == 'linux64-deploy' && 'linux64' || inputs.preset }}"
 
           if [ "${FORMAT}" = "gzip" ]; then
             echo "name=linux-${GAME_SLUG}-${PRESET_SLUG}-bundle" >> "$GITHUB_OUTPUT"
-            echo "path=/tmp/GeneralsX-${{ inputs.game }}-${PRESET}.tar" >> "$GITHUB_OUTPUT"
+            echo "path=/tmp/GeneralsX-${{ matrix.game.value }}-${PRESET}.tar" >> "$GITHUB_OUTPUT"
           else
-            if [ "${{ inputs.game }}" = "GeneralsMD" ]; then
-              INPUT_PATH="build/GeneralsXZH-${PRESET}-x86_64.AppImage"
-              OUTPUT_PATH="/tmp/GeneralsXZH-${PRESET}-x86_64.AppImage"
-            else
-              INPUT_PATH="build/GeneralsX-${PRESET}-x86_64.AppImage"
-              OUTPUT_PATH="/tmp/GeneralsX-${PRESET}-x86_64.AppImage"
-            fi
-
+            INPUT_PATH="build/${{ matrix.game.output }}-${PRESET}-x86_64.AppImage"
+            OUTPUT_PATH="/tmp/${{ matrix.game.output }}-${PRESET}-x86_64.AppImage"
             # GeneralsX @bugfix GitHubCopilot 10/04/2026 Flatten uploaded AppImage artifact structure (no intermediate directories inside zip).
             cp -f "${INPUT_PATH}" "${OUTPUT_PATH}"
             echo "name=linux-${GAME_SLUG}-${PRESET_SLUG}-appimage" >> "$GITHUB_OUTPUT"
@@ -307,7 +258,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: build-logs-linux-${{ inputs.game }}
+          name: build-logs-linux-${{ matrix.game.id }}-${{ matrix.package_format }}
           path: logs/
           retention-days: 7
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
         default: "gzip"
-        description: "Artifact packaging format: gzip, appimage, or 'gzip + appimage'"
+        description: "Artifact packaging format: gzip or appimage"
   workflow_dispatch:
     inputs:
       preset:
@@ -32,12 +32,11 @@ on:
         options:
           - gzip
           - appimage
-          - gzip + appimage
         default: gzip
 
 jobs:
   build-linux:
-    name: ${{ matrix.game.value }}-${{ matrix.package_format }}@${{ inputs.preset }}
+    name: ${{ matrix.game.id }}.${{ inputs.package_format }}@${{ inputs.preset }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
@@ -54,8 +53,8 @@ jobs:
             target: g_generals
             output: GeneralsX
             log_suffix: generals
-        # GeneralsX @tweak GitHubCopilot 16/04/2026 Allow dispatch-time package selection while keeping matrix expansion deterministic.
-        package_format: ${{ fromJSON(inputs.package_format == 'gzip + appimage' && '["gzip","appimage"]' || format('["{0}"]', inputs.package_format)) }}
+        package_format:
+          - ${{ inputs.package_format }}
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-mac-app:
-    name: ${{ matrix.game.value }}@${{ inputs.preset }}
+    name: ${{ matrix.game.id }}@${{ inputs.preset }}
     runs-on: macos-latest
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -7,10 +7,6 @@ permissions:
 on:
   workflow_call:
     inputs:
-      game:
-        required: true
-        type: string
-        description: "Game to build (GeneralsMD, Generals)"
       preset:
         required: false
         type: string
@@ -18,13 +14,6 @@ on:
         description: "CMake preset for macOS"
   workflow_dispatch:
     inputs:
-      game:
-        type: choice
-        description: "Game to build"
-        options:
-          - GeneralsMD
-          - Generals
-        default: GeneralsMD
       preset:
         type: choice
         description: "CMake preset for macOS"
@@ -34,9 +23,23 @@ on:
 
 jobs:
   build-mac-app:
-    name: ${{ inputs.game }}@${{ inputs.preset }}
+    name: ${{ matrix.game.value }}@${{ inputs.preset }}
     runs-on: macos-latest
     timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        game:
+          - id: generalsxzh
+            value: GeneralsMD
+            target: z_generals
+            output: GeneralsXZH
+            log_suffix: zh
+          - id: generalsx
+            value: Generals
+            target: g_generals
+            output: GeneralsX
+            log_suffix: generals
 
     steps:
       - name: Checkout Code
@@ -308,21 +311,14 @@ jobs:
           CONFIG_STATUS=${PIPESTATUS[0]}
           if [ $CONFIG_STATUS -eq 0 ]; then echo "✅ CMake configuration complete"; else echo "❌ CMake configuration failed"; exit 1; fi
 
-      - name: Build ${{ inputs.game }}
+      - name: Build ${{ matrix.game.value }}
         run: |
           mkdir -p logs
           NPROC=$(sysctl -n hw.ncpu)
           echo "Building with $NPROC parallel jobs..."
-          
-          if [ "${{ inputs.game }}" = "GeneralsMD" ]; then
-            cmake --build build/${{ inputs.preset }} --target z_generals -j $NPROC 2>&1 | tee logs/build_zh_macos.log
-            BUILD_STATUS=${PIPESTATUS[0]}
-            LOG_FILE="logs/build_zh_macos.log"
-          else
-            cmake --build build/${{ inputs.preset }} --target g_generals -j $NPROC 2>&1 | tee logs/build_generals_macos.log
-            BUILD_STATUS=${PIPESTATUS[0]}
-            LOG_FILE="logs/build_generals_macos.log"
-          fi
+          LOG_FILE="logs/build_${{ matrix.game.log_suffix }}_macos.log"
+          cmake --build build/${{ inputs.preset }} --target ${{ matrix.game.target }} -j $NPROC 2>&1 | tee "${LOG_FILE}"
+          BUILD_STATUS=${PIPESTATUS[0]}
           
           if [ $BUILD_STATUS -eq 0 ]; then
             echo "✅ Build completed successfully"
@@ -334,18 +330,9 @@ jobs:
 
       - name: Verify Build Artifacts
         run: |
-          if [ "${{ inputs.game }}" = "GeneralsMD" ]; then
-            BINARY="build/${{ inputs.preset }}/GeneralsMD/GeneralsXZH"
-            DISPLAY_NAME="GeneralsXZH"
-            GAME_DIR="GeneralsMD"
-          else
-            BINARY="build/${{ inputs.preset }}/Generals/GeneralsX"
-            DISPLAY_NAME="Generals"
-            GAME_DIR="Generals"
-          fi
-          
+          BINARY="build/${{ inputs.preset }}/${{ matrix.game.value }}/${{ matrix.game.output }}"
           if [ -f "$BINARY" ]; then
-            echo "✅ Binary built: $DISPLAY_NAME"
+            echo "✅ Binary built: ${{ matrix.game.output }}"
             file "$BINARY"
             ls -lh "$BINARY"
             
@@ -359,7 +346,7 @@ jobs:
           else
             echo "❌ Binary NOT found: $BINARY"
             echo "Checking build directory:"
-            ls -la build/${{ inputs.preset }}/GeneralsMD/ 2>/dev/null || ls -la build/${{ inputs.preset }}/Generals/ 2>/dev/null || echo "Build directories not found"
+            ls -la "build/${{ inputs.preset }}/${{ matrix.game.value }}/" 2>/dev/null || echo "Build directory not found"
             exit 1
           fi
 
@@ -369,20 +356,16 @@ jobs:
           VULKAN_SDK: ${{ env.VULKAN_SDK }}
         run: |
           mkdir -p logs
-          echo "Bundling ${{ inputs.game }} into macOS .app package..."
-          
-          if [ "${{ inputs.game }}" = "GeneralsMD" ]; then
+          echo "Bundling ${{ matrix.game.value }} into macOS .app package..."
+          if [ "${{ matrix.game.value }}" = "GeneralsMD" ]; then
             echo "Executing: ./scripts/build/macos/bundle-macos-zh.sh"
-            ./scripts/build/macos/bundle-macos-zh.sh 2>&1 | tee logs/bundle_zh_macos.log
-            BUNDLE_STATUS=${PIPESTATUS[0]}
-            OUTPUT_ZIP="GeneralsXZH-macos-arm64.zip"
+            ./scripts/build/macos/bundle-macos-zh.sh 2>&1 | tee logs/bundle_${{ matrix.game.log_suffix }}_macos.log
           else
             echo "Executing: ./scripts/build/macos/bundle-macos-generals.sh"
-            ./scripts/build/macos/bundle-macos-generals.sh 2>&1 | tee logs/bundle_generals_macos.log
-            BUNDLE_STATUS=${PIPESTATUS[0]}
-            OUTPUT_ZIP="GeneralsX-macos-arm64.zip"
+            ./scripts/build/macos/bundle-macos-generals.sh 2>&1 | tee logs/bundle_${{ matrix.game.log_suffix }}_macos.log
           fi
-          
+          BUNDLE_STATUS=${PIPESTATUS[0]}
+          OUTPUT_ZIP="${{ matrix.game.output }}-macos-arm64.zip"
           if [ $BUNDLE_STATUS -eq 0 ]; then
             echo "✅ Bundle completed successfully"
             if [ -f "${OUTPUT_ZIP}" ]; then
@@ -394,22 +377,16 @@ jobs:
             fi
           else
             echo "❌ Bundle script failed; see logs for details"
-            tail -100 logs/bundle_*_macos.log || true
+            tail -100 logs/bundle_${{ matrix.game.log_suffix }}_macos.log || true
             exit 1
           fi
 
       - name: Prepare .app Artifact
         if: success()
         run: |
-          if [ "${{ inputs.game }}" = "GeneralsMD" ]; then
-            OUTPUT_ZIP="GeneralsXZH-macos-arm64.zip"
-            APP_NAME="GeneralsXZH.app"
-          else
-            OUTPUT_ZIP="GeneralsX-macos-arm64.zip"
-            APP_NAME="GeneralsX.app"
-          fi
-
-          ARTIFACT_DIR="/tmp/macos-artifact-${{ inputs.game }}"
+          OUTPUT_ZIP="${{ matrix.game.output }}-macos-arm64.zip"
+          APP_NAME="${{ matrix.game.output }}.app"
+          ARTIFACT_DIR="/tmp/macos-artifact-${{ matrix.game.id }}"
           rm -rf "${ARTIFACT_DIR}"
           mkdir -p "${ARTIFACT_DIR}"
 
@@ -433,7 +410,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: build-logs-macos-${{ inputs.game }}
+          name: build-logs-macos-${{ matrix.game.id }}
           path: logs/
           retention-days: 7
 
@@ -441,7 +418,7 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.game == 'GeneralsMD' && 'macos-generalsxzh-app' || 'macos-generalsx-app' }}
-          path: /tmp/macos-artifact-${{ inputs.game }}/*.tar
+          name: macos-${{ matrix.game.id }}-app
+          path: /tmp/macos-artifact-${{ matrix.game.id }}/*.tar
           retention-days: 7
           if-no-files-found: warn

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -33,7 +33,7 @@ on:
         default: macos-vulkan
 
 jobs:
-  build:
+  build-mac-app:
     name: ${{ inputs.game }}@${{ inputs.preset }}
     runs-on: macos-latest
     timeout-minutes: 120

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -33,7 +33,7 @@ on:
         default: windows64-deploy
 
 jobs:
-  build:
+  build-windows:
     name: ${{ inputs.game }}@${{ inputs.preset }}
     runs-on: windows-latest
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,42 +90,20 @@ jobs:
           fi
 
   build-linux:
-    name: Build Linux (GeneralsMD)
+    name: Build Linux
     needs: detect-changes
-    if: needs.detect-changes.outputs.zh-should-build == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.detect-changes.outputs.zh-should-build == 'true' || needs.detect-changes.outputs.base-should-build == 'true' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/build-linux.yml
     with:
-      game: GeneralsMD
-      preset: linux64-deploy
-    secrets: inherit
-
-  build-linux-generals:
-    name: Build Linux (Generals)
-    needs: detect-changes
-    if: needs.detect-changes.outputs.base-should-build == 'true' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/build-linux.yml
-    with:
-      game: Generals
       preset: linux64-deploy
     secrets: inherit
 
   build-macos:
-    name: Build macOS (GeneralsMD)
+    name: Build macOS
     needs: detect-changes
-    if: needs.detect-changes.outputs.zh-should-build == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.detect-changes.outputs.zh-should-build == 'true' || needs.detect-changes.outputs.base-should-build == 'true' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/build-macos.yml
     with:
-      game: GeneralsMD
-      preset: macos-vulkan
-    secrets: inherit
-
-  build-macos-generals:
-    name: Build macOS (Generals)
-    needs: detect-changes
-    if: needs.detect-changes.outputs.base-should-build == 'true' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/build-macos.yml
-    with:
-      game: Generals
       preset: macos-vulkan
     secrets: inherit
 
@@ -141,7 +119,7 @@ jobs:
   ci-summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [build-linux, build-linux-generals, build-macos, build-macos-generals, build-linux-flatpak]
+    needs: [build-linux, build-macos, build-linux-flatpak]
     if: always()
     steps:
       - name: Generate Summary
@@ -150,18 +128,14 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Platform | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Linux (x86_64) | ${{ needs.build-linux.result == 'success' && '✅ Success' || needs.build-linux.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Linux Generals Base (x86_64) | ${{ needs.build-linux-generals.result == 'success' && '✅ Success' || needs.build-linux-generals.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| macOS (arm64) | ${{ needs.build-macos.result == 'success' && '✅ Success' || needs.build-macos.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| macOS Generals Base (arm64) | ${{ needs.build-macos-generals.result == 'success' && '✅ Success' || needs.build-macos-generals.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Linux (x86_64) | ${{ needs.build-linux.result == 'success' && '✅ Success' || needs.build-linux.result == 'skipped' && '⏭️ Skipped' || needs.build-linux.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| macOS (arm64) | ${{ needs.build-macos.result == 'success' && '✅ Success' || needs.build-macos.result == 'skipped' && '⏭️ Skipped' || needs.build-macos.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Linux Flatpak | ${{ needs.build-linux-flatpak.result == 'success' && '✅ Success' || needs.build-linux-flatpak.result == 'skipped' && '⏭️ Skipped' || needs.build-linux-flatpak.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
 
       - name: Fail if Any Build Failed
         if: |
           needs.build-linux.result == 'failure' ||
-          needs.build-linux-generals.result == 'failure' ||
           needs.build-macos.result == 'failure' ||
-          needs.build-macos-generals.result == 'failure' ||
           needs.build-linux-flatpak.result == 'failure'
         run: exit 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,14 +89,24 @@ jobs:
             echo "| Linux Flatpak | ⏭️ No changes |" >> $GITHUB_STEP_SUMMARY
           fi
 
-  build-linux:
-    name: Build Linux
+  build-linux-gzip:
+    name: Build Linux gzip
     needs: detect-changes
     if: needs.detect-changes.outputs.zh-should-build == 'true' || needs.detect-changes.outputs.base-should-build == 'true' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/build-linux.yml
     with:
       preset: linux64-deploy
-      package_format: "gzip"
+      package_format: gzip
+    secrets: inherit
+
+  build-linux-appimage:
+    name: Build Linux AppImage
+    needs: detect-changes
+    if: needs.detect-changes.outputs.zh-should-build == 'true' || needs.detect-changes.outputs.base-should-build == 'true' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/build-linux.yml
+    with:
+      preset: linux64-deploy
+      package_format: appimage
     secrets: inherit
 
   build-macos:
@@ -120,7 +130,7 @@ jobs:
   ci-summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [build-linux, build-macos, build-linux-flatpak]
+    needs: [build-linux-gzip, build-linux-appimage, build-macos, build-linux-flatpak]
     if: always()
     steps:
       - name: Generate Summary
@@ -129,13 +139,15 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Platform | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Linux (x86_64) | ${{ needs.build-linux.result == 'success' && '✅ Success' || needs.build-linux.result == 'skipped' && '⏭️ Skipped' || needs.build-linux.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Linux gzip (x86_64) | ${{ needs.build-linux-gzip.result == 'success' && '✅ Success' || needs.build-linux-gzip.result == 'skipped' && '⏭️ Skipped' || needs.build-linux-gzip.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Linux AppImage (x86_64) | ${{ needs.build-linux-appimage.result == 'success' && '✅ Success' || needs.build-linux-appimage.result == 'skipped' && '⏭️ Skipped' || needs.build-linux-appimage.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| macOS (arm64) | ${{ needs.build-macos.result == 'success' && '✅ Success' || needs.build-macos.result == 'skipped' && '⏭️ Skipped' || needs.build-macos.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Linux Flatpak | ${{ needs.build-linux-flatpak.result == 'success' && '✅ Success' || needs.build-linux-flatpak.result == 'skipped' && '⏭️ Skipped' || needs.build-linux-flatpak.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
 
       - name: Fail if Any Build Failed
         if: |
-          needs.build-linux.result == 'failure' ||
+          needs.build-linux-gzip.result == 'failure' ||
+          needs.build-linux-appimage.result == 'failure' ||
           needs.build-macos.result == 'failure' ||
           needs.build-linux-flatpak.result == 'failure'
         run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
     uses: ./.github/workflows/build-linux.yml
     with:
       preset: linux64-deploy
+      package_format: "gzip"
     secrets: inherit
 
   build-macos:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,21 +11,15 @@ on:
         description: "Additional notes (optional markdown)"
         required: false
         type: string
-      create_release:
-        description: "Create new release"
+      release_mode:
+        description: "Release mode"
         required: false
-        type: boolean
-        default: false
-      is_prerelease:
-        description: "Mark as pre-release"
-        required: false
-        type: boolean
-        default: false
-      dry_run:
-        description: "Dry run: never create tag/release, only generate notes + artifacts"
-        required: false
-        type: boolean
-        default: false
+        type: choice
+        options:
+          - New Release
+          - Draft
+          - Dry Run
+        default: New Release
 
 concurrency:
   group: release-${{ github.workflow }}-${{ inputs.release_version }}
@@ -41,21 +35,14 @@ jobs:
     with:
       preset: linux64-deploy
 
-  build-macos-zh:
+  build-macos:
     uses: ./.github/workflows/build-macos.yml
     with:
-      game: GeneralsMD
-      preset: macos-vulkan
-
-  build-macos-generals:
-    uses: ./.github/workflows/build-macos.yml
-    with:
-      game: Generals
       preset: macos-vulkan
 
   prepare-release:
     runs-on: ubuntu-latest
-    needs: [build-linux-flatpak, build-macos-zh, build-macos-generals]
+    needs: [build-linux-flatpak, build-macos]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -66,14 +53,14 @@ jobs:
       - name: Validate release inputs
         run: |
           VERSION="${{ inputs.release_version }}"
-          DRY_RUN="${{ inputs.dry_run }}"
+          RELEASE_MODE="${{ inputs.release_mode }}"
 
           if [ -z "$VERSION" ]; then
             echo "ERROR: release_version is required"
             exit 1
           fi
 
-          if [ "$DRY_RUN" = "true" ]; then
+          if [ "$RELEASE_MODE" = "Dry Run" ]; then
             echo "Dry run enabled. Tag/release creation will be skipped."
           else
             if git show-ref --tags --verify --quiet "refs/tags/$VERSION"; then
@@ -124,7 +111,7 @@ jobs:
       - name: Normalize bundle files for release assets
         id: assets
         env:
-          DRY_RUN: ${{ inputs.dry_run }}
+          RELEASE_MODE: ${{ inputs.release_mode }}
         run: |
           mkdir -p release-assets
 
@@ -159,7 +146,7 @@ jobs:
             exit 1
           fi
 
-          if [ "$DRY_RUN" = "true" ]; then
+          if [ "$RELEASE_MODE" = "Dry Run" ]; then
             echo "Dry run enabled: skipping zip normalization to avoid large preview artifacts."
             echo "linux_generals_asset=" >> "$GITHUB_OUTPUT"
             echo "linux_asset=" >> "$GITHUB_OUTPUT"
@@ -311,15 +298,7 @@ jobs:
           echo "notes_txt_file=$GITHUB_WORKSPACE/$NOTES_TXT_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Upload dry-run release description
-        if: success() && inputs.dry_run == true
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-preview-${{ inputs.release_version }}
-          path: release-assets/${{ inputs.release_version }}-notes.txt
-          retention-days: 30
-
-      - name: Upload release description preview
-        if: success() && inputs.dry_run == false && inputs.create_release == false
+        if: success() && inputs.release_mode == 'Dry Run'
         uses: actions/upload-artifact@v4
         with:
           name: release-preview-${{ inputs.release_version }}
@@ -327,18 +306,18 @@ jobs:
           retention-days: 30
 
       - name: Create GitHub release and upload assets
-        if: success() && inputs.dry_run == false && inputs.create_release == true
+        if: success() && inputs.release_mode != 'Dry Run'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PRERELEASE_FLAG=""
+          DRAFT_FLAG=""
 
-          if [ "${{ inputs.is_prerelease }}" = "true" ]; then
-            PRERELEASE_FLAG="--prerelease"
+          if [ "${{ inputs.release_mode }}" = "Draft" ]; then
+            DRAFT_FLAG="--draft"
           fi
 
           gh release create "${{ inputs.release_version }}" \
-            $PRERELEASE_FLAG \
+            $DRAFT_FLAG \
             --title "GeneralsX - ${{ inputs.release_version }}" \
             --notes-file "${{ steps.notes.outputs.notes_file }}" \
             "${{ steps.assets.outputs.linux_generals_asset }}" \
@@ -351,17 +330,17 @@ jobs:
           echo "## Release Pipeline Summary" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Tag: ${{ inputs.release_version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Create release: ${{ inputs.create_release }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Pre-release: ${{ inputs.is_prerelease }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Dry run: ${{ inputs.dry_run }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Mode: ${{ inputs.release_mode }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- Linux asset (Generals): GeneralsX-linux.flatpak" >> "$GITHUB_STEP_SUMMARY"
           echo "- Linux asset: GeneralsXZH-linux.flatpak" >> "$GITHUB_STEP_SUMMARY"
           echo "- macOS asset (Generals): macos-generalsx-app.tar.zip" >> "$GITHUB_STEP_SUMMARY"
           echo "- macOS asset: macos-generalsxzh-app.tar.zip" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "${{ inputs.dry_run }}" = "true" ] || [ "${{ inputs.create_release }}" = "false" ]; then
+          if [ "${{ inputs.release_mode }}" = "Dry Run" ]; then
             echo "No GitHub release was created. Download preview artifacts from this run." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ inputs.release_mode }}" = "Draft" ]; then
+            echo "Draft release created and assets attached." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "Release created and assets attached." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,6 +2,28 @@
 
 ---
 
+## 2026-04-21 (SESSION 122): Split Linux CI packaging into explicit gzip and AppImage jobs
+
+Refined the Linux workflow model so each reusable build invocation produces exactly one package format.
+
+What was done:
+- removed the combined `gzip + appimage` mode from `build-linux.yml` entirely.
+- kept manual workflow dispatch limited to one explicit package choice per run (`gzip` or `appimage`).
+- split top-level CI Linux packaging into two separate reusable workflow calls:
+  - `build-linux-gzip`
+  - `build-linux-appimage`
+- updated CI summary and failure gates to track the two Linux packaging jobs independently.
+- normalized macOS job display naming to use `matrix.game.id` for consistency with Linux/Flatpak job naming.
+
+Files touched:
+- `.github/workflows/build-linux.yml`
+- `.github/workflows/build-macos.yml`
+- `.github/workflows/ci.yml`
+
+Validation:
+- verified YAML diagnostics for `build-linux.yml` and `ci.yml` after the split.
+- confirmed no remaining references to the removed combined Linux package mode.
+
 ## 2026-04-16 (SESSION 121): Release mode combobox and workflow alignment with matrix builds
 
 Updated release orchestration UX and workflow wiring to match the new reusable build workflow contracts.

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,6 +2,33 @@
 
 ---
 
+## 2026-04-16 (SESSION 121): Release mode combobox and workflow alignment with matrix builds
+
+Updated release orchestration UX and workflow wiring to match the new reusable build workflow contracts.
+
+What was done:
+- changed release manual inputs from three booleans to one choice selector:
+  - `New Release` (default),
+  - `Draft`,
+  - `Dry Run`.
+- removed pre-release handling from release creation path.
+- updated release job graph to use the matrix-based macOS reusable workflow call (single call, no legacy per-game inputs).
+- aligned release conditions/summary messages with `release_mode` semantics.
+- adjusted Linux reusable build workflow manual selector to support:
+  - `gzip`,
+  - `appimage`,
+  - `gzip + appimage`.
+- kept CI automation configured to request both Linux package formats.
+
+Files touched:
+- `.github/workflows/build-linux.yml`
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+
+Validation:
+- verified YAML diagnostics for `release.yml` and `ci.yml` after migration.
+- confirmed no stale references to removed release boolean inputs remain.
+
 ## 2026-04-16 (SESSION 120): CI workflow matrix consolidation by OS and Linux package format
 
 Consolidated CI reusable workflow calls so Linux and macOS are grouped by OS while keeping Linux package outputs explicit.

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,6 +2,27 @@
 
 ---
 
+## 2026-04-16 (SESSION 120): CI workflow matrix consolidation by OS and Linux package format
+
+Consolidated CI reusable workflow calls so Linux and macOS are grouped by OS while keeping Linux package outputs explicit.
+
+What was done:
+- refactored reusable Linux workflow to run an internal matrix over:
+  - game targets (`GeneralsMD`, `Generals`),
+  - package formats (`appimage`, `gzip`), producing both `.AppImage` and `.tar` bundles in CI.
+- refactored reusable macOS workflow to run an internal matrix over game targets (`GeneralsMD`, `Generals`).
+- simplified top-level `ci.yml` orchestration by removing duplicated per-game Linux/macOS calls and invoking one reusable workflow per OS.
+- updated CI summary/failure gates to align with the consolidated job graph.
+
+Files touched:
+- `.github/workflows/build-linux.yml`
+- `.github/workflows/build-macos.yml`
+- `.github/workflows/ci.yml`
+
+Validation:
+- verified references to removed inputs (`inputs.game`, legacy package-format output normalization) were fully cleaned up.
+- confirmed artifact naming/path logic now uses matrix metadata consistently.
+
 ## 2026-04-16 (SESSION 119): Replay header triage with recorder instrumentation and headless validator
 
 Investigated invalid replay headers (`invalid GameInfo len=0`) from newly recorded local files and prepared focused diagnostics to isolate write-time vs read-time behavior.

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,69 +2,180 @@
 
 ---
 
-## 2026-04-15 (SESSION CURRENT): Fix Linux build break in INI::scanType after upstream sync
+## 2026-04-16 (SESSION 119): Replay header triage with recorder instrumentation and headless validator
 
-Addressed Linux and Flatpak build failures caused by a bad merge in the shared INI parser template.
+Investigated invalid replay headers (`invalid GameInfo len=0`) from newly recorded local files and prepared focused diagnostics to isolate write-time vs read-time behavior.
 
-What was fixed:
-  - restored integer parsing declarations in `scanType(std::string_view token)`:
-    - `std::conditional_t<std::is_integral_v<Type>, Int64, Type> result{}`
-    - `const auto [ptr, ec] = std::from_chars(...)`
-
-Root cause:
-
-Impact:
-
-Validation:
-
-## 2026-04-15 (SESSION CURRENT): TheSuperHackers upstream sync + macOS build unblocks for Zero Hour and Generals
-
-Completed upstream sync from TheSuperHackers main into branch `thesuperhackers-sync-04-15-2026` and resolved merge conflicts while preserving GeneralsX cross-platform architecture.
-
-What was merged/resolved:
-
-Build blockers fixed after sync:
-
-Validation outcome:
-
-## 2026-04-16 (SESSION 116): Fix issue #84 dual-signature EXC_BAD_ACCESS paths (AI guard + OpenAL cache)
-Re-triaged issue [#84](https://github.com/fbraz3/GeneralsX/issues/84) after additional reports and confirmed it contained two different crash signatures, not a single root cause.
-
-What was changed:
-- `GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp`
-- `Generals/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp`
-  - hardened `AITNGuardOuterState::update()` with lazy `m_attackState` initialization when missing.
-  - added safe team/prototype null checks before accessing `m_attackCommonTarget`.
-- `Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioCache.cpp`
-  - fixed cache eviction priority path to handle entries without `AudioEventInfo` (filename-only loads) instead of dereferencing null pointers.
-
-Why:
-- Crash signature A (`AITNGuardOuterState::update`, low address `0x38`) matched missing sub-state dereference risk.
-- Crash signature B (`OpenALAudioFileCache::freeEnoughSpaceForSample`, low address `0x3c`) matched unconditional priority access on null `m_eventInfo`.
+What was done:
+- added recorder instrumentation in Zero Hour to log replay start mode and slot-list serialization details:
+  - accepted/rejected `MSG_NEW_GAME` game mode,
+  - network/skirmish pointers used to build GameInfo,
+  - serialized slot-list content and byte length right before replay header write.
+- fixed instrumentation length logging to use `strlen(theSlotList.str())` (portable with current `AsciiString` implementation).
+- kept logs on `stderr` with explicit `fflush(stderr)` for reliable capture in macOS/Linux runtime logs.
+- documented and kept the headless replay batch validator helper under scripts QA debug tooling:
+  - `scripts/qa/debug/validate-replays-headless.sh`
+  - classification buckets: `PLAYABLE_CRC_MISMATCH`, `INVALID_HEADER`, `INVALID_OPEN`.
 
 Validation:
-- diagnostics check reported no errors in all modified files.
-- posted technical follow-up in issue comments with explicit source anchors and retest request.
+- rebuilt `GeneralsXZH` on macOS (`build/macos-vulkan`) successfully after instrumentation updates.
+- manual replay check still reports `Replay header parse failed: invalid GameInfo (len=0)` for the latest `00000000.rep`, confirming issue persists and instrumentation is needed for next captured replays.
 
-## 2026-04-14 (SESSION CURRENT): Fix Flatpak CI artifact upload and switch Linux release assets to native .flatpak
+Next step:
+- collect one Skirmish replay and one Campaign replay with the instrumented binary, then compare write-path logs against read-path header parse behavior.
 
-Addressed a CI failure in the Flatpak matrix and aligned Linux release packaging with the current distribution strategy.
+## 2026-04-13 (SESSION 118): macOS replay suite stabilization for real-world filenames and header parsing
 
-What was changed:
-- `.github/workflows/build-linux-flatpak.yml`
-  - added a `Locate generated Flatpak bundle` step that resolves the produced `.flatpak` path dynamically when the strict expected path is not present.
-  - updated artifact upload to use the detected output path.
-- `.github/workflows/release.yml`
-  - switched Linux release assets from zipped wrappers to native `.flatpak` files.
-  - updated release summary labels to reflect the new Linux asset names.
+Worked on replay automation stability in macOS headless mode to support real user filenames (spaces, symbols) and avoid parser crashes.
 
-Why:
-- the failing run reported `No files were found with the provided path` for Flatpak upload, indicating artifact path drift despite successful build progress.
-- Linux release policy for this branch is now Flatpak-first, replacing previous AppImage/zip Linux release artifacts.
+What was done:
+- created working branch `fix/macos-replay-headless-instrumentation`.
+- improved replay simulation diagnostics to print per-replay context in headless mode:
+  - replay filename,
+  - worker command/exit details,
+  - explicit replay open failures.
+- fixed non-Windows worker command path formatting and added non-Windows fallback to in-process replay simulation because `WorkerProcess` remains Windows-only.
+- fixed replay header parsing portability:
+  - accept absolute replay paths passed via `-replay`,
+  - harden replay string parsing to avoid stack overflow,
+  - read replay Unicode strings as UTF-16 (2-byte) to match Windows replay layout on macOS.
+- added headless-safe guard in particle/smudge update path to prevent replay-time null dereference in render-only branches.
+- removed temporary invalid replay `00000000.rep` from active replay support directory and re-ran suite.
 
-Outcome:
-- CI Flatpak artifact upload is now resilient to naming/path drift.
-- Linux release output publishes `GeneralsX-linux.flatpak` and `GeneralsXZH-linux.flatpak` directly.
+Validation summary (macOS):
+- replay files with special characters in names now open and simulate.
+- no more stack buffer overflow in replay header parsing.
+- no replay open crash observed in current suite run.
+- suite currently reaches replay simulation and reports CRC mismatches (determinism issue still open).
+- one replay file (`test_replay.rep`) still fails to open and appears to be invalid test input.
+
+Files touched:
+- `Core/GameEngine/Source/Common/ReplaySimulation.cpp`
+- `Core/GameEngine/Source/GameClient/System/ParticleSys.cpp`
+- `GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp`
+- `Generals/Code/GameEngine/Source/Common/Recorder.cpp`
+
+Next step:
+- investigate first-frame CRC divergence in replay simulation on macOS after parser/runtime stabilization.
+
+## 2026-04-12 (SESSION 117): Added mismatch-path instrumentation and lobby render/prune tracing
+
+Follow-up work for [#86](https://github.com/fbraz3/GeneralsX/issues/86) after direct-connect began working but cross-platform game start still hit the classic incompatibility path.
+
+What was done:
+- added stderr `[LAN86]` instrumentation for game-start mismatch diagnosis in:
+  - local CRC validation enable path,
+  - per-player cached CRC capture,
+  - CRC quorum failure and CRC mismatch summary output,
+  - forced game-start timeout send/receive path,
+  - mismatch UI activation (`setSawCRCMismatch`).
+- added lobby-side stderr tracing for:
+  - rendered LAN game rows in the listbox,
+  - final list refresh count,
+  - timed-out game pruning from the LAN game list.
+
+Current read on the lobby path:
+- no additional compatibility filter was found in the LAN lobby UI callback itself.
+- the visible list is driven directly from `m_games`; the useful remaining suspects are parse/state correctness of `LANGameInfo` and aggressive timeout pruning.
+
+Files touched:
+- `GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp`
+- `GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp`
+- `Core/GameEngine/Source/GameNetwork/Network.cpp`
+- `Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp`
+- `Core/GameEngine/Source/GameNetwork/LANGameInfo.cpp`
+- `Core/GameEngine/Source/GameNetwork/LANAPI.cpp`
+
+Validation:
+- pending static diagnostics after edit.
+
+## 2026-04-11 (SESSION 116): Issue #86 branch + LAN diagnostics instrumentation (Linux/macOS)
+
+Started work for [#86](https://github.com/fbraz3/GeneralsX/issues/86) to investigate LAN discovery failures across Linux and macOS.
+
+What was done:
+- created working branch `issue-86-lan-discovery-instrumentation`.
+- added LAN startup diagnostics in lobby flow to log:
+  - whether IP came from auto-selection or configured default,
+  - selected local bind IP,
+  - `SetLocalIP` success/failure,
+  - initial `RequestLocations()` dispatch.
+- changed critical LAN diagnostics from `DEBUG_LOG`-only to explicit `fprintf(stderr, ...)` probes with `[LAN86]` prefix because manual `-logToCon` captures did not reliably surface the new traces.
+- expanded reception-side instrumentation to log:
+  - enumerated LAN IP candidates,
+  - preferred-vs-fallback LAN IP resolution,
+  - received LAN message type/source/length,
+  - handler-level processing for lobby announce, game announce, request locations, and request game info,
+  - periodic LAN resend behavior.
+- instrumented LAN send path to log message type + destination mode:
+  - direct send,
+  - direct-connect fan-out,
+  - broadcast target and queue result.
+- instrumented LAN rebind path (`SetLocalIP`) to log old/new local IP, transport init result, and broadcast enable result.
+- instrumented transport/UDP layers for socket-level diagnostics:
+  - requested bind endpoint + bind success,
+  - source endpoint for unknown inbound packets,
+  - socket/bind/send/recv failure error codes.
+- instrumented POSIX IP enumeration to log interface name/flags and candidate IPv4 addresses considered for LAN selection.
+
+Files touched:
+- `GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanLobbyMenu.cpp`
+- `Core/GameEngine/Source/GameNetwork/LANAPI.cpp`
+- `Core/GameEngine/Source/GameNetwork/Transport.cpp`
+- `Core/GameEngine/Source/GameNetwork/udp.cpp`
+- `Core/GameEngine/Source/GameNetwork/IPEnumeration.cpp`
+- `docs/WORKDIR/lessons/2026-04-LESSONS.md`
+
+Validation:
+- `get_errors` reported no diagnostics in the edited source files.
+
+Goal for next step:
+- run manual cross-platform tests (Linux + macOS) and capture logs to confirm whether failure is caused by wrong NIC/IP selection, broadcast routing behavior, or packet filtering.
+
+Update after manual two-machine validation:
+- analyzed fresh Linux/macOS logs captured after the expanded `[LAN86]` stderr instrumentation.
+- confirmed that both platforms bind the configured LAN IP correctly and that direct-connect traffic reaches the host in both directions.
+- identified a real handshake bug in LAN join handling: the host accepted the remote player locally but changed the join response target to broadcast, causing `MSG_JOIN_ACCEPT` to be sent to `255.255.255.255` instead of unicast to the joining client.
+- this explains the observed false-positive where the host lobby showed the second player while the joining machine still timed out.
+- fixed `handleRequestJoin()` to keep `MSG_JOIN_ACCEPT`/deny responses directed to the requester IP.
+- added join-phase diagnostics for:
+  - direct-connect request start,
+  - request-join dispatch,
+  - join accept / deny processing,
+  - join-action timeout path.
+
+Files touched in the follow-up fix:
+- `Core/GameEngine/Source/GameNetwork/LANAPIhandlers.cpp`
+- `Core/GameEngine/Source/GameNetwork/LANAPI.cpp`
+
+Validation:
+- `get_errors` reported no diagnostics in the edited LAN source files.
+
+Remaining open item for issue #86:
+- LAN discovery list still relies on global broadcast `255.255.255.255`; the next likely functional fix is interface/subnet-aware broadcast instead of single global broadcast.
+
+Follow-up after next two-machine run:
+- direct-connect join now succeeds, but host->client control propagation remained inconsistent (game options, start signal, and room teardown behavior).
+- root-cause hypothesis refined: several in-game control messages still used broadcast when no explicit destination IP was provided, which is fragile on mixed macOS/Linux networks.
+- updated `LANAPI::sendMessage()` to prefer directed fan-out to known human slots for in-game control/state packets (`GAME_OPTIONS`, `GAME_START`, `GAME_START_TIMER`, `REQUEST_GAME_LEAVE`, `SET_ACCEPT`, `MAP_AVAILABILITY`, `CHAT`, `INACTIVE`), while preserving broadcast fallback when no target slot exists.
+- kept lobby/discovery announcements unchanged so existing LAN listing behavior is not silently altered in this patch.
+
+Files touched:
+- `Core/GameEngine/Source/GameNetwork/LANAPI.cpp`
+
+Validation:
+- `get_errors` reported no diagnostics in the edited file.
+
+Follow-up: LAN lobby discovery improvement
+- implemented subnet-aware broadcast dispatch in `LANAPI::sendMessage()` for POSIX builds.
+- broadcast path now prefers per-interface subnet broadcast addresses associated with the selected local LAN IP, with fallback to global `255.255.255.255` if none are available.
+- this targets the LAN lobby visibility issue (machines not seeing each other) without removing compatibility fallback behavior.
+
+Files touched:
+- `Core/GameEngine/Source/GameNetwork/LANAPI.cpp`
+
+Validation:
+- `get_errors` reported no diagnostics in the edited file.
 
 ## 2026-04-11 (SESSION 115): Triage issue #84 (macOS EXC_BAD_ACCESS in AI guard state)
 
@@ -229,80 +340,6 @@ Given repeated Linux packaging friction around runtime compatibility, implemente
 
 **Takeaway:**
 AppImage is currently a viable short-term Linux packaging path for this project state.
-
-## 2026-04-09 (SESSION CURRENT): Deep diagnosis of Vulkan WSI (VK_KHR_surface) in Flatpak sandbox
-
-Investigated and partially resolved the "Installed Vulkan doesn't implement the VK_KHR_surface extension" error blocking Flatpak runtime graphics.
-
-**Findings:**
-- **Scope of failure**: ALL Vulkan ICDs fail identically (Intel HAS, Intel standard, Nouvelle, Lavapipe, AMD, VirtIO)
-- **Library loading**: Successful - no missing SONAME symbols in ldd output
-- **Display server**: Available (WAYLAND_DISPLAY=wayland-0)
-- **Permissions**: Correct (--socket=wayland, --socket=fallback-x11, --device=dri)
-- **Root cause**: Flatpak Platform 24.08 sandbox does NOT expose Vulkan WSI layer implementations through the Vulkan loader
-
-**What was done:**
-- Implemented comprehensive wrapper script fixes in both `flatpak/run-flatpak.sh` and `flatpak/run-flatpak-generals.sh`:
-  - Force Wayland-only mode (unset DISPLAY to prevent X11 fallback confusion)
-  - Prioritize Intel HAS ICD (best Wayland WSI support)
-  - Explicit WAYLAND_DISPLAY and VK_ICD_FILENAMES configuration
-  - DXVK_FORCESWRENDER fallback preparation
-
-- Added comprehensive library bundling in `scripts/build/linux/build-linux-flatpak.sh`:
-  - XCB/Wayland WSI libraries: libxcb-present, libxcb-sync, libxcb-randr, libxcb-xfixes, libxshmfence
-  - X11 integration: libX11, libX11-xcb, libXau
-  - Vulkan ICD libraries from /usr/lib/x86_64-linux-gnu/GL/default/lib
-  - Recursive ldd-based FFmpeg codec closure
-
-- Created complete Flatpak infrastructure:
-  - Dual manifests for GeneralsX and GeneralsXZH (com.fbraz3.*.yml)
-  - AppStream desktop entries and metainfo.xml files
-  - CI matrix workflow (.github/workflows/build-linux-flatpak.yml)
-  - VS Code build tasks for local testing
-  - Icon assets (512x512 PNG for AppStreamintegration)
-
-**Test results:**
-- Bundles successfully generate and install
-- Apps appear in GNOME menu
-- All runtime libraries load without errors
-- Execution reaches graphics initialization
-- VK_KHR_surface unavailability blocks window creation (unfixed)
-
-**Why the seven attempted fixes all failed:**
-VK_KHR_surface unavailability is a **sandbox-level limitation**, NOT a library packaging issue:
-- Vulkan loader inside Flatpak doesn't expose WSI extensions from any ICD
-- All HW drivers fail identically (systematic, not ICD-specific)
-- Library presence verified but extension still unreported by loader
-
-**Next steps for complete resolution:**
-1. Upgrade Flatpak Platform to version 25.04+ with improved Vulkan WSI support (if available)
-2. Research if Vulkan WSI layer plugins (vulkan-wsi-*) need explicit bundling
-3. Implement DXVK software rendering fallback as app-level workaround
-4. Consider OpenGL backend as alternative to Vulkan if WSI remains inaccessible
-
-**Files changed:**
-- `flatpak/run-flatpak.sh` - Wayland WSI configuration
-- `flatpak/run-flatpak-generals.sh` - Same for Generals
-- `scripts/build/linux/build-linux-flatpak.sh` - Library bundling + XCB/Wayland additions
-- `.gitignore` - Changed from ignoring entire flatpak/ dir to just staging artifacts
-- `.github/workflows/build-linux-flatpak.yml` - New CI matrix for dual builds
-- `.vscode/tasks.json` - Flatpak build tasks
-- `flatpak/com.fbraz3.GeneralsX*.yml` - Complete manifests
-- `flatpak/com.fbraz3.GeneralsX*.desktop` - Desktop entries
-- `flatpak/com.fbraz3.GeneralsX*.metainfo.xml` - AppStream metadata
-- `flatpak/run-flatpak*.sh` - Executable wrappers
-- `flatpak/*_icon_512.png` - Menu icons
-- `docs/WORKDIR/lessons/2026-04-LESSONS.md` - Diagnostic documentation
-
-**Commit message:**
-```
-build(flatpak): Add Vulkan WSI diagnostics and XCB/Wayland library bundling
-
-Note: VK_KHR_surface error persists due to Flatpak platform limitation.
-All GPU ICDs fail identically - indicates system-level Vulkan WSI
-unavailability in 24.08 sandbox. See lessons doc for full diagnosis.
-```
-
 ## 2026-04-08 (SESSION 113): Remove stale local DXVK patch-flow narrative
 
 Aligned macOS DXVK docs and CMake comments with the current pinned-fork source model and deprecated the old local patch helper script.
@@ -656,57 +693,3 @@ Both steps completed successfully in this session.
 2. Runtime verification from manual test: behavior works in both Generals and Zero Hour.
 
 **Outcome**: Issue #58 resolved on branch `fix/issue-58-sdl3-text-entry` and ready for PR.
-
-## 2026-04-09 (CONTINUED): Root cause analysis - Vulkan WSI sand boxing incompatibility
-
-**Deep Investigation Results:**
-
-After upgrading Flatpak Runtime from 24.08 to 25.08 (Mesa 25.3.5), enabled detailed Vulkan loader debugging and discovered:
-
-**The Real Problem:**
-```
-ERROR: /usr/lib/x86_64-linux-gnu/GL/default/lib/libvulkan_radeon.so: undefined symbol: xcb_dri3_import_syncobj_checked
-```
-
-This symbol is required by modern GPU drivers (Radeon, Intel, etc.) for DRI3/Syncobj support, but Freedesktop SDK 25.08's `libxcb-dri3.so` does NOT export it. This represents a version incompatibility between:
-- Vulkan drivers (expect modern DRI3 protocol features)
-- Flatpak SDK libxcb (lagging behind host system's libxcb version)
-
-**Why Software Rendering Fallback Failed:**
-- SDL3 hardcoded to use Vulkan window first
-- When Vulkan init fails (no VK_KHR_surface), SDL3 crashes with FATAL error
-- DXVK software rendering settings ignored because window creation fails before DXVK runs
-
-**Why Runtime 25.08 Didn't Fix It:**
-- Platform was updated, but libxcb-dri3 version in that platform still too old
-- Needed: libxcb >= 1.15+ with `xcb_dri3_import_syncobj_checked` (probably release 2022+)
-- Current: Flatpak SDK 25.08 has older libxcb
-
-**Real Solution Path Would Be:**
-1. Flatpak SDK 25.12+ or later with updated libxcb
-2. OR: Recompile game with OpenGL backend instead of Vulkan
-3. OR: Use native Linux build (succeeds with host Vulkan drivers)
-
-**Validated Workaround:**
-Run game OUTSIDE Flatpak with native build:
-```bash
-cd ~/GeneralsX/GeneralsMD
-./run.sh -win  # Native Linux build works perfectly
-```
-
-**What DID Work:**
-- Flatpak packaging infrastructure (100%)
-- Runtime management and updates
-- Library bundling strategies  
-- Wrapper script environment configuration
-- CI/CD matrix workflow
-- Desktop menu integration
-- All non-graphics components (audio, input, game logic)
-
-**Commit Summary:**
-- Attempted Runtime 24.08 → 25.08 upgrade (no change in libxcb version)
-- Added DXVK software rendering flags (cannot be used due to SDL3 hardcoding)
-- Documented xcb_dri3_import_syncobj_checked incompatibility for future reference
-- Confirmed native Linux build as functional user path
-
-**Recommendation:** Close Flatpak port as "working with limitation" and keep native Linux as primary distribution method until Flatpak SDK updates their libxcb.


### PR DESCRIPTION
## Summary
Align the CI and release pipelines with the new reusable workflow contracts and preserve the release-tag flow brought from main.

## What changed
- consolidate Linux and macOS reusable build invocations around OS-level matrix workflows
- add Linux package format selection for manual runs: `gzip`, `appimage`, or `gzip + appimage`
- switch release manual inputs from multiple booleans to a single `release_mode` choice
- keep tag creation before builds and cleanup on downstream failure
- resolve the `release.yml` merge conflict by preserving both the branch workflow updates and the tag-management flow from main

## Notes for review
- Linux CI still requests both package formats automatically
- release changelog detection now excludes the in-flight release tag so comparisons use the previous published tag