### PR TITLE
fix(macos-build): detect vcpkg root automatically

### DIFF
--- a/docs/DEV_BLOG/2026-05-DIARY.md
+++ b/docs/DEV_BLOG/2026-05-DIARY.md
@@ -1,0 +1,17 @@
+# Development Diary - May 2026
+
+---
+
+## 2026-05-03: Harden macOS build scripts for missing VCPKG_ROOT
+
+Addressed a user-reported macOS configure failure where CMake could not find the vcpkg toolchain because `VCPKG_ROOT` was unset.
+
+What was done:
+- added `resolve_vcpkg_root()` to both macOS build entry scripts (`GeneralsXZH` and `GeneralsX`).
+- validated `VCPKG_ROOT` when present and auto-detected common install locations (including Homebrew).
+- added explicit actionable error guidance when vcpkg cannot be found.
+- documented the lesson in `docs/WORKDIR/lessons/2026-05-LESSONS.md`.
+
+Validation:
+- shell syntax checks passed for both updated scripts.
+- no editor diagnostics errors in changed files.

--- a/docs/WORKDIR/lessons/2026-05-LESSONS.md
+++ b/docs/WORKDIR/lessons/2026-05-LESSONS.md
@@ -1,0 +1,8 @@
+# 2026-05 Lessons
+
+## 2026-05-03 - macOS configure fails when VCPKG_ROOT is unset
+
+- Symptom: CMake fails during preset configure with "Could not find toolchain file: /scripts/buildsystems/vcpkg.cmake".
+- Root cause: `default-vcpkg` preset uses `$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake`; when `VCPKG_ROOT` is empty, CMake resolves to an invalid absolute path.
+- Fix applied: Add `resolve_vcpkg_root()` in macOS build scripts to validate environment value, auto-detect common locations (including Homebrew), and fail with actionable guidance.
+- Prevention: Keep environment checks before `cmake --preset` in user-facing platform scripts.

--- a/scripts/build/macos/build-macos-generals.sh
+++ b/scripts/build/macos/build-macos-generals.sh
@@ -36,6 +36,49 @@ check_tool ninja "brew install ninja"
 check_tool meson "brew install meson"
 check_tool python3 "brew install python3"
 
+# GeneralsX @build Copilot 03/05/2026 Auto-detect VCPKG_ROOT for preset toolchain resolution
+resolve_vcpkg_root() {
+    local candidate=""
+    local -a candidates=()
+    local brew_vcpkg_root=""
+
+    if [[ -n "${VCPKG_ROOT:-}" ]]; then
+        if [[ -f "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" ]]; then
+            echo "Using VCPKG_ROOT from environment: ${VCPKG_ROOT}"
+            return 0
+        fi
+        echo "WARNING: VCPKG_ROOT is set but invalid: ${VCPKG_ROOT}"
+    fi
+
+    if command -v brew &>/dev/null; then
+        brew_vcpkg_root="$(brew --prefix vcpkg 2>/dev/null || true)"
+    fi
+
+    candidates+=("${PWD}/vcpkg")
+    candidates+=("${HOME}/vcpkg")
+    candidates+=("/opt/vcpkg")
+    candidates+=("/opt/homebrew/opt/vcpkg")
+    candidates+=("/usr/local/opt/vcpkg")
+    if [[ -n "${brew_vcpkg_root}" ]]; then
+        candidates+=("${brew_vcpkg_root}")
+    fi
+
+    for candidate in "${candidates[@]}"; do
+        if [[ -f "${candidate}/scripts/buildsystems/vcpkg.cmake" ]]; then
+            export VCPKG_ROOT="${candidate}"
+            echo "Using detected VCPKG_ROOT: ${VCPKG_ROOT}"
+            return 0
+        fi
+    done
+
+    echo "ERROR: VCPKG_ROOT is not configured and no local vcpkg installation was detected."
+    echo "Set VCPKG_ROOT to a valid vcpkg root containing scripts/buildsystems/vcpkg.cmake"
+    echo "Example: export VCPKG_ROOT=\"/opt/homebrew/opt/vcpkg\""
+    exit 1
+}
+
+resolve_vcpkg_root
+
 VULKAN_FOUND=0
 for sdk_candidate in "${HOME}/VulkanSDK"/*/macOS; do
     if [[ -f "${sdk_candidate}/lib/libvulkan.dylib" ]]; then

--- a/scripts/build/macos/build-macos-zh.sh
+++ b/scripts/build/macos/build-macos-zh.sh
@@ -47,6 +47,49 @@ check_tool ninja "brew install ninja"
 check_tool meson "brew install meson"
 check_tool python3 "brew install python3"
 
+# GeneralsX @build Copilot 03/05/2026 Auto-detect VCPKG_ROOT for preset toolchain resolution
+resolve_vcpkg_root() {
+    local candidate=""
+    local -a candidates=()
+    local brew_vcpkg_root=""
+
+    if [[ -n "${VCPKG_ROOT:-}" ]]; then
+        if [[ -f "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" ]]; then
+            echo "Using VCPKG_ROOT from environment: ${VCPKG_ROOT}"
+            return 0
+        fi
+        echo "WARNING: VCPKG_ROOT is set but invalid: ${VCPKG_ROOT}"
+    fi
+
+    if command -v brew &>/dev/null; then
+        brew_vcpkg_root="$(brew --prefix vcpkg 2>/dev/null || true)"
+    fi
+
+    candidates+=("${PWD}/vcpkg")
+    candidates+=("${HOME}/vcpkg")
+    candidates+=("/opt/vcpkg")
+    candidates+=("/opt/homebrew/opt/vcpkg")
+    candidates+=("/usr/local/opt/vcpkg")
+    if [[ -n "${brew_vcpkg_root}" ]]; then
+        candidates+=("${brew_vcpkg_root}")
+    fi
+
+    for candidate in "${candidates[@]}"; do
+        if [[ -f "${candidate}/scripts/buildsystems/vcpkg.cmake" ]]; then
+            export VCPKG_ROOT="${candidate}"
+            echo "Using detected VCPKG_ROOT: ${VCPKG_ROOT}"
+            return 0
+        fi
+    done
+
+    echo "ERROR: VCPKG_ROOT is not configured and no local vcpkg installation was detected."
+    echo "Set VCPKG_ROOT to a valid vcpkg root containing scripts/buildsystems/vcpkg.cmake"
+    echo "Example: export VCPKG_ROOT=\"/opt/homebrew/opt/vcpkg\""
+    exit 1
+}
+
+resolve_vcpkg_root
+
 # Vulkan SDK check
 VULKAN_FOUND=0
 for sdk_candidate in "${HOME}/VulkanSDK"/*/macOS; do


### PR DESCRIPTION
## Summary
- add automatic `VCPKG_ROOT` resolution to macOS build entry scripts
- validate existing env value before configure
- detect common install paths (workspace, home, `/opt`, Homebrew)
- emit actionable error if vcpkg toolchain cannot be found

## Why
A user report in Discussion #120 showed configure failing with:
`Could not find toolchain file: /scripts/buildsystems/vcpkg.cmake`

This happens when `VCPKG_ROOT` is unset/invalid and the preset inherits `default-vcpkg`.

## Validation
- `bash -n scripts/build/macos/build-macos-zh.sh`
- `bash -n scripts/build/macos/build-macos-generals.sh`
- runtime check with invalid env:
  - `VCPKG_ROOT=/invalid/path ./scripts/build/macos/build-macos-zh.sh --build-only`
  - script warns and auto-detects local vcpkg root

Related-to #120
