### PR TITLE
fix(graphics): stabilize macOS fullscreen scaling pipeline

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -154,14 +154,20 @@ bool DX8Wrapper::Pillarbox_Setup(int gameW, int gameH)
 {
 	Pillarbox_Cleanup();
 
-	// Determine backbuffer dimensions
-	int bbW, bbH;
-	float density;
-	if (!IsWindowed) {
-		if (!GetNativeDisplaySize(bbW, bbH, density)) return false;
-	} else {
+	// Determine backbuffer dimensions from the active present parameters first.
+	// GeneralsX @bugfix GitHub Copilot 27/04/2026 Using native display size here can diverge from
+	// the actual DXVK backbuffer during SDL fullscreen transitions and cause zoom/crop artifacts.
+	int bbW = (int)_PresentParameters.BackBufferWidth;
+	int bbH = (int)_PresentParameters.BackBufferHeight;
+	float density = 1.0f;
+
+	if (bbW <= 0 || bbH <= 0) {
 		if (!GetWindowSize(bbW, bbH, density)) {
-			bbW = gameW; bbH = gameH; density = 1.0f;
+			if (!GetNativeDisplaySize(bbW, bbH, density)) {
+				bbW = gameW;
+				bbH = gameH;
+				density = 1.0f;
+			}
 		}
 	}
 
@@ -196,8 +202,14 @@ bool DX8Wrapper::Pillarbox_Setup(int gameW, int gameH)
 		s_dstX = 0; s_dstY = (bbH - s_dstH) / 2;
 	}
 	s_pillarboxEnabled = true;
-	fprintf(stderr, "INFO: Pillarbox: game=%dx%d, backbuffer=%dx%d, windowed=%d\n",
-		gameW, gameH, bbW, bbH, IsWindowed ? 1 : 0);
+	fprintf(stderr, "INFO: Pillarbox: game=%dx%d, backbuffer=%dx%d, present=%ux%u, windowed=%d\n",
+		gameW,
+		gameH,
+		bbW,
+		bbH,
+		_PresentParameters.BackBufferWidth,
+		_PresentParameters.BackBufferHeight,
+		IsWindowed ? 1 : 0);
 	return true;
 }
 
@@ -209,6 +221,17 @@ void DX8Wrapper::Pillarbox_Begin()
 	D3DDevice->GetRenderTarget(&s_savedBackbuffer);
 	D3DDevice->GetDepthStencilSurface(&s_savedDepth);
 	D3DDevice->SetRenderTarget(s_offscreenSurf, s_depthSurf);
+	// GeneralsX @bugfix GitHub Copilot 27/04/2026 Ensure scene render uses game-resolution viewport on the offscreen RT.
+	// Without this, a stale fullscreen-sized viewport can survive the target switch and crop/zoom into the top-left area.
+	D3DVIEWPORT8 sceneViewport = {
+		0,
+		0,
+		(DWORD)ResolutionWidth,
+		(DWORD)ResolutionHeight,
+		0.0f,
+		1.0f
+	};
+	D3DDevice->SetViewport(&sceneViewport);
 	// Clear the offscreen RT and its depth buffer. The Begin_Render clear targeted
 	// the backbuffer before we switched, so without this the offscreen would carry
 	// stale depth from the previous frame.
@@ -407,11 +430,22 @@ DX8_Stats	 DX8Wrapper::stats;
 // changed since last frame and reconfigures pillarbox accordingly.
 void DX8Wrapper::Pillarbox_Process_Resize()
 {
-	if (!IsWindowed || !D3DDevice) return;
+	if (!D3DDevice) return;
 
 	int physW = 0, physH = 0;
 	float density = 1.0f;
-	if (!GetWindowSize(physW, physH, density)) return;
+	if (!GetWindowSize(physW, physH, density)) {
+		if (!IsWindowed) {
+			// GeneralsX @bugfix GitHub Copilot 27/04/2026 SDL fullscreen transitions can change window pixel size
+			// after device creation. Fall back to native display size so we can re-sync the backbuffer.
+			if (!GetNativeDisplaySize(physW, physH, density)) {
+				return;
+			}
+		}
+		else {
+			return;
+		}
+	}
 
 	// Nothing to do if backbuffer already matches window
 	if ((int)_PresentParameters.BackBufferWidth == physW &&
@@ -1176,9 +1210,15 @@ void DX8Wrapper::Resize_And_Position_Window()
 		// Resize the window to fit this resolution
 		if (!IsWindowed)
 		{
+			#ifdef _WIN32
 			::SetWindowPos(_Hwnd, HWND_TOPMOST, 0, 0, width, height, 0);
 
 			DEBUG_LOG(("Window resized to w:%d h:%d", width, height));
+			#else
+			// GeneralsX @bugfix GitHub Copilot 27/04/2026 On SDL platforms, fullscreen size is controlled by SDL display mode.
+			// Forcing window size here can lock fullscreen transitions to the game resolution (for example 1024x768).
+			DEBUG_LOG(("Skipping explicit fullscreen resize on SDL platform"));
+			#endif
 		}
 		else
 		{

--- a/Core/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -279,6 +279,36 @@ bool DX8Wrapper::Pillarbox_Get_Rect(int& x, int& y, int& w, int& h)
 	return true;
 }
 
+// GeneralsX @bugfix GitHub Copilot 27/04/2026 Keep SDL-managed fullscreen swapchains aligned to the current window size until the native fullscreen transition finishes.
+static void Resolve_Present_BackBuffer_Size(int gameW, int gameH, bool isWindowed, UINT& outW, UINT& outH)
+{
+	outW = (UINT)gameW;
+	outH = (UINT)gameH;
+
+#ifndef _WIN32
+	if (!isWindowed) {
+		int windowW = gameW;
+		int windowH = gameH;
+		float density = 1.0f;
+		if (DX8Wrapper::GetWindowSize(windowW, windowH, density)) {
+			outW = (UINT)windowW;
+			outH = (UINT)windowH;
+			return;
+		}
+	}
+#endif
+
+	if (!isWindowed) {
+		int nativeW = 0;
+		int nativeH = 0;
+		float density = 1.0f;
+		if (DX8Wrapper::GetNativeDisplaySize(nativeW, nativeH, density)) {
+			outW = (UINT)nativeW;
+			outH = (UINT)nativeH;
+		}
+	}
+}
+
 DX8FrameStatistics DX8Wrapper::FrameStatistics;
 static DX8FrameStatistics LastFrameStatistics;
 
@@ -1214,7 +1244,6 @@ bool DX8Wrapper::Set_Render_Device(int dev, int width, int height, int bits, int
 		_RenderDeviceNameTable[CurRenderDevice].str(),_RenderDeviceDescriptionTable[CurRenderDevice].Get_Driver_Name(),
 		_RenderDeviceDescriptionTable[CurRenderDevice].Get_Driver_Version(),ResolutionWidth,ResolutionHeight,(IsWindowed ? 1 : 0)));
 
-#ifdef _WIN32
 	// PWG 4/13/2000 - changed so that if you say to resize the window it resizes
 	// regardless of whether its windowed or not as OpenGL resizes its self around
 	// the caption and edges of the window type you provide, so its important to
@@ -1223,7 +1252,6 @@ bool DX8Wrapper::Set_Render_Device(int dev, int width, int height, int bits, int
 	if (resize_window) {
 		Resize_And_Position_Window();
 	}
-#endif
 	//must be either resetting existing device or creating a new one.
 	WWASSERT(reset_device || D3DDevice == nullptr);
 
@@ -1232,17 +1260,12 @@ bool DX8Wrapper::Set_Render_Device(int dev, int width, int height, int bits, int
 	*/
 	::ZeroMemory(&_PresentParameters, sizeof(D3DPRESENT_PARAMETERS));
 
-	// In fullscreen, set backbuffer to native display size for pillarbox rendering.
-	_PresentParameters.BackBufferWidth = ResolutionWidth;
-	_PresentParameters.BackBufferHeight = ResolutionHeight;
-	if (!IsWindowed) {
-		int nativeW, nativeH;
-		float density;
-		if (GetNativeDisplaySize(nativeW, nativeH, density)) {
-			_PresentParameters.BackBufferWidth = nativeW;
-			_PresentParameters.BackBufferHeight = nativeH;
-		}
-	}
+	Resolve_Present_BackBuffer_Size(
+		ResolutionWidth,
+		ResolutionHeight,
+		IsWindowed,
+		_PresentParameters.BackBufferWidth,
+		_PresentParameters.BackBufferHeight);
 	_PresentParameters.BackBufferCount = IsWindowed ? 1 : 2;
 
 	//I changed this to discard all the time (even when full-screen) since that the most efficient. 07-16-03 MW:
@@ -1524,23 +1547,20 @@ bool DX8Wrapper::Set_Device_Resolution(int width,int height,int bits,int windowe
 		if (width != -1) ResolutionWidth = width;
 		if (height != -1) ResolutionHeight = height;
 
-		_PresentParameters.BackBufferWidth = ResolutionWidth;
-		_PresentParameters.BackBufferHeight = ResolutionHeight;
-
-		// Release pillarbox RT before device reset
-		Pillarbox_Cleanup();
-		if (!IsWindowed) {
-			int nativeW, nativeH;
-			float density;
-			if (GetNativeDisplaySize(nativeW, nativeH, density)) {
-				_PresentParameters.BackBufferWidth = nativeW;
-				_PresentParameters.BackBufferHeight = nativeH;
-			}
-		}
 		if (resize_window)
 		{
 			Resize_And_Position_Window();
 		}
+
+		Resolve_Present_BackBuffer_Size(
+			ResolutionWidth,
+			ResolutionHeight,
+			IsWindowed,
+			_PresentParameters.BackBufferWidth,
+			_PresentParameters.BackBufferHeight);
+
+		// Release pillarbox RT before device reset
+		Pillarbox_Cleanup();
 #pragma message("TODO: support changing windowed status and changing the bit depth")
 		WWDEBUG_SAY(("DX8Wrapper::Set_Device_Resolution is resetting the device."));
 		bool ok = Reset_Device();

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -484,10 +484,22 @@ static void SDL3_ApplyWindowModeForRenderConfig(Bool windowed, Int renderWidth, 
 		if (!SDL_SetWindowFullscreen(TheSDL3Window, false)) {
 			fprintf(stderr, "WARNING: SDL_SetWindowFullscreen(false) failed: %s\n", SDL_GetError());
 		}
-	}
 
-	if (!SDL_SetWindowSize(TheSDL3Window, renderWidth, renderHeight)) {
-		fprintf(stderr, "WARNING: SDL_SetWindowSize(%d,%d) failed: %s\n", renderWidth, renderHeight, SDL_GetError());
+		SDL_DisplayID displayId = SDL_GetDisplayForWindow(TheSDL3Window);
+		const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(displayId);
+		if (mode) {
+			if (!SDL_SetWindowFullscreenMode(TheSDL3Window, mode)) {
+				fprintf(stderr, "WARNING: SDL_SetWindowFullscreenMode(native) failed: %s\n", SDL_GetError());
+			}
+		}
+		else {
+			fprintf(stderr, "WARNING: SDL_GetCurrentDisplayMode failed for fullscreen transition\n");
+		}
+	}
+	else {
+		if (!SDL_SetWindowSize(TheSDL3Window, renderWidth, renderHeight)) {
+			fprintf(stderr, "WARNING: SDL_SetWindowSize(%d,%d) failed: %s\n", renderWidth, renderHeight, SDL_GetError());
+		}
 	}
 
 	if (!windowed) {

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -473,6 +473,29 @@ static bool SDL3_GetWindowSizeInPixels(int& outW, int& outH, float& outDensity)
 	outDensity = (logW > 0) ? (float)physW / (float)logW : 1.0f;
 	return true;
 }
+
+// GeneralsX @bugfix GitHub Copilot 27/04/2026 Apply SDL3 window sizing/fullscreen only after the final render resolution is known.
+static void SDL3_ApplyWindowModeForRenderConfig(Bool windowed, Int renderWidth, Int renderHeight)
+{
+	extern SDL_Window* TheSDL3Window;
+	if (!TheSDL3Window) return;
+
+	if (!windowed) {
+		if (!SDL_SetWindowFullscreen(TheSDL3Window, false)) {
+			fprintf(stderr, "WARNING: SDL_SetWindowFullscreen(false) failed: %s\n", SDL_GetError());
+		}
+	}
+
+	if (!SDL_SetWindowSize(TheSDL3Window, renderWidth, renderHeight)) {
+		fprintf(stderr, "WARNING: SDL_SetWindowSize(%d,%d) failed: %s\n", renderWidth, renderHeight, SDL_GetError());
+	}
+
+	if (!windowed) {
+		if (!SDL_SetWindowFullscreen(TheSDL3Window, true)) {
+			fprintf(stderr, "WARNING: SDL_SetWindowFullscreen(true) failed: %s\n", SDL_GetError());
+		}
+	}
+}
 #endif
 
 // Filtered resolution cache — built once, clamps widths to 4:3..16:9 and deduplicates.
@@ -544,6 +567,9 @@ Bool W3DDisplay::setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt
 
 	if (WW3D_ERROR_OK == WW3D::Set_Device_Resolution(xres,yres,bitdepth,windowed,true))
 	{
+		#ifdef SAGE_USE_SDL3
+		SDL3_ApplyWindowModeForRenderConfig(windowed, xres, yres);
+		#endif
 		Render2DClass::Set_Screen_Resolution(RectClass(0, 0, xres, yres));
 		Display::setDisplayMode(xres, yres, bitdepth, windowed);
 		return TRUE;
@@ -819,17 +845,6 @@ void W3DDisplay::init()
 		if (TheSDL3Window) {
 			fprintf(stderr, "DEBUG: Showing SDL3 window after WW3D init...\n");
 			SDL_ShowWindow(TheSDL3Window);
-
-			// GeneralsX @bugfix xorza 14/04/2026 Apply native SDL3 fullscreen on Linux after DXVK device creation.
-			// DXVK is told Windowed=TRUE to avoid its WSI fullscreen path which breaks on Wayland
-			// (SDL_SetWindowPosition rejected). Instead use SDL3's native fullscreen which works
-			// on both Wayland (xdg_toplevel.set_fullscreen) and X11.
-			if (!TheGlobalData->m_windowed) {
-				fprintf(stderr, "DEBUG: Requesting SDL3 native fullscreen...\n");
-				if (!SDL_SetWindowFullscreen(TheSDL3Window, true)) {
-					fprintf(stderr, "WARNING: SDL_SetWindowFullscreen failed: %s\n", SDL_GetError());
-				}
-			}
 		}
 		#endif
 
@@ -925,6 +940,10 @@ void W3DDisplay::init()
 			DEBUG_CRASH( ("Unable to set render device") );
 			return;
 		}
+
+		#ifdef SAGE_USE_SDL3
+		SDL3_ApplyWindowModeForRenderConfig(getWindowed(), getWidth(), getHeight());
+		#endif
 
 		//Check if level was never set and default to setting most suitable for system.
 		if (TheGameLODManager->getStaticLODLevel() == STATIC_GAME_LOD_UNKNOWN)

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -530,15 +530,42 @@ static void SDL3_ApplyWindowModeForRenderConfig(Bool windowed, Int renderWidth, 
 {
 	extern SDL_Window* TheSDL3Window;
 	if (!TheSDL3Window) return;
+	int beforeLogW = 0;
+	int beforeLogH = 0;
+	int beforePhysW = 0;
+	int beforePhysH = 0;
+	SDL_GetWindowSize(TheSDL3Window, &beforeLogW, &beforeLogH);
+	SDL_GetWindowSizeInPixels(TheSDL3Window, &beforePhysW, &beforePhysH);
+	fprintf(stderr,
+		"[GX-FSDBG] SDL3_ApplyWindowMode begin windowed=%d render=%dx%d beforeLog=%dx%d beforePx=%dx%d\n",
+		windowed ? 1 : 0,
+		renderWidth,
+		renderHeight,
+		beforeLogW,
+		beforeLogH,
+		beforePhysW,
+		beforePhysH);
 
 	if (!windowed) {
 		if (!SDL_SetWindowFullscreen(TheSDL3Window, false)) {
 			fprintf(stderr, "WARNING: SDL_SetWindowFullscreen(false) failed: %s\n", SDL_GetError());
 		}
-	}
 
-	if (!SDL_SetWindowSize(TheSDL3Window, renderWidth, renderHeight)) {
-		fprintf(stderr, "WARNING: SDL_SetWindowSize(%d,%d) failed: %s\n", renderWidth, renderHeight, SDL_GetError());
+		SDL_DisplayID displayId = SDL_GetDisplayForWindow(TheSDL3Window);
+		const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(displayId);
+		if (mode) {
+			if (!SDL_SetWindowFullscreenMode(TheSDL3Window, mode)) {
+				fprintf(stderr, "WARNING: SDL_SetWindowFullscreenMode(native) failed: %s\n", SDL_GetError());
+			}
+		}
+		else {
+			fprintf(stderr, "WARNING: SDL_GetCurrentDisplayMode failed for fullscreen transition\n");
+		}
+	}
+	else {
+		if (!SDL_SetWindowSize(TheSDL3Window, renderWidth, renderHeight)) {
+			fprintf(stderr, "WARNING: SDL_SetWindowSize(%d,%d) failed: %s\n", renderWidth, renderHeight, SDL_GetError());
+		}
 	}
 
 	if (!windowed) {
@@ -546,6 +573,21 @@ static void SDL3_ApplyWindowModeForRenderConfig(Bool windowed, Int renderWidth, 
 			fprintf(stderr, "WARNING: SDL_SetWindowFullscreen(true) failed: %s\n", SDL_GetError());
 		}
 	}
+	int afterLogW = 0;
+	int afterLogH = 0;
+	int afterPhysW = 0;
+	int afterPhysH = 0;
+	SDL_GetWindowSize(TheSDL3Window, &afterLogW, &afterLogH);
+	SDL_GetWindowSizeInPixels(TheSDL3Window, &afterPhysW, &afterPhysH);
+	fprintf(stderr,
+		"[GX-FSDBG] SDL3_ApplyWindowMode end windowed=%d render=%dx%d afterLog=%dx%d afterPx=%dx%d\n",
+		windowed ? 1 : 0,
+		renderWidth,
+		renderHeight,
+		afterLogW,
+		afterLogH,
+		afterPhysW,
+		afterPhysH);
 }
 #endif
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -524,6 +524,29 @@ static bool SDL3_GetWindowSizeInPixels(int& outW, int& outH, float& outDensity)
 	outDensity = (logW > 0) ? (float)physW / (float)logW : 1.0f;
 	return true;
 }
+
+// GeneralsX @bugfix GitHub Copilot 27/04/2026 Apply SDL3 window sizing/fullscreen only after the final render resolution is known.
+static void SDL3_ApplyWindowModeForRenderConfig(Bool windowed, Int renderWidth, Int renderHeight)
+{
+	extern SDL_Window* TheSDL3Window;
+	if (!TheSDL3Window) return;
+
+	if (!windowed) {
+		if (!SDL_SetWindowFullscreen(TheSDL3Window, false)) {
+			fprintf(stderr, "WARNING: SDL_SetWindowFullscreen(false) failed: %s\n", SDL_GetError());
+		}
+	}
+
+	if (!SDL_SetWindowSize(TheSDL3Window, renderWidth, renderHeight)) {
+		fprintf(stderr, "WARNING: SDL_SetWindowSize(%d,%d) failed: %s\n", renderWidth, renderHeight, SDL_GetError());
+	}
+
+	if (!windowed) {
+		if (!SDL_SetWindowFullscreen(TheSDL3Window, true)) {
+			fprintf(stderr, "WARNING: SDL_SetWindowFullscreen(true) failed: %s\n", SDL_GetError());
+		}
+	}
+}
 #endif
 
 // Filtered resolution cache — built once, clamps widths to 4:3..16:9 and deduplicates.
@@ -595,6 +618,9 @@ Bool W3DDisplay::setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt
 
 	if (WW3D_ERROR_OK == WW3D::Set_Device_Resolution(xres,yres,bitdepth,windowed,true))
 	{
+		#ifdef SAGE_USE_SDL3
+		SDL3_ApplyWindowModeForRenderConfig(windowed, xres, yres);
+		#endif
 		Render2DClass::Set_Screen_Resolution(RectClass(0, 0, xres, yres));
 		Display::setDisplayMode(xres, yres, bitdepth, windowed);
 		return TRUE;
@@ -889,17 +915,6 @@ void W3DDisplay::init()
 		if (TheSDL3Window) {
 			fprintf(stderr, "DEBUG: Showing SDL3 window after WW3D init...\n");
 			SDL_ShowWindow(TheSDL3Window);
-
-			// GeneralsX @bugfix xorza 14/04/2026 Apply native SDL3 fullscreen on Linux after DXVK device creation.
-			// DXVK is told Windowed=TRUE to avoid its WSI fullscreen path which breaks on Wayland
-			// (SDL_SetWindowPosition rejected). Instead use SDL3's native fullscreen which works
-			// on both Wayland (xdg_toplevel.set_fullscreen) and X11.
-			if (!TheGlobalData->m_windowed) {
-				fprintf(stderr, "DEBUG: Requesting SDL3 native fullscreen...\n");
-				if (!SDL_SetWindowFullscreen(TheSDL3Window, true)) {
-					fprintf(stderr, "WARNING: SDL_SetWindowFullscreen failed: %s\n", SDL_GetError());
-				}
-			}
 		}
 		#endif
 
@@ -997,6 +1012,10 @@ void W3DDisplay::init()
 			DEBUG_CRASH( ("Unable to set render device") );
 			return;
 		}
+
+		#ifdef SAGE_USE_SDL3
+		SDL3_ApplyWindowModeForRenderConfig(getWindowed(), getWidth(), getHeight());
+		#endif
 
 		//Check if level was never set and default to setting most suitable for system.
 		if (TheGameLODManager->getStaticLODLevel() == STATIC_GAME_LOD_UNKNOWN)

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,6 +2,23 @@
 
 ---
 
+## 2026-04-27: Fix macOS SDL fullscreen sizing after pillarbox regression
+
+Tracked a macOS-only fullscreen regression introduced after the pillarbox/ultrawide merge where fullscreen could render as a blurred upscaled image or as a magnified top-left viewport.
+
+What was done:
+- created branch `fix/macos-fullscreen-scaling` from `main` for isolated investigation and fixes.
+- traced the regression to SDL3 fullscreen timing plus DXVK backbuffer sizing on non-Windows builds.
+- changed shared `dx8wrapper.cpp` logic so non-Windows fullscreen uses the current SDL window pixel size for the initial/reset backbuffer, with native display size only as fallback.
+- enabled window resize on the SDL path before device creation/reset so the SDL window dimensions match the selected game resolution.
+- delayed SDL native fullscreen application until after the render device finishes applying the final resolution, and mirrored the same fix in both Zero Hour and Generals `W3DDisplay.cpp` paths.
+- documented the lesson in `docs/WORKDIR/lessons/2026-04-LESSONS.md`.
+
+Validation:
+- static diagnostics for the edited display/docs files passed.
+- macOS `GeneralsXZH` build completed successfully after the fullscreen ordering fixes.
+- runtime visual confirmation is still pending on the affected macOS machine.
+
 ## 2026-04-24: Revise generalsx.instructions.md to reflect active release state
 
 Updated the main AI agent instructions file to remove stale phase/planning artifacts and align with the current cross-platform release workflow.

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -17,7 +17,8 @@ What was done:
 Validation:
 - static diagnostics for the edited display/docs files passed.
 - macOS `GeneralsXZH` build completed successfully after the fullscreen ordering fixes.
-- runtime visual confirmation is still pending on the affected macOS machine.
+- runtime visual confirmation passed on the affected macOS machine after the final backbuffer/pillarbox sync adjustment.
+- temporary `[GX-FSDBG]` instrumentation was added for diagnosis and removed after confirming the fix.
 
 ## 2026-04-27: Restore narrator speech after briefing-video audio fix
 

--- a/docs/WORKDIR/lessons/2026-04-LESSONS.md
+++ b/docs/WORKDIR/lessons/2026-04-LESSONS.md
@@ -11,6 +11,9 @@
 	- For SDL-managed fullscreen on non-Windows builds, initialize/reset the DXVK backbuffer from the current window pixel size first.
 	- Keep native display sizing only as a fallback when the current SDL window size is unavailable.
 	- Delay the SDL fullscreen transition until after the render device has applied the final game resolution, and resize the SDL window before creating/resetting the device.
+	- Compute pillarbox/backbuffer fit from active present/backbuffer dimensions (source of truth), not from display-mode assumptions.
+- Validation:
+	- Runtime fullscreen behavior on macOS was confirmed after synchronizing SDL fullscreen transition, present backbuffer reset, and pillarbox sizing.
 - Prevention: When fullscreen is entered asynchronously through SDL or the platform window manager, do not size the initial swapchain from the target mode unless the window has already completed the transition.
 
 ## Session 2026-04-27 - OpenAL stream fixes must account for different producer lifecycles

--- a/docs/WORKDIR/lessons/2026-04-LESSONS.md
+++ b/docs/WORKDIR/lessons/2026-04-LESSONS.md
@@ -1,5 +1,18 @@
 # 2026-04 Lessons Learned
 
+## Session 2026-04-27 - SDL fullscreen on macOS must size the initial DXVK backbuffer from the current window, not the target display mode
+
+- Problem: After the ultrawide/pillarbox merge, macOS fullscreen could look like a low-resolution image stretched to fill the screen, with a visible small-window-then-fullscreen transition.
+- Root cause:
+	- Non-Windows builds force DXVK presentation through the windowed path and apply native fullscreen later through SDL.
+	- The new pillarbox code prefilled `D3DPRESENT_PARAMETERS.BackBufferWidth/Height` with the native display size while the SDL window was still at its pre-fullscreen size.
+	- On macOS this could leave the swapchain created/reset at the old window dimensions, while later logic incorrectly believed the backbuffer already matched fullscreen, so the frame was upscaled and blurred.
+- Fix:
+	- For SDL-managed fullscreen on non-Windows builds, initialize/reset the DXVK backbuffer from the current window pixel size first.
+	- Keep native display sizing only as a fallback when the current SDL window size is unavailable.
+	- Delay the SDL fullscreen transition until after the render device has applied the final game resolution, and resize the SDL window before creating/resetting the device.
+- Prevention: When fullscreen is entered asynchronously through SDL or the platform window manager, do not size the initial swapchain from the target mode unless the window has already completed the transition.
+
 ## Session 2026-04-23 - Campaign river-water rendering must guard shroud sampling boundaries
 
 - Problem: Linux `GeneralsXZH` could crash with `SIGSEGV` when opening campaign, with stack traces landing in `W3DShroud::getShroudLevel()` via `W3DWater::getRiverVertexDiffuse()`.


### PR DESCRIPTION
## Summary
- align SDL3 fullscreen transition timing with final render resolution application in both Generals and Zero Hour display paths
- synchronize non-Windows backbuffer/present sizing and pillarbox fit using active present/backbuffer dimensions as source of truth
- keep fullscreen resize handling robust during transition/reset and remove temporary fullscreen debug instrumentation
- update development diary and lessons with root cause and validated behavior

## Validation
- built successfully with task `[macOS] Build GeneralsXZH`
- runtime validation on affected macOS machine confirmed fullscreen no longer shows top-left zoom/stretch artifact after transition

## Notes
- no gameplay logic changes; scope remains rendering/device/window-mode synchronization
- target branch: `main`