### PR TITLE
fix(audio-openal): restore briefing video audio

### DIFF
--- a/Core/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
@@ -568,6 +568,14 @@ void SinglePlayerLoadScreen::init( GameInfo *game )
 
 			m_videoStream->frameNext();
 
+			// GeneralsX @bugfix fbraz3 20/04/2026 The LoadScreen video loop is a blocking loop
+			// that never reaches TheVideoPlayer->update(). Without an explicit update() call here,
+			// the OpenAL audio source can underrun (AL_STOPPED) or stay in AL_INITIAL and never
+			// restart. update() calls audioStream->play() if the source is not already playing.
+			// Issue: https://github.com/fbraz3/GeneralsX/issues/38
+			if (TheVideoPlayer)
+				TheVideoPlayer->update();
+
 			if(m_videoBuffer)
 				m_loadScreen->winGetInstanceData()->setVideoBuffer(m_videoBuffer);
 			if(m_videoStream->frameIndex() % progressUpdateCount == 0)

--- a/Core/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
@@ -959,6 +959,10 @@ void ChallengeLoadScreen::init( GameInfo *game )
 
 	// create the new background video stream
 	m_videoStream = TheVideoPlayer->open( TheCampaignManager->getCurrentMission()->m_movieLabel );
+	if (m_videoStream == nullptr)
+	{
+		return;
+	}
 
 	// Create the new buffer
 	m_videoBuffer = TheDisplay->createVideoBuffer();

--- a/Core/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
@@ -1086,6 +1086,13 @@ void ChallengeLoadScreen::init( GameInfo *game )
 			m_videoStream->frameRender(m_videoBuffer);
 			m_videoStream->frameNext();
 
+			// GeneralsX @bugfix fbraz3 20/04/2026 Same blocking loop fix as SinglePlayerLoadScreen.
+			// TheVideoPlayer->update() must be called explicitly here since this loop never returns
+			// to the main game loop. Without it, OpenAL audio source stays AL_INITIAL/AL_STOPPED.
+			// Issue: https://github.com/fbraz3/GeneralsX/issues/38
+			if (TheVideoPlayer)
+				TheVideoPlayer->update();
+
 			if(m_videoBuffer)
 				m_loadScreen->winGetInstanceData()->setVideoBuffer(m_videoBuffer);
 

--- a/Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioStream.cpp
+++ b/Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioStream.cpp
@@ -71,10 +71,12 @@ void OpenALAudioStream::update()
         }
     }
 
-    // Only restart a stopped source when there is data queued to play.
-    // Calling alSourcePlay() with an empty queue produces no sound and
-    // immediately transitions the source back to AL_STOPPED.
-    if (sourceState == AL_STOPPED) {
+    // GeneralsX @bugfix fbraz3 20/04/2026 Also restart an AL_INITIAL source (freshly created or
+    // reset()ed on a new stream) - alSourceStop() is a no-op on AL_INITIAL so reset() leaves
+    // the source in AL_INITIAL, not AL_STOPPED. Without this, the first video in a session
+    // would never start audio because update() from onFrame() saw AL_INITIAL and skipped play().
+    // Issue: https://github.com/fbraz3/GeneralsX/issues/38
+    if (sourceState == AL_STOPPED || sourceState == AL_INITIAL) {
         ALint num_remaining;
         alGetSourcei(m_source, AL_BUFFERS_QUEUED, &num_remaining);
         if (num_remaining > 0) {

--- a/Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioStream.cpp
+++ b/Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioStream.cpp
@@ -1,13 +1,25 @@
 #include "OpenALAudioDevice/OpenALAudioStream.h"
 #include "OpenALAudioDevice/OpenALAudioManager.h"
+#include <AL/alext.h>
 
 OpenALAudioStream::OpenALAudioStream()
 { 
     alGenSources(1, &m_source);
     alGenBuffers(AL_STREAM_BUFFER_COUNT, m_buffers);
 
-    // Make stream ignore positioning
+    // GeneralsX @bugfix BenderAI 22/04/2026 Force video stream source to non-positional direct playback.
     alSourcei(m_source, AL_SOURCE_RELATIVE, AL_TRUE);
+    alSource3f(m_source, AL_POSITION, 0.0f, 0.0f, 0.0f);
+    alSource3f(m_source, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
+    alSourcef(m_source, AL_ROLLOFF_FACTOR, 0.0f);
+    alSourcef(m_source, AL_GAIN, 1.0f);
+    alSourcei(m_source, AL_LOOPING, AL_FALSE);
+#ifdef AL_DIRECT_CHANNELS_SOFT
+    alSourcei(m_source, AL_DIRECT_CHANNELS_SOFT, AL_TRUE);
+#endif
+#ifdef AL_SOURCE_SPATIALIZE_SOFT
+    alSourcei(m_source, AL_SOURCE_SPATIALIZE_SOFT, AL_FALSE);
+#endif
 
     DEBUG_LOG(("OpenALAudioStream created: %i\n", m_source));
 }
@@ -34,8 +46,24 @@ bool OpenALAudioStream::bufferData(uint8_t *data, size_t data_size, ALenum forma
     }
 
     ALuint &current_buffer = m_buffers[m_current_buffer_idx];
+    // GeneralsX @bugfix BenderAI 22/04/2026 Detect and reject invalid OpenAL buffer/queue operations.
+    while (alGetError() != AL_NO_ERROR) {}
     alBufferData(current_buffer, format, data, data_size, samplerate);
+    ALenum err = alGetError();
+    if (err != AL_NO_ERROR) {
+        DEBUG_LOG(("OpenALAudioStream::bufferData alBufferData failed: err=0x%x format=0x%x size=%zu rate=%d\n",
+            (unsigned int)err, (unsigned int)format, data_size, samplerate));
+        return false;
+    }
+
     alSourceQueueBuffers(m_source, 1, &current_buffer);
+    err = alGetError();
+    if (err != AL_NO_ERROR) {
+        DEBUG_LOG(("OpenALAudioStream::bufferData alSourceQueueBuffers failed: err=0x%x source=%u buffer=%u\n",
+            (unsigned int)err, (unsigned int)m_source, (unsigned int)current_buffer));
+        return false;
+    }
+
     m_current_buffer_idx++;
 
     if (m_current_buffer_idx >= AL_STREAM_BUFFER_COUNT)
@@ -49,42 +77,45 @@ void OpenALAudioStream::update()
     ALint sourceState;
     alGetSourcei(m_source, AL_SOURCE_STATE, &sourceState);
 
-    ALint processed;
-    alGetSourcei(m_source, AL_BUFFERS_PROCESSED, &processed);
-    DEBUG_LOG(("%i buffers have been processed\n", processed));
-    while (processed > 0) {
-        ALuint buffer;
-        alSourceUnqueueBuffers(m_source, 1, &buffer);
-        processed--;
-    }
-
     ALint num_queued;
     alGetSourcei(m_source, AL_BUFFERS_QUEUED, &num_queued);
-    DEBUG_LOG(("Having %i buffers queued\n", num_queued));
-    if (num_queued < AL_STREAM_BUFFER_COUNT/2 && m_requireDataCallback) {
-        // Ask for more data to be buffered
-        // Only fill up to the half, because some formats can output
-        // more than one buffer per decoded frame
-        while (num_queued < AL_STREAM_BUFFER_COUNT/2) {
-            m_requireDataCallback();
-        	num_queued++;
-        }
+
+    // GeneralsX @bugfix BenderAI 22/04/2026 Restart before unqueue to avoid dropping freshly queued
+    // briefing buffers when OpenAL reports AL_STOPPED with processed buffers.
+    if ((sourceState == AL_STOPPED || sourceState == AL_INITIAL || sourceState == AL_PAUSED) && num_queued > 0) {
+        play();
+        alGetSourcei(m_source, AL_SOURCE_STATE, &sourceState);
     }
 
-    // GeneralsX @bugfix fbraz3 20/04/2026 Restart source if it is not playing:
-    // - AL_STOPPED: source ran out of buffers and stopped.
-    // - AL_INITIAL: freshly created / reset()ed source (alSourceStop on AL_INITIAL is a no-op,
-    //   so reset() leaves the source in AL_INITIAL rather than AL_STOPPED).
-    // - AL_PAUSED: OpenAL-Soft on macOS auto-pauses all sources when the application loses
-    //   window focus (Core Audio session suspension). Without this, a momentary focus loss
-    //   during the shell-map / loading-screen transition permanently silences video audio
-    //   because update() never called play() again.
-    // Issue: https://github.com/fbraz3/GeneralsX/issues/38
-    if (sourceState == AL_STOPPED || sourceState == AL_INITIAL || sourceState == AL_PAUSED) {
-        ALint num_remaining;
-        alGetSourcei(m_source, AL_BUFFERS_QUEUED, &num_remaining);
-        if (num_remaining > 0) {
-            play();
+    ALint processedBeforeUnqueue = 0;
+    alGetSourcei(m_source, AL_BUFFERS_PROCESSED, &processedBeforeUnqueue);
+    DEBUG_LOG(("%i buffers have been processed\n", processedBeforeUnqueue));
+
+    // GeneralsX @bugfix BenderAI 22/04/2026 Only unqueue processed data in active playback states.
+    ALint processedToUnqueue = ((sourceState == AL_PLAYING || sourceState == AL_PAUSED) ? processedBeforeUnqueue : 0);
+    while (processedToUnqueue > 0) {
+        ALuint buffer;
+        alSourceUnqueueBuffers(m_source, 1, &buffer);
+        processedToUnqueue--;
+    }
+
+    alGetSourcei(m_source, AL_BUFFERS_QUEUED, &num_queued);
+    DEBUG_LOG(("Having %i buffers queued\n", num_queued));
+
+    if (num_queued < AL_STREAM_BUFFER_COUNT / 2 && m_requireDataCallback) {
+        // GeneralsX @bugfix BenderAI 22/04/2026 Do not fake queue growth when callback fails to enqueue data.
+        // Ask for more data to be buffered.
+        // Only fill up to the half, because some formats can output
+        // more than one buffer per decoded frame.
+        while (num_queued < AL_STREAM_BUFFER_COUNT / 2) {
+            m_requireDataCallback();
+
+            ALint refreshedQueued = 0;
+            alGetSourcei(m_source, AL_BUFFERS_QUEUED, &refreshedQueued);
+            if (refreshedQueued <= num_queued) {
+                break;
+            }
+            num_queued = refreshedQueued;
         }
     }
 }

--- a/Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioStream.cpp
+++ b/Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioStream.cpp
@@ -71,12 +71,16 @@ void OpenALAudioStream::update()
         }
     }
 
-    // GeneralsX @bugfix fbraz3 20/04/2026 Also restart an AL_INITIAL source (freshly created or
-    // reset()ed on a new stream) - alSourceStop() is a no-op on AL_INITIAL so reset() leaves
-    // the source in AL_INITIAL, not AL_STOPPED. Without this, the first video in a session
-    // would never start audio because update() from onFrame() saw AL_INITIAL and skipped play().
+    // GeneralsX @bugfix fbraz3 20/04/2026 Restart source if it is not playing:
+    // - AL_STOPPED: source ran out of buffers and stopped.
+    // - AL_INITIAL: freshly created / reset()ed source (alSourceStop on AL_INITIAL is a no-op,
+    //   so reset() leaves the source in AL_INITIAL rather than AL_STOPPED).
+    // - AL_PAUSED: OpenAL-Soft on macOS auto-pauses all sources when the application loses
+    //   window focus (Core Audio session suspension). Without this, a momentary focus loss
+    //   during the shell-map / loading-screen transition permanently silences video audio
+    //   because update() never called play() again.
     // Issue: https://github.com/fbraz3/GeneralsX/issues/38
-    if (sourceState == AL_STOPPED || sourceState == AL_INITIAL) {
+    if (sourceState == AL_STOPPED || sourceState == AL_INITIAL || sourceState == AL_PAUSED) {
         ALint num_remaining;
         alGetSourcei(m_source, AL_BUFFERS_QUEUED, &num_remaining);
         if (num_remaining > 0) {

--- a/Core/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
@@ -323,6 +323,9 @@ FFmpegVideoStream::FFmpegVideoStream(FFmpegFile* file)
 
 #ifdef SAGE_USE_OPENAL
 	// Start audio playback
+	// GeneralsX @bugfix fbraz3 23/04/2026 Ensure video stream starts with audible gain even after prior source reuse.
+	// Issue: https://github.com/fbraz3/GeneralsX/issues/38
+	audioStream->setVolume(1.0f);
 	audioStream->play();
 #endif
 
@@ -363,24 +366,62 @@ void FFmpegVideoStream::onFrame(AVFrame *frame, int stream_idx, int stream_type,
 #ifdef SAGE_USE_OPENAL
 	else if (stream_type == AVMEDIA_TYPE_AUDIO) {
 		OpenALAudioStream* audioStream = (OpenALAudioStream*)TheAudio->getHandleForBink();
-		// Unqueue processed buffers first, then buffer new data, then
-		// (re)start playback. update() is called AFTER bufferData() so that
-		// the newly queued buffer is already present when update() checks
-		// whether to call alSourcePlay().
 		AVSampleFormat sampleFmt = static_cast<AVSampleFormat>(frame->format);
 		const int bytesPerSample = av_get_bytes_per_sample(sampleFmt);
 		const int frameSize = av_samples_get_buffer_size(nullptr, frame->ch_layout.nb_channels, frame->nb_samples, sampleFmt, 1);
+		if (frameSize <= 0 || bytesPerSample <= 0 || frame->ch_layout.nb_channels <= 0 || frame->nb_samples <= 0)
+			return;
+
+		int outputBitsPerSample = bytesPerSample * 8;
+		int outputFrameSize = frameSize;
 		uint8_t* frameData = frame->data[0];
-		// The format is planar - convert it to interleaved
-		if (av_sample_fmt_is_planar(sampleFmt))
+
+		// GeneralsX @bugfix fbraz3 23/04/2026 Convert float32 FFmpeg output to PCM16 for robust OpenAL compatibility.
+		// Issue: https://github.com/fbraz3/GeneralsX/issues/38
+		if (sampleFmt == AV_SAMPLE_FMT_FLT || sampleFmt == AV_SAMPLE_FMT_FLTP)
 		{
-			videoStream->m_audioBuffer = static_cast<uint8_t*>(av_realloc(videoStream->m_audioBuffer, frameSize));
+			outputBitsPerSample = 16;
+			outputFrameSize = frame->nb_samples * frame->ch_layout.nb_channels * (int)sizeof(int16_t);
+			videoStream->m_audioBuffer = static_cast<uint8_t*>(av_realloc(videoStream->m_audioBuffer, outputFrameSize));
+			if (videoStream->m_audioBuffer == nullptr)
+			{
+				DEBUG_LOG(("Failed to allocate converted audio buffer"));
+				return;
+			}
+			int16_t *dst = reinterpret_cast<int16_t *>(videoStream->m_audioBuffer);
+			if (sampleFmt == AV_SAMPLE_FMT_FLTP)
+			{
+				for (int sample_idx = 0; sample_idx < frame->nb_samples; ++sample_idx)
+				{
+					for (int channel_idx = 0; channel_idx < frame->ch_layout.nb_channels; ++channel_idx)
+					{
+						const float sample = reinterpret_cast<const float *>(frame->data[channel_idx])[sample_idx];
+						const float clamped = (sample < -1.0f) ? -1.0f : ((sample > 1.0f) ? 1.0f : sample);
+						*dst++ = static_cast<int16_t>(clamped * 32767.0f);
+					}
+				}
+			}
+			else
+			{
+				const float *src = reinterpret_cast<const float *>(frame->data[0]);
+				const int totalSamples = frame->nb_samples * frame->ch_layout.nb_channels;
+				for (int i = 0; i < totalSamples; ++i)
+				{
+					const float clamped = (src[i] < -1.0f) ? -1.0f : ((src[i] > 1.0f) ? 1.0f : src[i]);
+					*dst++ = static_cast<int16_t>(clamped * 32767.0f);
+				}
+			}
+			frameData = videoStream->m_audioBuffer;
+		}
+		// The format is planar - convert it to interleaved
+		else if (av_sample_fmt_is_planar(sampleFmt))
+		{
+			videoStream->m_audioBuffer = static_cast<uint8_t*>(av_realloc(videoStream->m_audioBuffer, outputFrameSize));
 			if (videoStream->m_audioBuffer == nullptr)
 			{
 				DEBUG_LOG(("Failed to allocate audio buffer"));
 				return;
 			}
-
 			// Write the samples into our audio buffer
 			for (int sample_idx = 0; sample_idx < frame->nb_samples; sample_idx++)
 			{
@@ -395,8 +436,8 @@ void FFmpegVideoStream::onFrame(AVFrame *frame, int stream_idx, int stream_type,
 			frameData = videoStream->m_audioBuffer;
 		}
 
-		ALenum format = OpenALAudioManager::getALFormat(frame->ch_layout.nb_channels, bytesPerSample * 8);
-		audioStream->bufferData(frameData, frameSize, format, frame->sample_rate);
+		ALenum format = OpenALAudioManager::getALFormat(frame->ch_layout.nb_channels, outputBitsPerSample);
+		audioStream->bufferData(frameData, outputFrameSize, format, frame->sample_rate);
 		audioStream->update();
 	}
 #endif

--- a/Core/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
@@ -335,6 +335,17 @@ FFmpegVideoStream::FFmpegVideoStream(FFmpegFile* file)
 
 FFmpegVideoStream::~FFmpegVideoStream()
 {
+	// GeneralsX @bugfix fbraz3 20/04/2026 Stop and clear queued OpenAL buffers so video audio
+	// does not bleed into gameplay after the loading screen closes the stream.
+	// Issue: https://github.com/fbraz3/GeneralsX/issues/38
+#ifdef SAGE_USE_OPENAL
+	if (TheAudio)
+	{
+		OpenALAudioStream* audioStream = (OpenALAudioStream*)TheAudio->getHandleForBink();
+		if (audioStream)
+			audioStream->reset();
+	}
+#endif
 	av_freep(&m_audioBuffer);
 	av_frame_free(&m_frame);
 	sws_freeContext(m_swsContext);

--- a/GeneralsMD/Code/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
@@ -336,6 +336,9 @@ FFmpegVideoStream::FFmpegVideoStream(FFmpegFile* file)
 
 #ifdef SAGE_USE_OPENAL
     // Start audio playback
+    // GeneralsX @bugfix fbraz3 23/04/2026 Ensure video stream starts with audible gain even after prior source reuse.
+    // Issue: https://github.com/fbraz3/GeneralsX/issues/38
+    audioStream->setVolume(1.0f);
     audioStream->play();
 #endif
 
@@ -376,15 +379,61 @@ void FFmpegVideoStream::onFrame(AVFrame *frame, int stream_idx, int stream_type,
 #ifdef SAGE_USE_OPENAL
     else if (stream_type == AVMEDIA_TYPE_AUDIO) {
         OpenALAudioStream* audioStream = (OpenALAudioStream*)TheAudio->getHandleForBink();
+
         AVSampleFormat sampleFmt = static_cast<AVSampleFormat>(frame->format);
         const int bytesPerSample = av_get_bytes_per_sample(sampleFmt);
         const int frameSize =
             av_samples_get_buffer_size(NULL, frame->ch_layout.nb_channels, frame->nb_samples, sampleFmt, 1);
+        if (frameSize <= 0 || bytesPerSample <= 0 || frame->ch_layout.nb_channels <= 0 || frame->nb_samples <= 0) {
+            return;
+        }
+
+        int outputBitsPerSample = bytesPerSample * 8;
+        int outputFrameSize = frameSize;
         uint8_t* frameData = frame->data[0];
-        // The format is planar - convert it to interleaved
-        if (av_sample_fmt_is_planar(sampleFmt))
+
+        // GeneralsX @bugfix BenderAI 22/04/2026 Convert float32 FFmpeg output to PCM16 for robust OpenAL compatibility.
+        if (sampleFmt == AV_SAMPLE_FMT_FLT || sampleFmt == AV_SAMPLE_FMT_FLTP)
         {
-            videoStream->m_audioBuffer = static_cast<uint8_t*>(av_realloc(videoStream->m_audioBuffer, frameSize));
+            outputBitsPerSample = 16;
+            outputFrameSize = frame->nb_samples * frame->ch_layout.nb_channels * (int)sizeof(int16_t);
+            videoStream->m_audioBuffer = static_cast<uint8_t*>(av_realloc(videoStream->m_audioBuffer, outputFrameSize));
+            if (videoStream->m_audioBuffer == nullptr)
+            {
+                DEBUG_LOG(("Failed to allocate converted audio buffer"));
+                return;
+            }
+
+            int16_t *dst = reinterpret_cast<int16_t *>(videoStream->m_audioBuffer);
+            if (sampleFmt == AV_SAMPLE_FMT_FLTP)
+            {
+                for (int sample_idx = 0; sample_idx < frame->nb_samples; ++sample_idx)
+                {
+                    for (int channel_idx = 0; channel_idx < frame->ch_layout.nb_channels; ++channel_idx)
+                    {
+                        const float sample = reinterpret_cast<const float *>(frame->data[channel_idx])[sample_idx];
+                        const float clamped = (sample < -1.0f) ? -1.0f : ((sample > 1.0f) ? 1.0f : sample);
+                        *dst++ = static_cast<int16_t>(clamped * 32767.0f);
+                    }
+                }
+            }
+            else
+            {
+                const float *src = reinterpret_cast<const float *>(frame->data[0]);
+                const int totalSamples = frame->nb_samples * frame->ch_layout.nb_channels;
+                for (int i = 0; i < totalSamples; ++i)
+                {
+                    const float clamped = (src[i] < -1.0f) ? -1.0f : ((src[i] > 1.0f) ? 1.0f : src[i]);
+                    *dst++ = static_cast<int16_t>(clamped * 32767.0f);
+                }
+            }
+
+            frameData = videoStream->m_audioBuffer;
+        }
+        // The format is planar - convert it to interleaved
+        else if (av_sample_fmt_is_planar(sampleFmt))
+        {
+            videoStream->m_audioBuffer = static_cast<uint8_t*>(av_realloc(videoStream->m_audioBuffer, outputFrameSize));
             if (videoStream->m_audioBuffer == nullptr)
             {
                 DEBUG_LOG(("Failed to allocate audio buffer"));
@@ -407,8 +456,8 @@ void FFmpegVideoStream::onFrame(AVFrame *frame, int stream_idx, int stream_type,
             frameData = videoStream->m_audioBuffer;
         }
 
-        ALenum format = OpenALAudioManager::getALFormat(frame->ch_layout.nb_channels, bytesPerSample * 8);
-        audioStream->bufferData(frameData, frameSize, format, frame->sample_rate);
+        ALenum format = OpenALAudioManager::getALFormat(frame->ch_layout.nb_channels, outputBitsPerSample);
+        audioStream->bufferData(frameData, outputFrameSize, format, frame->sample_rate);
         audioStream->update();
     }
 #endif
@@ -422,14 +471,11 @@ void FFmpegVideoStream::onFrame(AVFrame *frame, int stream_idx, int stream_type,
 void FFmpegVideoStream::update( void )
 {
 #ifdef SAGE_USE_OPENAL
-    // Resume audio playback only if not already playing.
-    // Calling alSourcePlay() on an AL_PLAYING source restarts it from the
-    // first unprocessed buffer (OpenAL 1.1 spec §4.3.9), which causes
-    // effective silence when invoked every game frame.
+    // GeneralsX @bugfix BenderAI 22/04/2026 Keep source maintenance without force-restarting playback each frame.
+    // Calling play() from the video update loop can continuously reset source progress
+    // during loadscreen transitions, leading to effective silence.
     OpenALAudioStream* audioStream = (OpenALAudioStream*)TheAudio->getHandleForBink();
-    if (!audioStream->isPlaying()) {
-        audioStream->play();
-    }
+    audioStream->update();
 #endif
 	//BinkWait( m_handle );
 }

--- a/GeneralsMD/Code/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
@@ -348,6 +348,17 @@ FFmpegVideoStream::FFmpegVideoStream(FFmpegFile* file)
 
 FFmpegVideoStream::~FFmpegVideoStream()
 {
+    // GeneralsX @bugfix fbraz3 20/04/2026 Stop and clear queued OpenAL buffers so video audio
+    // does not bleed into gameplay after the loading screen closes the stream.
+    // Issue: https://github.com/fbraz3/GeneralsX/issues/38
+#ifdef SAGE_USE_OPENAL
+    if (TheAudio)
+    {
+        OpenALAudioStream* audioStream = (OpenALAudioStream*)TheAudio->getHandleForBink();
+        if (audioStream)
+            audioStream->reset();
+    }
+#endif
     av_freep(&m_audioBuffer);
     av_frame_free(&m_frame);
     sws_freeContext(m_swsContext);

--- a/GeneralsMD/Code/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
@@ -334,7 +334,7 @@ FFmpegVideoStream::FFmpegVideoStream(FFmpegFile* file)
     while (m_good && m_gotFrame == false)
         m_good = m_ffmpegFile->decodePacket();
 
- #ifdef SAGE_USE_OPENAL
+#ifdef SAGE_USE_OPENAL
     // Start audio playback
     audioStream->play();
 #endif
@@ -376,10 +376,6 @@ void FFmpegVideoStream::onFrame(AVFrame *frame, int stream_idx, int stream_type,
 #ifdef SAGE_USE_OPENAL
     else if (stream_type == AVMEDIA_TYPE_AUDIO) {
         OpenALAudioStream* audioStream = (OpenALAudioStream*)TheAudio->getHandleForBink();
-        // Unqueue processed buffers first, then buffer new data, then
-        // (re)start playback. update() is called AFTER bufferData() so that
-        // the newly queued buffer is already present when update() checks
-        // whether to call alSourcePlay().
         AVSampleFormat sampleFmt = static_cast<AVSampleFormat>(frame->format);
         const int bytesPerSample = av_get_bytes_per_sample(sampleFmt);
         const int frameSize =

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,6 +2,30 @@
 
 ---
 
+## 2026-04-23: Backport briefing-video audio fix to Generals and remove audit instrumentation
+
+Finished the issue #38 video-audio fix by carrying the stable OpenAL/FFmpeg changes from Zero Hour into the shared Generals path, then cleaned out the temporary audit probes used during triage.
+
+What was done:
+- kept the shared OpenAL stream fix that restarts before unqueueing processed buffers, preventing freshly queued briefing audio from being dropped when the source reaches `AL_STOPPED`, `AL_INITIAL`, or `AL_PAUSED`.
+- backported the FFmpeg-side hardening into the shared/Core video path used by Generals:
+  - force Bink/OpenAL stream gain to `1.0f` before playback start.
+  - reject invalid decoded audio frame sizes early.
+  - convert FFmpeg float audio output (`FLT`/`FLTP`) to PCM16 before queueing into OpenAL.
+- kept the Zero Hour FFmpeg path aligned with the same playback and conversion behavior.
+- removed all temporary `[GX-AUDIT]` traces and leftover `cstdio` includes from the touched files.
+
+Files touched:
+- `Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioStream.cpp`
+- `Core/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp`
+- `GeneralsMD/Code/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp`
+- `Core/GameEngine/Source/GameClient/GUI/LoadScreen.cpp`
+
+Validation:
+- manual testing confirmed the fix behaves correctly in both Generals and Zero Hour.
+- verified no `GX-AUDIT`, `Temporary audit`, or `Runtime audit` markers remain in the touched files.
+- verified editor diagnostics report no errors in the modified sources.
+
 ## 2026-04-21 (SESSION 122): Split Linux CI packaging into explicit gzip and AppImage jobs
 
 Refined the Linux workflow model so each reusable build invocation produces exactly one package format.

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,6 +2,24 @@
 
 ---
 
+## 2026-04-20: Fix issue #38 - briefing audio bleeding into gameplay (Linux/macOS, Generals + Zero Hour)
+
+Branch: `fix/issue-38-briefing-audio-timing`
+
+**Problem**: On Linux/macOS (OpenAL builds), the campaign mission briefing audio played during the mission itself instead of during the loading screen video playback. Confirmed in both Generals base game and Zero Hour.
+
+**Root cause**: `FFmpegVideoStream::~FFmpegVideoStream()` freed FFmpeg resources (`m_frame`, `m_swsContext`, `m_ffmpegFile`) but did NOT stop or clear the OpenAL audio stream (`m_binkAudio` via `getHandleForBink()`). Audio buffers already queued in the OpenAL source continued draining after the stream object was destroyed, so the briefing audio played during the early frames of the mission.
+
+**Fix**: Added `audioStream->reset()` (which calls `alSourceStop()` + unqueues all pending OpenAL buffers) inside `FFmpegVideoStream::~FFmpegVideoStream()` under `#ifdef SAGE_USE_OPENAL`, with null-checks for `TheAudio` and `audioStream`. Applied to both:
+- `Core/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp`
+- `GeneralsMD/Code/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp`
+
+**Note**: `OpenALAudioStream::reset()` is already called in the constructor when a new stream opens. The destructor was the missing call site.
+
+**Related**: Issue #31 (long voice lines/OpenAL reliability) may contribute to the Generals `m_briefingVoice` path, but is a separate problem.
+
+---
+
 ## 2026-04-15 (SESSION CURRENT): Fix Linux build break in INI::scanType after upstream sync
 
 Addressed Linux and Flatpak build failures caused by a bad merge in the shared INI parser template.

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,6 +2,31 @@
 
 ---
 
+## 2026-04-20 (2): Fix video audio silenced after AL_PAUSED from macOS focus loss
+
+Branch: `fix/issue-38-briefing-audio-timing`
+
+**Problem**: After the AL_INITIAL fix, intro and campaign videos still played silently on macOS. Log analysis (previous session, 16958-line log) confirmed the OpenAL source starts in AL_PLAYING then permanently transitions to AL_PAUSED ~3 seconds into playback.
+
+**Root cause — OpenAL-Soft macOS auto-pause on focus loss**:
+OpenAL-Soft uses the Core Audio backend on macOS. When the application momentarily loses window focus (e.g., during shell-map → loading-screen transition — `SDL_EVENT_WINDOW_FOCUS_LOST` fires, Core Audio suspends the session), ALL OpenAL sources are auto-transitioned to `AL_PAUSED`. `OpenALAudioStream::update()` only restarted on `AL_STOPPED` and `AL_INITIAL`, so `AL_PAUSED` was never handled and the source stayed silent for the rest of the session.
+
+**Evidence from log**: state transitions from 4114 (AL_PLAYING) → 4115 (AL_PAUSED) at the exact moment `OSDisplaySetBusyState(false, false)` was logged (called by `GameLogic::setGameMode()` during shell-map mode change, which triggers window event processing). 97 AL_PLAYING entries, then 710+ AL_PAUSED entries — never recovered.
+
+**Fix**: Extended `OpenALAudioStream::update()` restart condition to also cover `AL_PAUSED`:
+```cpp
+if (sourceState == AL_STOPPED || sourceState == AL_INITIAL || sourceState == AL_PAUSED) {
+```
+Calling `alSourcePlay()` on a paused source resumes from the current position (OpenAL 1.1 spec §4.3.9), which is the correct behavior for continuous video audio streaming.
+
+Also removed temporary diagnostic `fprintf(stderr, ...)` traces from `FFmpegVideoPlayer.cpp` and `OpenALAudioStream.cpp` that were used to identify the root cause.
+
+**Files changed**:
+- `Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioStream.cpp` — AL_PAUSED handling
+- `GeneralsMD/Code/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp` — diagnostic cleanup
+
+---
+
 ## 2026-04-20: Fix campaign video audio not playing (OpenAL AL_INITIAL state + LoadScreen loop)
 
 Branch: `fix/issue-38-briefing-audio-timing`

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,7 +2,23 @@
 
 ---
 
-## 2026-04-20: Fix issue #38 - briefing audio bleeding into gameplay (Linux/macOS, Generals + Zero Hour)
+## 2026-04-20: Fix campaign video audio not playing (OpenAL AL_INITIAL state + LoadScreen loop)
+
+Branch: `fix/issue-38-briefing-audio-timing`
+
+**Problem**: Campaign briefing videos played without audio on Linux/macOS (OpenAL builds). Video image displayed correctly but no sound.
+
+**Root cause #1 — `AL_INITIAL` state not handled**:
+`OpenALAudioStream::update()` only restarted playback on `AL_STOPPED`. After `reset()` is called on a freshly created `OpenALAudioStream`, `alSourceStop()` is a no-op on an `AL_INITIAL` source, so the source stays in `AL_INITIAL` (not `AL_STOPPED`). When audio frames arrived via `onFrame()` and called `update()`, the `AL_INITIAL ≠ AL_STOPPED` condition skipped the `play()` call.
+
+**Root cause #2 — `TheVideoPlayer->update()` never called in blocking loop**:
+`SinglePlayerLoadScreen::init()` runs a blocking video loop that never returns to the main game loop, so `TheVideoPlayer->update()` (which calls `FFmpegVideoStream::update()` → `play()` if not playing) was never invoked during video playback. If the audio source underran or failed to start, there was nothing to restart it.
+
+**Fix**:
+- `OpenALAudioStream::update()`: added `|| sourceState == AL_INITIAL` to the restart condition
+- `LoadScreen.cpp` video loop: added explicit `TheVideoPlayer->update()` call after `frameNext()`
+
+
 
 Branch: `fix/issue-38-briefing-audio-timing`
 


### PR DESCRIPTION
## Summary
Fixes the briefing and video-audio regression from issue #38 by stabilizing the shared OpenAL streaming path and backporting the FFmpeg-side hardening needed by the base Generals path.

## What changed
- restart shared OpenAL video streams before unqueueing processed buffers
- keep video sources non-positional and direct in OpenAL
- reject invalid decoded audio frames before queueing
- convert FFmpeg float audio output to PCM16 before passing it to OpenAL
- force Bink/OpenAL video stream gain to `1.0f` before playback start
- keep the Generals and Zero Hour FFmpeg paths aligned
- remove temporary audit instrumentation used during triage
- update the April dev diary

## Validation
- manual test on macOS confirmed briefing/video audio works correctly in both Generals and Zero Hour
- verified no `GX-AUDIT`, `Temporary audit`, or `Runtime audit` markers remain in the touched files

Fixes #38