### PR TITLE
fix(sdl3-cursor): use SDL_CreateAnimatedCursor

### DIFF
--- a/Generals/Code/GameEngineDevice/Include/SDL3Device/GameClient/SDL3Mouse.h
+++ b/Generals/Code/GameEngineDevice/Include/SDL3Device/GameClient/SDL3Mouse.h
@@ -120,7 +120,6 @@ private:
 
 	// GeneralsX @bugfix BenderAI 22/02/2026 Add cursor animation tracking
 	Int m_directionFrame;         ///< current frame of directional cursor (from 0 points up)
-	UnsignedInt m_inputFrame;     ///< input frame counter for animation timing
 };
 
 #endif // !_WIN32

--- a/Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -51,21 +51,21 @@
  * Holds the frames of an animated cursor with frame timing info
  */
 struct AnimatedCursor {
-	std::array<SDL_Cursor*, MAX_2D_CURSOR_ANIM_FRAMES> m_frameCursors;
+	SDL_Cursor* m_cursor = nullptr;
 	std::array<SDL_Surface*, MAX_2D_CURSOR_ANIM_FRAMES> m_frameSurfaces;
-	int m_currentFrame = 0;
 	int m_frameCount = 0;
 	int m_frameRate = 0; // the time a frame is displayed in 1/60th of a second
 
 	~AnimatedCursor()
 	{
+		if (m_cursor)
+		{
+			SDL_DestroyCursor(m_cursor);
+			m_cursor = nullptr;
+		}
+
 		for (int i = 0; i < MAX_2D_CURSOR_ANIM_FRAMES; i++)
 		{
-			if (m_frameCursors[i])
-			{
-				SDL_DestroyCursor(m_frameCursors[i]);
-				m_frameCursors[i] = nullptr;
-			}
 			if (m_frameSurfaces[i])
 			{
 				SDL_DestroySurface(m_frameSurfaces[i]);
@@ -140,8 +140,7 @@ SDL3Mouse::SDL3Mouse(SDL_Window* window)
 	  m_RightButtonDownTime(0),
 	  m_MiddleButtonDownTime(0),
 	  m_LastFrameNumber(0),  // GeneralsX @bugfix felipebraz 18/02/2026 Initialize frame tracking
-	  m_directionFrame(0),   // GeneralsX @bugfix BenderAI 22/02/2026 Initialize cursor direction frame
-	  m_inputFrame(0)        // GeneralsX @bugfix BenderAI 22/02/2026 Initialize input frame counter
+	  m_directionFrame(0)    // GeneralsX @bugfix BenderAI 22/02/2026 Initialize cursor direction frame
 {
 	// GeneralsX @bugfix BenderAI 18/02/2026 Temporarily disable debug logging (Phase 1.8)
 	// fprintf(stderr, "DEBUG: SDL3Mouse::SDL3Mouse() created\n");
@@ -231,7 +230,8 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 		else if (chunk->id == list_id && chunk->type == fram_id)
 		{
 			int frame_index = 0;
-			size_t frame_offset = 0;
+			int hot_spot_x = 0;
+			int hot_spot_y = 0;
 
 			RIFFChunk *frame = (RIFFChunk*)((char *)chunk + sizeof(RIFFChunk));
 			while (frame != NULL && (char *)frame < file_buffer + size)
@@ -252,10 +252,10 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 
 					// Allow specifying the hot spot via properties on the surface
 					SDL_PropertiesID props = SDL_GetSurfaceProperties(surface);
-					int hot_spot_x = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_X_NUMBER, 0);
-					int hot_spot_y = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_Y_NUMBER, 0);
+					hot_spot_x = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_X_NUMBER, 0);
+					hot_spot_y = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_Y_NUMBER, 0);
 
-					cursor->m_frameCursors[frame_index++] = SDL_CreateColorCursor(surface, hot_spot_x, hot_spot_y);
+					frame_index++;
 				}
 
 				if (frame_index >= MAX_2D_CURSOR_ANIM_FRAMES)
@@ -266,6 +266,31 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 
 				frame = getNextChunk(frame);
 			}
+
+			if (frame_index > 0)
+			{
+				cursor->m_frameCount = frame_index;
+				const int clamped_rate = (cursor->m_frameRate > 0) ? cursor->m_frameRate : 4;
+				const Uint32 frame_duration_ms = (Uint32)((clamped_rate * 1000) / 60);
+				SDL_CursorFrameInfo frame_infos[MAX_2D_CURSOR_ANIM_FRAMES];
+
+				for (int i = 0; i < frame_index; ++i)
+				{
+					frame_infos[i].surface = cursor->m_frameSurfaces[i];
+					frame_infos[i].duration = frame_duration_ms;
+				}
+
+				// GeneralsX @bugfix felipebraz 28/04/2026 Use SDL native animated cursor to ensure frame playback.
+				cursor->m_cursor = SDL_CreateAnimatedCursor(frame_infos, frame_index, hot_spot_x, hot_spot_y);
+				if (!cursor->m_cursor)
+				{
+					DEBUG_LOG(("SDL3Mouse::loadCursorFromFile: SDL_CreateAnimatedCursor failed [%s]", SDL_GetError()));
+					delete cursor;
+					delete[] file_buffer;
+					return NULL;
+				}
+			}
+
 			break;
 		}
 		else
@@ -279,7 +304,7 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 	size_t loaded_frames = 0;
 	for (int i = 0; i < MAX_2D_CURSOR_ANIM_FRAMES; i++)
 	{
-		if (cursor->m_frameCursors[i])
+		if (cursor->m_frameSurfaces[i])
 			loaded_frames++;
 	}
 
@@ -398,11 +423,9 @@ void SDL3Mouse::setCursor(MouseCursor cursor)
 	else
 	{
 		AnimatedCursor* currentCursor = cursorResources[cursor][m_directionFrame];
-		if (currentCursor)
+		if (currentCursor && currentCursor->m_cursor)
 		{
-			// The game runs at 30FPS, the frame rate within the metadata is for 60FPS
-			size_t index = m_inputFrame * 2 / currentCursor->m_frameRate;
-			SDL_SetCursor(currentCursor->m_frameCursors[index % currentCursor->m_frameCount]);
+			SDL_SetCursor(currentCursor->m_cursor);
 		}
 		else
 		{
@@ -412,9 +435,9 @@ void SDL3Mouse::setCursor(MouseCursor cursor)
 
 	if (bUseDefaultCursor)
 	{
-		if (cursorResources[NORMAL][0])
+		if (cursorResources[NORMAL][0] && cursorResources[NORMAL][0]->m_cursor)
 		{
-			SDL_SetCursor(cursorResources[NORMAL][0]->m_frameCursors[0]);
+			SDL_SetCursor(cursorResources[NORMAL][0]->m_cursor);
 		}
 		else
 		{

--- a/GeneralsMD/Code/GameEngineDevice/Include/SDL3Device/GameClient/SDL3Mouse.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/SDL3Device/GameClient/SDL3Mouse.h
@@ -120,7 +120,6 @@ private:
 	
 	// GeneralsX @bugfix BenderAI 22/02/2026 Add cursor animation tracking
 	Int m_directionFrame;         ///< current frame of directional cursor (from 0 points up)
-	UnsignedInt m_inputFrame;     ///< input frame counter for animation timing
 };
 
 #endif // !_WIN32

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -51,21 +51,21 @@
  * Holds the frames of an animated cursor with frame timing info
  */
 struct AnimatedCursor {
-	std::array<SDL_Cursor*, MAX_2D_CURSOR_ANIM_FRAMES> m_frameCursors;
+	SDL_Cursor* m_cursor = nullptr;
 	std::array<SDL_Surface*, MAX_2D_CURSOR_ANIM_FRAMES> m_frameSurfaces;
-	int m_currentFrame = 0;
 	int m_frameCount = 0;
 	int m_frameRate = 0; // the time a frame is displayed in 1/60th of a second
 
 	~AnimatedCursor()
 	{
+		if (m_cursor)
+		{
+			SDL_DestroyCursor(m_cursor);
+			m_cursor = nullptr;
+		}
+
 		for (int i = 0; i < MAX_2D_CURSOR_ANIM_FRAMES; i++)
 		{
-			if (m_frameCursors[i])
-			{
-				SDL_DestroyCursor(m_frameCursors[i]);
-				m_frameCursors[i] = nullptr;
-			}
 			if (m_frameSurfaces[i])
 			{
 				SDL_DestroySurface(m_frameSurfaces[i]);
@@ -140,8 +140,7 @@ SDL3Mouse::SDL3Mouse(SDL_Window* window)
 	  m_RightButtonDownTime(0),
 	  m_MiddleButtonDownTime(0),
 	  m_LastFrameNumber(0),  // GeneralsX @bugfix felipebraz 18/02/2026 Initialize frame tracking
-	  m_directionFrame(0),   // GeneralsX @bugfix BenderAI 22/02/2026 Initialize cursor direction frame
-	  m_inputFrame(0)        // GeneralsX @bugfix BenderAI 22/02/2026 Initialize input frame counter
+	  m_directionFrame(0)    // GeneralsX @bugfix BenderAI 22/02/2026 Initialize cursor direction frame
 {
 	// GeneralsX @bugfix BenderAI 18/02/2026 Temporarily disable debug logging (Phase 1.8)
 	// fprintf(stderr, "DEBUG: SDL3Mouse::SDL3Mouse() created\n");
@@ -231,7 +230,8 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 		else if (chunk->id == list_id && chunk->type == fram_id)
 		{
 			int frame_index = 0;
-			size_t frame_offset = 0;
+			int hot_spot_x = 0;
+			int hot_spot_y = 0;
 
 			RIFFChunk *frame = (RIFFChunk*)((char *)chunk + sizeof(RIFFChunk));
 			while (frame != NULL && (char *)frame < file_buffer + size)
@@ -252,10 +252,10 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 
 					// Allow specifying the hot spot via properties on the surface
 					SDL_PropertiesID props = SDL_GetSurfaceProperties(surface);
-					int hot_spot_x = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_X_NUMBER, 0);
-					int hot_spot_y = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_Y_NUMBER, 0);
+					hot_spot_x = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_X_NUMBER, 0);
+					hot_spot_y = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_Y_NUMBER, 0);
 
-					cursor->m_frameCursors[frame_index++] = SDL_CreateColorCursor(surface, hot_spot_x, hot_spot_y);
+					frame_index++;
 				}
 
 				if (frame_index >= MAX_2D_CURSOR_ANIM_FRAMES)
@@ -266,6 +266,31 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 
 				frame = getNextChunk(frame);
 			}
+
+			if (frame_index > 0)
+			{
+				cursor->m_frameCount = frame_index;
+				const int clamped_rate = (cursor->m_frameRate > 0) ? cursor->m_frameRate : 4;
+				const Uint32 frame_duration_ms = (Uint32)((clamped_rate * 1000) / 60);
+				SDL_CursorFrameInfo frame_infos[MAX_2D_CURSOR_ANIM_FRAMES];
+
+				for (int i = 0; i < frame_index; ++i)
+				{
+					frame_infos[i].surface = cursor->m_frameSurfaces[i];
+					frame_infos[i].duration = frame_duration_ms;
+				}
+
+				// GeneralsX @bugfix felipebraz 28/04/2026 Use SDL native animated cursor to ensure frame playback.
+				cursor->m_cursor = SDL_CreateAnimatedCursor(frame_infos, frame_index, hot_spot_x, hot_spot_y);
+				if (!cursor->m_cursor)
+				{
+					DEBUG_LOG(("SDL3Mouse::loadCursorFromFile: SDL_CreateAnimatedCursor failed [%s]", SDL_GetError()));
+					delete cursor;
+					delete[] file_buffer;
+					return NULL;
+				}
+			}
+
 			break;
 		}
 		else
@@ -279,7 +304,7 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 	size_t loaded_frames = 0;
 	for (int i = 0; i < MAX_2D_CURSOR_ANIM_FRAMES; i++)
 	{
-		if (cursor->m_frameCursors[i])
+		if (cursor->m_frameSurfaces[i])
 			loaded_frames++;
 	}
 
@@ -398,14 +423,9 @@ void SDL3Mouse::setCursor(MouseCursor cursor)
 	else
 	{
 		AnimatedCursor* currentCursor = cursorResources[cursor][m_directionFrame];
-		if (currentCursor && currentCursor->m_frameCount > 0)
+		if (currentCursor && currentCursor->m_cursor)
 		{
-			// The game runs at 30FPS, the frame rate within the metadata is for 60FPS
-			// GeneralsX @bugfix BenderAI 07/03/2026 Guard against divide-by-zero
-			size_t index = (currentCursor->m_frameRate > 0)
-				? (m_inputFrame * 2 / currentCursor->m_frameRate) % currentCursor->m_frameCount
-				: 0;
-			SDL_SetCursor(currentCursor->m_frameCursors[index]);
+			SDL_SetCursor(currentCursor->m_cursor);
 		}
 		else
 		{
@@ -415,9 +435,9 @@ void SDL3Mouse::setCursor(MouseCursor cursor)
 
 	if (bUseDefaultCursor)
 	{
-		if (cursorResources[NORMAL][0])
+		if (cursorResources[NORMAL][0] && cursorResources[NORMAL][0]->m_cursor)
 		{
-			SDL_SetCursor(cursorResources[NORMAL][0]->m_frameCursors[0]);
+			SDL_SetCursor(cursorResources[NORMAL][0]->m_cursor);
 		}
 		else
 		{

--- a/docs/DEV_BLOG/2026-04-DIARY.md
+++ b/docs/DEV_BLOG/2026-04-DIARY.md
@@ -2,6 +2,20 @@
 
 ---
 
+## 2026-04-28: Switch SDL cursor pipeline to SDL_CreateAnimatedCursor
+
+Replaced the SDL cursor frame-by-frame selection path with SDL native animated cursors to ensure ANI cursor playback is handled by SDL runtime.
+
+What was done:
+- created branch `feat/sdl-animated-cursor` from `main`.
+- updated both Zero Hour and Generals SDL3 mouse implementations to create one animated `SDL_Cursor` per cursor/direction using `SDL_CreateAnimatedCursor`.
+- removed per-frame `SDL_SetCursor` animation stepping logic and dropped obsolete `m_inputFrame` state from SDL3 mouse headers.
+- preserved fallback behavior to NORMAL/default SDL cursor when animated resources are unavailable.
+
+Validation:
+- macOS `[Platform] Build GeneralsXZH` completed successfully after the change.
+- no new blocking compile errors introduced by the cursor migration.
+
 ## 2026-04-28: Harden macOS SDL fullscreen transition against intermittent pseudo-borderless state
 
 Addressed a new intermittent macOS fullscreen failure where the game occasionally stayed in a borderless-looking state with Dock/menu bar visible and input focus/mouse interaction degraded.


### PR DESCRIPTION
## Summary
Switch SDL cursor animation handling from manual frame switching (`SDL_CreateColorCursor` + per-frame `SDL_SetCursor`) to SDL native animated cursors via `SDL_CreateAnimatedCursor`.

## What changed
- Updated SDL3 cursor loading in both products:
  - `GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp`
  - `Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp`
- Reworked `AnimatedCursor` storage to keep a single animated `SDL_Cursor*` plus source surfaces.
- Removed obsolete manual frame stepping state (`m_inputFrame`) from:
  - `GeneralsMD/Code/GameEngineDevice/Include/SDL3Device/GameClient/SDL3Mouse.h`
  - `Generals/Code/GameEngineDevice/Include/SDL3Device/GameClient/SDL3Mouse.h`
- Kept fallback behavior to NORMAL/default SDL cursor when animated resources are unavailable.

## Validation
- macOS task `[Platform] Build GeneralsXZH` completed successfully after the change.

## Notes
- Added dev diary entry for this session in `docs/DEV_BLOG/2026-04-DIARY.md` as required by project workflow.