### PR TITLE
ci(workflows): upgrade actions for node24

### DIFF
--- a/.github/workflows/build-linux-flatpak.yml
+++ b/.github/workflows/build-linux-flatpak.yml
@@ -41,8 +41,9 @@ jobs:
             log_suffix: generals
 
     steps:
+      # GeneralsX @build GitHubCopilot 08/05/2026 Use Node 24 compatible GitHub Actions major versions to remove runner deprecation warnings.
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -64,7 +65,7 @@ jobs:
           flatpak --user install -y flathub org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
 
       - name: Cache flatpak-builder state
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .flatpak-builder
           key: flatpak-builder-${{ runner.os }}-${{ inputs.preset }}-${{ hashFiles('flatpak/com.fbraz3.GeneralsX.yml', 'flatpak/com.fbraz3.GeneralsXZH.yml', 'scripts/build/linux/build-linux-flatpak.sh', 'cmake/lzhl.cmake', 'CMakeLists.txt') }}
@@ -100,7 +101,7 @@ jobs:
 
       - name: Upload Build Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-logs-linux-flatpak-${{ matrix.game.id }}-${{ inputs.preset }}
           path: logs/
@@ -108,7 +109,7 @@ jobs:
 
       - name: Upload Flatpak Bundle
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-flatpak-${{ matrix.game.id }}-${{ inputs.preset }}
           path: ${{ steps.bundle.outputs.path }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -57,14 +57,15 @@ jobs:
           - ${{ inputs.package_format }}
 
     steps:
+      # GeneralsX @build GitHubCopilot 08/05/2026 Use Node 24 compatible GitHub Actions major versions to remove runner deprecation warnings.
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Cache vcpkg
         id: cache-vcpkg
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /opt/vcpkg
           key: vcpkg-linux-${{ runner.os }}-${{ hashFiles('vcpkg.json', 'vcpkg-lock.json') }}
@@ -269,7 +270,7 @@ jobs:
 
       - name: Upload Build Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-logs-linux-${{ matrix.game.id }}-${{ matrix.package_format }}
           path: logs/
@@ -277,7 +278,7 @@ jobs:
 
       - name: Upload Deployment Bundle
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.artifact.outputs.name }}
           path: ${{ steps.artifact.outputs.path }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -42,14 +42,15 @@ jobs:
             log_suffix: generals
 
     steps:
+      # GeneralsX @build GitHubCopilot 08/05/2026 Use Node 24 compatible GitHub Actions major versions to remove runner deprecation warnings.
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Cache brew packages
         id: cache-brew
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/Library/Caches/Homebrew
           key: brew-macos-${{ runner.os }}-${{ hashFiles('.github/workflows/build-macos.yml') }}
@@ -408,7 +409,7 @@ jobs:
 
       - name: Upload Build Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-logs-macos-${{ matrix.game.id }}
           path: logs/
@@ -416,7 +417,7 @@ jobs:
 
       - name: Upload Bundle
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-${{ matrix.game.id }}-app
           path: /tmp/macos-artifact-${{ matrix.game.id }}/*.tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       flatpak-should-build: ${{ steps.filter.outputs.flatpak-should-build }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
 
       - name: Filter Changed Paths
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Filter Changed Paths
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           token: ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,9 @@ jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
+      # GeneralsX @build GitHubCopilot 08/05/2026 Use Node 24 compatible GitHub Actions major versions to remove runner deprecation warnings.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -97,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -117,7 +118,7 @@ jobs:
     needs: [build-linux-flatpak, build-macos]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -156,25 +157,25 @@ jobs:
           fi
 
       - name: Download Linux Zero Hour Flatpak artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-flatpak-generalsxzh-linux64-deploy
           path: artifacts/linux-flatpak-zh
 
       - name: Download Linux Generals Flatpak artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-flatpak-generalsx-linux64-deploy
           path: artifacts/linux-flatpak-generals
 
       - name: Download macOS bundle artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: macos-generalsxzh-app
           path: artifacts/macos
 
       - name: Download macOS Generals bundle artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: macos-generalsx-app
           path: artifacts/macos-generals
@@ -372,7 +373,7 @@ jobs:
 
       - name: Upload dry-run release description
         if: success() && inputs.release_mode == 'Dry Run'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-preview-${{ inputs.release_version }}
           path: release-assets/${{ inputs.release_version }}-notes.txt

--- a/.github/workflows/replay-tests.yml
+++ b/.github/workflows/replay-tests.yml
@@ -33,8 +33,9 @@ jobs:
       # -----------------------------------------------------------------------
       # 1. Download built binary artifact from upstream build job
       # -----------------------------------------------------------------------
+      # GeneralsX @build GitHubCopilot 08/05/2026 Use Node 24 compatible GitHub Actions major versions to remove runner deprecation warnings.
       - name: Download game artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.game-artifact }}
           path: /tmp/game-artifact
@@ -118,7 +119,7 @@ jobs:
       # 4. Check out and extract game assets (password-protected 7z, uses LFS)
       # -----------------------------------------------------------------------
       - name: Checkout game assets repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: fbraz3/generalsx-test-files
           path: ci-assets-repo
@@ -148,7 +149,7 @@ jobs:
       #    Repo structure: GeneralsXZH/Maps/<MapFolder>/  GeneralsXZH/Replays/<platform>_*.rep
       # -----------------------------------------------------------------------
       - name: Checkout replay files repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: fbraz3/GeneralsXReplays
           path: ci-replays-repo

--- a/docs/DEV_BLOG/2026-05-DIARY.md
+++ b/docs/DEV_BLOG/2026-05-DIARY.md
@@ -2,6 +2,20 @@
 
 ---
 
+## 2026-05-08: Upgrade active GitHub Actions to Node 24 majors
+
+Cleaned up GitHub Actions runner deprecation warnings caused by Node 20-based action versions in active release and build workflows.
+
+What was done:
+- created a dedicated working branch for the workflow migration.
+- updated active workflows to visible major tags that run on Node 24: `actions/checkout@v6`, `actions/cache@v5`, `actions/upload-artifact@v7`, and `actions/download-artifact@v8`.
+- aligned `ci.yml`, release, Linux build, macOS build, Flatpak build, and replay-test workflows to the same versioning policy.
+- kept changes scoped to active workflows only; reference repositories and archived workflows were left untouched.
+
+Validation:
+- verified the edited workflow files report no YAML/editor diagnostics.
+- confirmed active workflows no longer retain the previous Node 20-era action references that triggered the warning.
+
 ## 2026-05-07: Full TheSuperHackers upstream sync with Core unify reconciliation
 
 Performed a full upstream merge from `thesuperhackers/main` into `thesuperhackers-sync-05-07-2026` with strict preservation of GeneralsX cross-platform direction.


### PR DESCRIPTION
## Summary
Upgrade active GitHub Actions workflows to Node 24-compatible major versions and remove the runner deprecation warnings reported in CI and release jobs.

## What changed
- update active workflows to visible major tags
- switch to `actions/checkout@v6`
- switch to `actions/cache@v5`
- switch to `actions/upload-artifact@v7`
- switch to `actions/download-artifact@v8`
- align `ci.yml`, release, Linux build, macOS build, Flatpak build, and replay-test workflows to the same policy
- add a short entry to the May 2026 dev diary

## Validation
- verified edited workflow files have no YAML/editor diagnostics
- confirmed active workflows no longer use the previous Node 20-era action majors that triggered the warning

## Notes
- changes are intentionally limited to active workflows under `.github/workflows`
- reference repositories and archived workflows were left untouched