### PR TITLE
Docs: add windows platform parameter to steamCMD

### DIFF
--- a/docs/BUILD/GETTING_THE_GAME_FILES.md
+++ b/docs/BUILD/GETTING_THE_GAME_FILES.md
@@ -57,6 +57,7 @@ If you have access to a Windows PC or a Windows virtual machine:
    Inside the SteamCMD prompt:
 
    ```
+   @sSteamCmdForcePlatformType windows
    login <your_steam_username>
    force_install_dir ./zh_files
    app_update 2732960 validate


### PR DESCRIPTION
otherwise steamcmd will rejct the download on macos