### PR TITLE
docs: add getting game files guide and rename install doc

### DIFF
--- a/.github/agents/Bender.agent.md
+++ b/.github/agents/Bender.agent.md
@@ -1,7 +1,8 @@
 ---
 description: "Pay Bender a beer and he'll help you with GeneralsX development tasks!"
-[vscode, execute, read, agent, edit, search, web, 'cognitionai/deepwiki/*', 'fetch/*', 'git/*', 'memory/*', 'sequentialthinking/*', todo]
+tools: [execute, read, agent, edit, search, web, 'cognitionai/deepwiki/*', 'git/*', 'github/*', todo]
 ---
+
 You are Bender, a sarcastic assistant for GeneralsX project. development. Focus on gaming and graphics programming (DirectX8, Vulkan, C++, asset pipelines).
 
 # Personality and Behavior

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,9 +334,11 @@ jobs:
           {
             echo "> This is a **beta** release. Some bugs are still expected. If you run into any problems, please [open an issue](https://github.com/fbraz3/GeneralsX/issues) so we can investigate."
             echo ""
-            echo "# Install Instructions"
+            echo "# Getting Started"
             echo ""
-            echo "https://github.com/fbraz3/GeneralsX/blob/main/docs/BUILD/INSTALL_INSTRUCTIONS.md"
+            echo "**Install the engine:** Follow the [Installation Guide](https://github.com/fbraz3/GeneralsX/blob/main/docs/BUILD/INSTALLATION.md) to set up GeneralsX on your platform."
+            echo ""
+            echo "**Don't have the game files?** Steam does not offer a macOS or Linux download for this title. See [Getting the Game Files](https://github.com/fbraz3/GeneralsX/blob/main/docs/BUILD/GETTING_THE_GAME_FILES.md) for step-by-step instructions (copy from Windows, CrossOver trial, or SteamCMD)."
             echo ""
 
             if [ -n "$ADDITIONAL_NOTES" ]; then

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ For **official releases and instructions**, visit:
 
 For release/runtime setup instructions (Linux and macOS), see:
 
-- [docs/BUILD/INSTALL_INSTRUCTIONS.md](docs/BUILD/INSTALL_INSTRUCTIONS.md)
+- [docs/BUILD/INSTALLATION.md](docs/BUILD/INSTALLATION.md)
+
+> **Don't have the game files yet?** The Steam version does not offer a macOS or Linux download. See [docs/BUILD/GETTING_THE_GAME_FILES.md](docs/BUILD/GETTING_THE_GAME_FILES.md) for three ways to obtain the original game assets (copy from Windows, CrossOver trial, or SteamCMD).
 
 ## How does this project differ from TheSuperHackers' work?
 

--- a/docs/BUILD/GETTING_THE_GAME_FILES.md
+++ b/docs/BUILD/GETTING_THE_GAME_FILES.md
@@ -1,0 +1,80 @@
+# Getting the Game Files
+
+GeneralsX is an open-source engine port — it provides the launcher and runtime, but **cannot distribute the original game assets** due to copyright. You must own a legitimate copy of *Command & Conquer: Generals - Zero Hour* (or the base game) to play.
+
+We build and test against the [Steam version](https://store.steampowered.com/app/2732960/Command__Conquer_Generals_Zero_Hour/). Other retail releases may work, but are not officially supported.
+
+Once you have the game files, see [INSTALLATION.md](INSTALLATION.md) for how to set up GeneralsX on your platform.
+
+---
+
+## The Problem: Steam Does Not Offer a macOS / Linux Download
+
+The original game is a Windows-only title on Steam. If you open Steam on macOS or Linux, the **Install** button will not appear. You need to obtain the Windows game files through one of the methods below and then copy them to your system.
+
+---
+
+## Option 1 — Copy From a Windows Installation (Easiest)
+
+If you have access to a Windows PC or a Windows virtual machine:
+
+1. Install *C&C Generals: Zero Hour* (and/or *Generals*) via Steam on Windows.
+2. Locate the installation folder, typically:
+   - `C:\Program Files (x86)\Steam\steamapps\common\Command and Conquer Generals Zero Hour`
+   - `C:\Program Files (x86)\Steam\steamapps\common\Command and Conquer Generals`
+3. Copy the folder(s) to your Mac or Linux system via USB drive, network share, or cloud storage.
+4. Place them in the expected locations:
+   - `$HOME/GeneralsX/GeneralsZH` for Zero Hour
+   - `$HOME/GeneralsX/Generals` for the base game
+
+---
+
+## Option 2 — CrossOver Trial (No Windows PC Needed)
+
+[CrossOver](https://www.codeweavers.com/crossover) allows you to run Windows software — including the Windows Steam client — directly on macOS or Linux. It offers a **free 14-day trial**.
+
+1. Download and install CrossOver from [codeweavers.com/crossover](https://www.codeweavers.com/crossover).
+2. Inside CrossOver, create a new bottle and install the **Windows version of Steam**.
+3. Log in to Steam and download *C&C Generals: Zero Hour* (and/or *Generals*).
+4. Locate the installed game files inside the CrossOver bottle (usually under `~/Library/Application Support/CrossOver/Bottles/<bottle-name>/drive_c/Program Files (x86)/Steam/steamapps/common/` on macOS).
+5. Copy the game folder(s) to the expected locations described above.
+
+> **Note**: CrossOver is only needed to download the game files. You do not need it to run GeneralsX — the GeneralsX engine runs natively on macOS and Linux.
+
+---
+
+## Option 3 — SteamCMD (Advanced, Command-Line)
+
+[SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) is Valve's official headless Steam client. It can download Windows game files on any platform, including macOS and Linux.
+
+1. Download and install SteamCMD by following the [official instructions](https://developer.valvesoftware.com/wiki/SteamCMD).
+2. Run SteamCMD and log in with your Steam account:
+
+   ```bash
+   ./steamcmd.sh
+   ```
+
+   Inside the SteamCMD prompt:
+
+   ```
+   login <your_steam_username>
+   force_install_dir ./zh_files
+   app_update 2732960 validate
+   quit
+   ```
+
+   - App ID `2732960` is *C&C Generals: Zero Hour*.
+   - App ID `2732940` is *C&C Generals* (base game).
+
+3. After the download completes, move the game folder to the expected location:
+   ```bash
+   mv ./zh_files "$HOME/GeneralsX/GeneralsZH"
+   ```
+
+---
+
+## Next Steps
+
+After placing the game files in the correct directories, follow [INSTALLATION.md](INSTALLATION.md) to download the GeneralsX release for your platform and launch the game.
+
+If you run into any issues, please [open a discussion](https://github.com/fbraz3/GeneralsX/discussions) or [report a bug](https://github.com/fbraz3/GeneralsX/issues/new/choose).

--- a/docs/BUILD/INSTALLATION.md
+++ b/docs/BUILD/INSTALLATION.md
@@ -3,6 +3,9 @@
 ## Prerequisites
 
 1. You must own a legitimate copy of the game. We build and test against the [Steam version](https://store.steampowered.com/app/2732960/Command__Conquer_Generals_Zero_Hour/). Other retail releases may work, but are not officially supported.
+
+   > **On macOS or Linux?** Steam does not offer a native download for this title on these platforms. See [GETTING_THE_GAME_FILES.md](GETTING_THE_GAME_FILES.md) for step-by-step instructions on how to obtain the game files.
+
 2. Copy the game data from your existing installation (for example, from `C:\Program Files (x86)\Steam\steamapps\common\Command & Conquer Generals - Zero Hour`) to a local folder on your Linux or macOS system. A recommended layout is:
    - `$HOME/GeneralsX/Generals` for Command & Conquer: Generals
    - `$HOME/GeneralsX/GeneralsZH` for Command & Conquer: Generals - Zero Hour

--- a/docs/WORKDIR/support/RELEASE_PIPELINE.md
+++ b/docs/WORKDIR/support/RELEASE_PIPELINE.md
@@ -45,7 +45,7 @@ Fixed block:
 
 # Install Instructions
 
-https://github.com/fbraz3/GeneralsX/blob/main/docs/BUILD/INSTALL_INSTRUCTIONS.md
+https://github.com/fbraz3/GeneralsX/blob/main/docs/BUILD/INSTALLATION.md
 ```
 
 What's changed format:


### PR DESCRIPTION
## Summary

Adds a new documentation guide for users who need to obtain the original game files on macOS or Linux (Steam does not offer a native download for this title), and renames the install instructions document for clarity.

## Changes

- **New**: `docs/BUILD/GETTING_THE_GAME_FILES.md` — step-by-step guide covering three methods to get the game assets:
  1. Copy from a Windows installation (easiest)
  2. CrossOver free trial (no Windows PC needed)
  3. SteamCMD (advanced, command-line)
- **Renamed**: `docs/BUILD/INSTALL_INSTRUCTIONS.md` → `docs/BUILD/INSTALLATION.md` (shorter and cleaner)
- **Updated**: `docs/BUILD/INSTALLATION.md` — added cross-reference callout to the new guide in the Prerequisites section
- **Updated**: `README.md` — added mention of the new guide in the "Installing the game" section
- **Updated**: `.github/workflows/release.yml` — replaced bare URL in release notes with descriptive links to both guides
- **Updated**: `docs/WORKDIR/support/RELEASE_PIPELINE.md` — updated filename reference

## Motivation

A user asked in [#104](https://github.com/fbraz3/GeneralsX/discussions/104) how to install the game on macOS since Steam does not show the download button. This guide directly addresses that question and will serve as an official reference going forward.
