### PR TITLE
fix(graphics): harden macOS fullscreen focus lock

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -483,6 +483,25 @@ static bool SDL3_GetWindowSizeInPixels(int& outW, int& outH, float& outDensity)
 	return true;
 }
 
+// GeneralsX @bugfix GitHub Copilot 28/04/2026 Ensure SDL3 fullscreen transition actually lands in native fullscreen and foreground.
+static void SDL3_EnsureNativeFullscreen(SDL_Window* window)
+{
+	if (!window) return;
+
+	for (int attempt = 0; attempt < 3; ++attempt) {
+		SDL_PumpEvents();
+		if ((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0) {
+			break;
+		}
+		if (!SDL_SetWindowFullscreen(window, true)) {
+			fprintf(stderr, "WARNING: SDL_SetWindowFullscreen(retry) failed: %s\n", SDL_GetError());
+			break;
+		}
+	}
+
+	SDL_RaiseWindow(window);
+}
+
 // GeneralsX @bugfix GitHub Copilot 27/04/2026 Apply SDL3 window sizing/fullscreen only after the final render resolution is known.
 static void SDL3_ApplyWindowModeForRenderConfig(Bool windowed, Int renderWidth, Int renderHeight)
 {
@@ -515,6 +534,7 @@ static void SDL3_ApplyWindowModeForRenderConfig(Bool windowed, Int renderWidth, 
 		if (!SDL_SetWindowFullscreen(TheSDL3Window, true)) {
 			fprintf(stderr, "WARNING: SDL_SetWindowFullscreen(true) failed: %s\n", SDL_GetError());
 		}
+		SDL3_EnsureNativeFullscreen(TheSDL3Window);
 	}
 }
 #endif

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -534,26 +534,30 @@ static bool SDL3_GetWindowSizeInPixels(int& outW, int& outH, float& outDensity)
 	return true;
 }
 
+// GeneralsX @bugfix GitHub Copilot 28/04/2026 Ensure SDL3 fullscreen transition actually lands in native fullscreen and foreground.
+static void SDL3_EnsureNativeFullscreen(SDL_Window* window)
+{
+	if (!window) return;
+
+	for (int attempt = 0; attempt < 3; ++attempt) {
+		SDL_PumpEvents();
+		if ((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0) {
+			break;
+		}
+		if (!SDL_SetWindowFullscreen(window, true)) {
+			fprintf(stderr, "WARNING: SDL_SetWindowFullscreen(retry) failed: %s\n", SDL_GetError());
+			break;
+		}
+	}
+
+	SDL_RaiseWindow(window);
+}
+
 // GeneralsX @bugfix GitHub Copilot 27/04/2026 Apply SDL3 window sizing/fullscreen only after the final render resolution is known.
 static void SDL3_ApplyWindowModeForRenderConfig(Bool windowed, Int renderWidth, Int renderHeight)
 {
 	extern SDL_Window* TheSDL3Window;
 	if (!TheSDL3Window) return;
-	int beforeLogW = 0;
-	int beforeLogH = 0;
-	int beforePhysW = 0;
-	int beforePhysH = 0;
-	SDL_GetWindowSize(TheSDL3Window, &beforeLogW, &beforeLogH);
-	SDL_GetWindowSizeInPixels(TheSDL3Window, &beforePhysW, &beforePhysH);
-	fprintf(stderr,
-		"[GX-FSDBG] SDL3_ApplyWindowMode begin windowed=%d render=%dx%d beforeLog=%dx%d beforePx=%dx%d\n",
-		windowed ? 1 : 0,
-		renderWidth,
-		renderHeight,
-		beforeLogW,
-		beforeLogH,
-		beforePhysW,
-		beforePhysH);
 
 	if (!windowed) {
 		if (!SDL_SetWindowFullscreen(TheSDL3Window, false)) {
@@ -581,22 +585,8 @@ static void SDL3_ApplyWindowModeForRenderConfig(Bool windowed, Int renderWidth, 
 		if (!SDL_SetWindowFullscreen(TheSDL3Window, true)) {
 			fprintf(stderr, "WARNING: SDL_SetWindowFullscreen(true) failed: %s\n", SDL_GetError());
 		}
+		SDL3_EnsureNativeFullscreen(TheSDL3Window);
 	}
-	int afterLogW = 0;
-	int afterLogH = 0;
-	int afterPhysW = 0;
-	int afterPhysH = 0;
-	SDL_GetWindowSize(TheSDL3Window, &afterLogW, &afterLogH);
-	SDL_GetWindowSizeInPixels(TheSDL3Window, &afterPhysW, &afterPhysH);
-	fprintf(stderr,
-		"[GX-FSDBG] SDL3_ApplyWindowMode end windowed=%d render=%dx%d afterLog=%dx%d afterPx=%dx%d\n",
-		windowed ? 1 : 0,
-		renderWidth,
-		renderHeight,
-		afterLogW,
-		afterLogH,
-		afterPhysW,
-		afterPhysH);
 }
 #endif
 

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,6 +2,21 @@
 
 ---
 
+## 2026-04-28: Harden macOS SDL fullscreen transition against intermittent pseudo-borderless state
+
+Addressed a new intermittent macOS fullscreen failure where the game occasionally stayed in a borderless-looking state with Dock/menu bar visible and input focus/mouse interaction degraded.
+
+What was done:
+- created branch `fix/macos-fullscreen-focus-lock` from `main` for isolated fix.
+- updated SDL fullscreen transition helper in both Zero Hour and Generals `W3DDisplay.cpp` paths.
+- added a short fullscreen-state verification/retry loop after requesting fullscreen to handle asynchronous SDL/macOS transition timing.
+- raised the game window after fullscreen transition to improve foreground/focus consistency.
+- removed temporary fullscreen debug instrumentation remnants from the previous session in active game paths.
+
+Validation:
+- macOS `GeneralsXZH` build completed successfully after the change.
+- macOS deploy completed successfully to `~/GeneralsX/GeneralsZH/` for manual runtime validation.
+
 ## 2026-04-28: Finalize upstream sync branch, unify platform tasks, and standardize deploy UX
 
 Completed the final adjustments on `thesuperhackers-sync-04-28-2026` before commit/push/PR.

--- a/docs/WORKDIR/lessons/2026-04-LESSONS.md
+++ b/docs/WORKDIR/lessons/2026-04-LESSONS.md
@@ -1,5 +1,20 @@
 # 2026-04 Lessons Learned
 
+## Session 2026-04-28 - SDL native fullscreen on macOS needs post-request state verification and foreground enforcement
+
+- Problem: Even with correct render/backbuffer sizing, macOS could intermittently remain in a pseudo-borderless state (Dock/menu visible) after fullscreen request, with degraded focus/cursor behavior.
+- Root cause:
+	- `SDL_SetWindowFullscreen(true)` is asynchronous relative to compositor/window-manager transitions.
+	- A successful call does not guarantee the window is already flagged as fullscreen in the immediate next code path.
+	- If the window stays foreground-inconsistent during that transition, input behavior can degrade in practice.
+- Fix:
+	- After requesting fullscreen, verify window fullscreen flag and retry a few times when needed.
+	- Raise the window once transition is requested to reinforce foreground focus state.
+	- Apply the same logic in both `GeneralsMD` and `Generals` SDL display paths to keep behavior aligned.
+- Validation:
+	- macOS build and deploy completed successfully with the hardened fullscreen path.
+- Prevention: Treat fullscreen entry as a transition state machine on macOS/SDL; validate resulting state, do not rely on a single call as terminal state.
+
 ## Session 2026-04-27 - Custom map pipelines must treat path separators and map-name encoding as cross-platform invariants
 
 - Problem: User custom maps under `~/Library/Application Support/GeneralsX/GeneralsZH/Maps` could fail discovery/metadata flow when code assumed Windows-only separators and mixed path composition styles.


### PR DESCRIPTION
## Summary
- harden SDL3 fullscreen transition in both Zero Hour and Generals display paths
- add post-request fullscreen state verification with short retry to handle asynchronous macOS transition timing
- raise the SDL window after fullscreen request to improve foreground/focus consistency
- remove temporary fullscreen instrumentation remnants from active game paths

## Validation
- built successfully with `./scripts/build/macos/build-macos-zh.sh --build-only`
- deployed successfully with `./scripts/build/macos/deploy-macos-zh.sh`
- runtime launch intentionally left for manual verification as requested

## Scope
- rendering/window-mode synchronization only
- no gameplay logic changes