### PR TITLE
fix(audio-openal): restore narrator speech streams

### DIFF
--- a/Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioStream.cpp
+++ b/Core/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioStream.cpp
@@ -118,6 +118,14 @@ void OpenALAudioStream::update()
             num_queued = refreshedQueued;
         }
     }
+
+    // GeneralsX @bugfix fbraz3 27/04/2026 Restart after refill when a generic speech stream
+    // began the frame with an empty queue; otherwise processPlayingList() can release it as
+    // stopped before the newly buffered narrator audio ever starts playing.
+    alGetSourcei(m_source, AL_SOURCE_STATE, &sourceState);
+    if ((sourceState == AL_STOPPED || sourceState == AL_INITIAL || sourceState == AL_PAUSED) && num_queued > 0) {
+        play();
+    }
 }
 
 void OpenALAudioStream::reset()

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,6 +2,22 @@
 
 ---
 
+## 2026-04-27: Restore narrator speech after briefing-video audio fix
+
+Investigated the regression reported after commit `c0ce9f0`, where briefing and victory narrator speech stopped playing even though campaign videos regained audio.
+
+Root cause:
+- the OpenAL fix in `OpenALAudioStream::update()` was correct for video streams that already queue audio before calling `update()`, but generic `AT_Streaming` speech follows a different lifecycle.
+- narrator speech streams entered `processPlayingList()` with no queued buffers, filled the queue during `update()`, but were not restarted again in the same frame.
+- the manager then still saw the source as stopped and released it immediately, so mission intro narration and victory speech never got a chance to begin.
+
+Fix:
+- added a post-refill restart check in `OpenALAudioStream::update()` so a stream that buffers data during the current update cycle is started before `processPlayingList()` evaluates it for teardown.
+- kept the existing pre-unqueue restart logic intact so the briefing-video audio fix from issue #38 remains preserved.
+
+Validation:
+- code inspection confirms the fix is isolated to shared stream lifecycle logic and does not alter the FFmpeg video-specific conversion/reset path introduced by `c0ce9f0`.
+
 ## 2026-04-24: Revise generalsx.instructions.md to reflect active release state
 
 Updated the main AI agent instructions file to remove stale phase/planning artifacts and align with the current cross-platform release workflow.

--- a/docs/WORKDIR/lessons/2026-04-LESSONS.md
+++ b/docs/WORKDIR/lessons/2026-04-LESSONS.md
@@ -1,5 +1,17 @@
 # 2026-04 Lessons Learned
 
+## Session 2026-04-27 - OpenAL stream fixes must account for different producer lifecycles
+
+- Problem: After restoring briefing-video audio in commit `c0ce9f0`, mission intro narrator lines and victory speech stopped playing on OpenAL builds.
+- Root cause:
+	- The shared `OpenALAudioStream::update()` logic was adjusted around the video use case, where FFmpeg queues audio before or during explicit stream maintenance.
+	- Generic `AT_Streaming` speech uses a different lifecycle: the stream can enter `processPlayingList()` with no queued buffers, fill during `update()`, and still be seen as stopped in the same frame if playback is not retriggered after refill.
+	- The manager then releases the stream immediately, so narrator speech never starts.
+- Fix:
+	- Added a post-refill restart check in `OpenALAudioStream::update()` so newly buffered speech data is started before stopped-stream teardown runs.
+	- Preserved the video-specific FFmpeg/OpenAL path introduced for issue #38.
+- Prevention: When hardening shared stream classes for video/audio regressions, always validate both producer models: push-queued video streams and lazy-filled gameplay speech streams.
+
 ## Session 2026-04-23 - Campaign river-water rendering must guard shroud sampling boundaries
 
 - Problem: Linux `GeneralsXZH` could crash with `SIGSEGV` when opening campaign, with stack traces landing in `W3DShroud::getShroudLevel()` via `W3DWater::getRiverVertexDiffuse()`.


### PR DESCRIPTION
## Summary
This PR fixes a narrator speech regression introduced while restoring briefing video audio in commit c0ce9f0.

Mission intro speech and victory narration were silently dropped on OpenAL builds because generic AT_Streaming streams could be refilled during update() but still remain stopped in the same frame, then get released by processPlayingList() before playback starts.

## Root Cause
- OpenAL stream lifecycle logic was hardened for video timing.
- Generic speech streams have a different producer lifecycle from video streams.
- After in-frame refill, stopped state could persist until teardown check.

## Fix
- Add a post-refill restart check in OpenALAudioStream::update() when source is AL_STOPPED/AL_INITIAL/AL_PAUSED and queued buffers are present.
- Keep the existing video audio restoration path intact.

## Validation
- User confirmed end-to-end behavior: videos remain working and narrator speech is restored.
- Editor diagnostics are clean for touched files.

## Notes
- Dev diary updated in docs/DEV_BLOG/2026-04-DIARY.md.
- Lessons learned updated in docs/WORKDIR/lessons/2026-04-LESSONS.md.

Related-to #38
