### PR TITLE
fix(map-cache): support custom map paths and names

### DIFF
--- a/Core/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Core/GameEngine/Source/GameClient/MapUtil.cpp
@@ -67,6 +67,36 @@
 // PRIVATE DATA ///////////////////////////////////////////////////////////////////////////////////
 static const char *mapExtension = ".map";
 
+// GeneralsX @bugfix Copilot 27/04/2026 Accept both '\' and '/' separators so user custom maps work on macOS/Linux paths.
+static const char *findLastPathSeparator(const AsciiString& path)
+{
+	const char *backslash = path.reverseFind('\\');
+	const char *slash = path.reverseFind('/');
+
+	if (!backslash)
+	{
+		return slash;
+	}
+
+	if (!slash)
+	{
+		return backslash;
+	}
+
+	return slash > backslash ? slash : backslash;
+}
+
+static Bool hasValidMapLeafLayout(const AsciiString& filepathLower, const AsciiString& filenameLower)
+{
+	AsciiString endingStrBackslash;
+	endingStrBackslash.format("%s\\%s%s", filenameLower.str(), filenameLower.str(), mapExtension);
+
+	AsciiString endingStrSlash;
+	endingStrSlash.format("%s/%s%s", filenameLower.str(), filenameLower.str(), mapExtension);
+
+	return filepathLower.endsWithNoCase(endingStrBackslash.str()) || filepathLower.endsWithNoCase(endingStrSlash.str());
+}
+
 static Int m_width = 0;						///< Height map width.
 static Int m_height = 0;					///< Height map height (y size of array).
 static Int m_borderSize = 0;			///< Non-playable border area.
@@ -531,14 +561,13 @@ Bool MapCache::loadMapsFromDisk( const AsciiString &mapDir, Bool isOfficial, Boo
 		AsciiString filepathLower = *filepathIt;
 		filepathLower.toLower();
 
-		const char *szFilenameLower = filepathLower.reverseFind('\\');
+		const char *szFilenameLower = findLastPathSeparator(filepathLower);
 		if (!szFilenameLower)
 		{
-			DEBUG_CRASH(("Couldn't find \\ in map name!"));
+			DEBUG_CRASH(("Couldn't find path separator in map name!"));
 			continue;
 		}
 
-		AsciiString endingStr;
 		AsciiString filenameLower = szFilenameLower+1;
 		filenameLower.truncateBy(strlen(mapExtension));
 
@@ -548,9 +577,7 @@ Bool MapCache::loadMapsFromDisk( const AsciiString &mapDir, Bool isOfficial, Boo
 			continue;
 		}
 
-		endingStr.format("%s\\%s%s", filenameLower.str(), filenameLower.str(), mapExtension);
-
-		if (!filepathLower.endsWithNoCase(endingStr.str()))
+		if (!hasValidMapLeafLayout(filepathLower, filenameLower))
 		{
 			DEBUG_CRASH(("Found map '%s' in wrong spot (%s)", filenameLower.str(), filepathLower.str()));
 			continue;
@@ -574,7 +601,7 @@ Bool MapCache::loadMapsFromDisk( const AsciiString &mapDir, Bool isOfficial, Boo
 }
 
 Bool MapCache::addMap(
-	const AsciiString &mapDir,
+	const AsciiString &/*mapDir*/,
 	const AsciiString &fname,
 	const AsciiString &lowerFname,
 	FileInfo &fileInfo,
@@ -593,7 +620,8 @@ Bool MapCache::addMap(
 			{
 				// unofficial maps or maps without names
 				AsciiString tempdisplayname;
-				tempdisplayname = fname.reverseFind('\\') + 1;
+				const char *displayNameStart = findLastPathSeparator(fname);
+				tempdisplayname = displayNameStart ? displayNameStart + 1 : fname;
 				(*this)[lowerFname].m_displayName.translate(tempdisplayname);
 				if (md.m_numPlayers >= 2)
 				{
@@ -655,7 +683,8 @@ Bool MapCache::addMap(
 	{
 		DEBUG_LOG(("Missing TheKey_mapName!"));
 		AsciiString tempdisplayname;
-		tempdisplayname = fname.reverseFind('\\') + 1;
+		const char *displayNameStart = findLastPathSeparator(fname);
+		tempdisplayname = displayNameStart ? displayNameStart + 1 : fname;
 		md.m_displayName.translate(tempdisplayname);
 		if (md.m_numPlayers >= 2)
 		{
@@ -667,10 +696,17 @@ Bool MapCache::addMap(
 	}
 	else
 	{
-		AsciiString stringFileName;
-		stringFileName.format("%s\\%s", mapDir.str(), fname.str());
+		AsciiString stringFileName = fname;
 		stringFileName.truncateBy(4);
-		stringFileName.concat("\\map.str");
+		const char *stringFileSeparator = findLastPathSeparator(stringFileName);
+		if (stringFileSeparator && *stringFileSeparator == '/')
+		{
+			stringFileName.concat("/map.str");
+		}
+		else
+		{
+			stringFileName.concat("\\map.str");
+		}
 		TheGameText->initMapStringFile(stringFileName);
 		md.m_displayName = TheGameText->fetch(nameLookupTag);
 		if (md.m_numPlayers >= 2)

--- a/Generals/Code/GameEngine/Source/Common/INI/INIMapCache.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INIMapCache.cpp
@@ -39,6 +39,25 @@
 #include "Common/WellKnownKeys.h"
 #include "Common/QuotedPrintable.h"
 
+// GeneralsX @bugfix Copilot 27/04/2026 Support both POSIX and Windows separators when deriving map display names.
+static const char *findLastPathSeparator(const AsciiString& path)
+{
+	const char *backslash = path.reverseFind('\\');
+	const char *slash = path.reverseFind('/');
+
+	if (!backslash)
+	{
+		return slash;
+	}
+
+	if (!slash)
+	{
+		return backslash;
+	}
+
+	return slash > backslash ? slash : backslash;
+}
+
 
 class MapMetaDataReader
 {
@@ -149,7 +168,8 @@ void INI::parseMapCacheDefinition( INI* ini )
 	{
 		// maps without localized name tags
 		AsciiString tempdisplayname;
-		tempdisplayname = name.reverseFind('\\') + 1;
+		const char *displayNameStart = findLastPathSeparator(name);
+		tempdisplayname = displayNameStart ? displayNameStart + 1 : name;
 		md.m_displayName.translate(tempdisplayname);
 		if (md.m_numPlayers >= 2)
 		{

--- a/Generals/Code/GameEngine/Source/Common/System/QuotedPrintable.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/QuotedPrintable.cpp
@@ -153,7 +153,7 @@ AsciiString AsciiStringToQuotedPrintable(AsciiString original)
 	int i=0;
 	while ( src[0]!='\0' && i<1021 )
 	{
-		if (!isalnum(*src))
+		if (!isAsciiAlphaNumeric(*src))
 		{
 			dest[i++] = MAGIC_CHAR;
 			dest[i++] = intToHexDigit((*src)>>4);

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INIMapCache.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INIMapCache.cpp
@@ -39,6 +39,25 @@
 #include "Common/WellKnownKeys.h"
 #include "Common/QuotedPrintable.h"
 
+// GeneralsX @bugfix Copilot 27/04/2026 Support both POSIX and Windows separators when deriving map display names.
+static const char *findLastPathSeparator(const AsciiString& path)
+{
+	const char *backslash = path.reverseFind('\\');
+	const char *slash = path.reverseFind('/');
+
+	if (!backslash)
+	{
+		return slash;
+	}
+
+	if (!slash)
+	{
+		return backslash;
+	}
+
+	return slash > backslash ? slash : backslash;
+}
+
 
 class MapMetaDataReader
 {
@@ -149,7 +168,8 @@ void INI::parseMapCacheDefinition( INI* ini )
 	{
 		// maps without localized name tags
 		AsciiString tempdisplayname;
-		tempdisplayname = name.reverseFind('\\') + 1;
+		const char *displayNameStart = findLastPathSeparator(name);
+		tempdisplayname = displayNameStart ? displayNameStart + 1 : name;
 		md.m_displayName.translate(tempdisplayname);
 		if (md.m_numPlayers >= 2)
 		{

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/QuotedPrintable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/QuotedPrintable.cpp
@@ -153,7 +153,7 @@ AsciiString AsciiStringToQuotedPrintable(AsciiString original)
 	int i=0;
 	while ( src[0]!='\0' && i<1021 )
 	{
-		if (!isalnum(*src))
+		if (!isAsciiAlphaNumeric(*src))
 		{
 			dest[i++] = MAGIC_CHAR;
 			dest[i++] = intToHexDigit((*src)>>4);

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,6 +2,30 @@
 
 ---
 
+## 2026-04-27: Fix macOS user custom map loading and harden special-character handling
+
+Addressed the user-reported issue where custom maps in `~/Library/Application Support/GeneralsX/GeneralsZH/Maps` were not being discovered reliably on macOS, including maps with custom assets/string files.
+
+What was done:
+- created branch `fix/macos-user-custom-maps-loading` for isolated investigation/fix.
+- fixed map scanning in shared `Core` path by accepting both `\\` and `/` separators when parsing map file paths and validating map folder layout.
+- fixed map display-name extraction paths to handle both separators in map cache/runtime code paths.
+- fixed map `map.str` path derivation to build from the real map file path instead of mixed `mapDir + fname` composition.
+- patched `INIMapCache.cpp` in both `GeneralsMD` and `Generals` so cache parsing of map names without lookup tags also accepts both separators.
+- hardened `QuotedPrintable` ASCII encoding in both `GeneralsMD` and `Generals` to use locale-independent ASCII checks (`isAsciiAlphaNumeric`) for predictable handling of punctuation/special characters.
+
+Stress/validation notes:
+- confirmed custom map load success in runtime logs for user-path maps (including accented-name case).
+- executed stress dataset generation with 14 map directory names covering spaces, quotes, punctuation, and accented Unicode characters; no new crash/regression observed in successful run (`Exiting with code 0`).
+- cleaned temporary `GX_STRESS_*` map directories from user data after testing.
+
+Files touched:
+- `Core/GameEngine/Source/GameClient/MapUtil.cpp`
+- `GeneralsMD/Code/GameEngine/Source/Common/INI/INIMapCache.cpp`
+- `Generals/Code/GameEngine/Source/Common/INI/INIMapCache.cpp`
+- `GeneralsMD/Code/GameEngine/Source/Common/System/QuotedPrintable.cpp`
+- `Generals/Code/GameEngine/Source/Common/System/QuotedPrintable.cpp`
+
 ## 2026-04-27: Fix macOS SDL fullscreen sizing after pillarbox regression
 
 Tracked a macOS-only fullscreen regression introduced after the pillarbox/ultrawide merge where fullscreen could render as a blurred upscaled image or as a magnified top-left viewport.

--- a/docs/WORKDIR/lessons/2026-04-LESSONS.md
+++ b/docs/WORKDIR/lessons/2026-04-LESSONS.md
@@ -1,5 +1,21 @@
 # 2026-04 Lessons Learned
 
+## Session 2026-04-27 - Custom map pipelines must treat path separators and map-name encoding as cross-platform invariants
+
+- Problem: User custom maps under `~/Library/Application Support/GeneralsX/GeneralsZH/Maps` could fail discovery/metadata flow when code assumed Windows-only separators and mixed path composition styles.
+- Root cause:
+	- Shared map scan/cache paths used `reverseFind('\\')` and Windows-only suffix checks.
+	- `map.str` lookup composition used `mapDir + fname` assumptions that are fragile when `fname` already carries rooted/qualified path semantics.
+	- Special-character map names rely on quoted-printable conversion; locale-sensitive `isalnum` in ASCII encoding can produce inconsistent behavior.
+- Fix:
+	- Added separator-agnostic path handling (`\\` or `/`) in shared map scanning (`MapUtil.cpp`) and in map cache parsing (`INIMapCache.cpp` for both ZH and Generals).
+	- Built map string-file path from the actual map filepath and separator style instead of recomposing from mixed fragments.
+	- Switched ASCII quoted-printable checks to locale-independent ASCII classification (`isAsciiAlphaNumeric`) in both game variants.
+- Validation:
+	- Custom user-path maps load successfully on macOS after patch.
+	- Stress dataset with names containing spaces, quotes, punctuation, and accented Unicode characters completed without crash in successful run.
+- Prevention: Treat map-name handling as a pipeline (filesystem scan -> cache serialization -> cache parse -> localized display load). Any separator/encoding change must be validated end-to-end, not only at one layer.
+
 ## Session 2026-04-27 - SDL fullscreen on macOS must size the initial DXVK backbuffer from the current window, not the target display mode
 
 - Problem: After the ultrawide/pillarbox merge, macOS fullscreen could look like a low-resolution image stretched to fill the screen, with a visible small-window-then-fullscreen transition.


### PR DESCRIPTION
## Summary
This PR fixes custom user map loading on macOS for maps stored under `~/Library/Application Support/GeneralsX/GeneralsZH/Maps`, including maps with special characters in folder/file names and maps that rely on local `map.str` metadata.

## What Changed
- Made map path handling separator-agnostic (`\\` and `/`) in shared map scanning and layout checks.
- Hardened map display-name extraction for cache/runtime flows to avoid Windows-only path assumptions.
- Fixed `map.str` path derivation to use the real map filepath context.
- Applied matching cache-parse separator hardening in both Zero Hour and Generals `INIMapCache.cpp` paths.
- Hardened `QuotedPrintable` ASCII encoding to use locale-independent ASCII checks for predictable special-character handling.

## Files
- `Core/GameEngine/Source/GameClient/MapUtil.cpp`
- `GeneralsMD/Code/GameEngine/Source/Common/INI/INIMapCache.cpp`
- `Generals/Code/GameEngine/Source/Common/INI/INIMapCache.cpp`
- `GeneralsMD/Code/GameEngine/Source/Common/System/QuotedPrintable.cpp`
- `Generals/Code/GameEngine/Source/Common/System/QuotedPrintable.cpp`

## Validation
- Confirmed custom map load from user path in runtime logs.
- Stress dataset created with names containing spaces, quotes, punctuation, and accented Unicode; successful runtime execution completed with exit code 0.
- No diagnostics errors in edited INI/QuotedPrintable files.

## Docs
- Updated `docs/DEV_BLOG/2026-04-DIARY.md`.
- Updated `docs/WORKDIR/lessons/2026-04-LESSONS.md`.
