### PR TITLE
fix(linux-filesystem): resolve asset-root case mismatches

### DIFF
--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
@@ -81,6 +81,55 @@ static std::filesystem::path fixFilenameFromWindowsPath(const Char *filename, In
 			if (std::filesystem::exists(assetRootPath, ecAsset) || writeAndParentExists) {
 				return assetRootPath;
 			}
+
+			#ifdef __linux__
+			// GeneralsX @bugfix BenderAI 11/05/2026 Linux: resolve case-insensitive paths from asset root.
+			// Some cursor files are lowercase on disk (e.g. sccpointer.ani) while INI references mixed-case names.
+			// The existing case-insensitive traversal below only checks cwd, not the asset root fallback.
+			std::filesystem::path assetRootFixed = s_assetFallbackPath;
+			std::filesystem::path assetRootCurrent = s_assetFallbackPath;
+			bool assetRootFound = true;
+			for (const auto& p : path)
+			{
+				std::filesystem::path pathFixedPart;
+				std::error_code ecAssetCase;
+				if (std::filesystem::exists(assetRootCurrent / p, ecAssetCase))
+				{
+					pathFixedPart = p;
+				}
+				else
+				{
+					for (auto& entry : std::filesystem::directory_iterator(assetRootCurrent, ecAssetCase))
+					{
+						if (strcasecmp(entry.path().filename().string().c_str(), p.string().c_str()) == 0)
+						{
+							pathFixedPart = entry.path().filename();
+							break;
+						}
+					}
+				}
+
+				if (pathFixedPart.empty())
+				{
+					assetRootFound = false;
+					break;
+				}
+
+				assetRootFixed /= pathFixedPart;
+				assetRootCurrent /= pathFixedPart;
+			}
+
+			if (assetRootFound)
+			{
+				std::error_code ecAssetFixed;
+				const bool writeAndParentExistsFixed = (access & File::WRITE)
+					&& std::filesystem::exists(assetRootFixed.parent_path(), ecAssetFixed);
+				if (std::filesystem::exists(assetRootFixed, ecAssetFixed) || writeAndParentExistsFixed)
+				{
+					return assetRootFixed;
+				}
+			}
+			#endif
 		}
 		// Traverse path to try and match case-insensitively
 		std::filesystem::path parent = path.parent_path();

--- a/Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -232,6 +232,9 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 			int frame_index = 0;
 			int hot_spot_x = 0;
 			int hot_spot_y = 0;
+			#ifdef __linux__
+			bool has_hotspot = false;
+			#endif
 
 			RIFFChunk *frame = (RIFFChunk*)((char *)chunk + sizeof(RIFFChunk));
 			while (frame != NULL && (char *)frame < file_buffer + size)
@@ -252,8 +255,17 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 
 					// Allow specifying the hot spot via properties on the surface
 					SDL_PropertiesID props = SDL_GetSurfaceProperties(surface);
+					#ifdef __linux__
+					if (!has_hotspot)
+					{
+						hot_spot_x = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_X_NUMBER, 0);
+						hot_spot_y = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_Y_NUMBER, 0);
+						has_hotspot = true;
+					}
+					#else
 					hot_spot_x = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_X_NUMBER, 0);
 					hot_spot_y = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_Y_NUMBER, 0);
+					#endif
 
 					frame_index++;
 				}
@@ -273,6 +285,9 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 				const int clamped_rate = (cursor->m_frameRate > 0) ? cursor->m_frameRate : 4;
 				const Uint32 frame_duration_ms = (Uint32)((clamped_rate * 1000) / 60);
 				SDL_CursorFrameInfo frame_infos[MAX_2D_CURSOR_ANIM_FRAMES];
+				#ifdef __linux__
+				SDL_Surface *first_surface = cursor->m_frameSurfaces[0];
+				#endif
 
 				for (int i = 0; i < frame_index; ++i)
 				{
@@ -280,14 +295,39 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 					frame_infos[i].duration = frame_duration_ms;
 				}
 
+				#ifdef __linux__
+				if (first_surface)
+				{
+					if (hot_spot_x < 0) hot_spot_x = 0;
+					if (hot_spot_y < 0) hot_spot_y = 0;
+					if (hot_spot_x >= first_surface->w) hot_spot_x = first_surface->w - 1;
+					if (hot_spot_y >= first_surface->h) hot_spot_y = first_surface->h - 1;
+				}
+				#endif
+
 				// GeneralsX @bugfix felipebraz 28/04/2026 Use SDL native animated cursor to ensure frame playback.
 				cursor->m_cursor = SDL_CreateAnimatedCursor(frame_infos, frame_index, hot_spot_x, hot_spot_y);
 				if (!cursor->m_cursor)
 				{
 					DEBUG_LOG(("SDL3Mouse::loadCursorFromFile: SDL_CreateAnimatedCursor failed [%s]", SDL_GetError()));
+					#ifdef __linux__
+					// GeneralsX @bugfix BenderAI 11/05/2026 Fallback to static cursor when ANI animation fails.
+					if (first_surface)
+					{
+						cursor->m_cursor = SDL_CreateColorCursor(first_surface, hot_spot_x, hot_spot_y);
+					}
+					if (!cursor->m_cursor)
+					{
+						DEBUG_LOG(("SDL3Mouse::loadCursorFromFile: SDL_CreateColorCursor fallback failed [%s]", SDL_GetError()));
+						delete cursor;
+						delete[] file_buffer;
+						return NULL;
+					}
+					#else
 					delete cursor;
 					delete[] file_buffer;
 					return NULL;
+					#endif
 				}
 			}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -232,6 +232,9 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 			int frame_index = 0;
 			int hot_spot_x = 0;
 			int hot_spot_y = 0;
+			#ifdef __linux__
+			bool has_hotspot = false;
+			#endif
 
 			RIFFChunk *frame = (RIFFChunk*)((char *)chunk + sizeof(RIFFChunk));
 			while (frame != NULL && (char *)frame < file_buffer + size)
@@ -252,8 +255,17 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 
 					// Allow specifying the hot spot via properties on the surface
 					SDL_PropertiesID props = SDL_GetSurfaceProperties(surface);
+					#ifdef __linux__
+					if (!has_hotspot)
+					{
+						hot_spot_x = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_X_NUMBER, 0);
+						hot_spot_y = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_Y_NUMBER, 0);
+						has_hotspot = true;
+					}
+					#else
 					hot_spot_x = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_X_NUMBER, 0);
 					hot_spot_y = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_Y_NUMBER, 0);
+					#endif
 
 					frame_index++;
 				}
@@ -273,6 +285,9 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 				const int clamped_rate = (cursor->m_frameRate > 0) ? cursor->m_frameRate : 4;
 				const Uint32 frame_duration_ms = (Uint32)((clamped_rate * 1000) / 60);
 				SDL_CursorFrameInfo frame_infos[MAX_2D_CURSOR_ANIM_FRAMES];
+				#ifdef __linux__
+				SDL_Surface *first_surface = cursor->m_frameSurfaces[0];
+				#endif
 
 				for (int i = 0; i < frame_index; ++i)
 				{
@@ -280,14 +295,39 @@ AnimatedCursor* SDL3Mouse::loadCursorFromFile(const char* filepath)
 					frame_infos[i].duration = frame_duration_ms;
 				}
 
+				#ifdef __linux__
+				if (first_surface)
+				{
+					if (hot_spot_x < 0) hot_spot_x = 0;
+					if (hot_spot_y < 0) hot_spot_y = 0;
+					if (hot_spot_x >= first_surface->w) hot_spot_x = first_surface->w - 1;
+					if (hot_spot_y >= first_surface->h) hot_spot_y = first_surface->h - 1;
+				}
+				#endif
+
 				// GeneralsX @bugfix felipebraz 28/04/2026 Use SDL native animated cursor to ensure frame playback.
 				cursor->m_cursor = SDL_CreateAnimatedCursor(frame_infos, frame_index, hot_spot_x, hot_spot_y);
 				if (!cursor->m_cursor)
 				{
 					DEBUG_LOG(("SDL3Mouse::loadCursorFromFile: SDL_CreateAnimatedCursor failed [%s]", SDL_GetError()));
+					#ifdef __linux__
+					// GeneralsX @bugfix BenderAI 11/05/2026 Fallback to static cursor when ANI animation fails.
+					if (first_surface)
+					{
+						cursor->m_cursor = SDL_CreateColorCursor(first_surface, hot_spot_x, hot_spot_y);
+					}
+					if (!cursor->m_cursor)
+					{
+						DEBUG_LOG(("SDL3Mouse::loadCursorFromFile: SDL_CreateColorCursor fallback failed [%s]", SDL_GetError()));
+						delete cursor;
+						delete[] file_buffer;
+						return NULL;
+					}
+					#else
 					delete cursor;
 					delete[] file_buffer;
 					return NULL;
+					#endif
 				}
 			}
 

--- a/docs/DEV_BLOG/2026-05-DIARY.md
+++ b/docs/DEV_BLOG/2026-05-DIARY.md
@@ -2,6 +2,22 @@
 
 ---
 
+## 2026-05-11: Fix Linux case-sensitive asset lookup for cursors and movie playback
+
+Closed a Linux-only asset resolution gap where mixed-case file references in game data could fail against lowercase files on disk, causing cursor fallback and inconsistent video behavior.
+
+What was done:
+- created branch `fix/issue-128-linux-sdl3-cursors` and investigated runtime logs for cursor fallback in Linux.
+- confirmed affected cursor assets existed on disk but with case differences (for example `sccpointer.ani` vs requested `SCCPointer.ani`).
+- fixed `StdLocalFileSystem` asset-root fallback path resolution on Linux to perform case-insensitive traversal (same behavior users expect from legacy Windows paths).
+- kept the change Linux-scoped (`#ifdef __linux__`) to avoid changing macOS behavior.
+- retained SDL3 cursor loading hardening (animated cursor fallback path) and removed temporary diagnostics after validation.
+
+Validation:
+- manual Linux test confirmed default/action/attack cursors render correctly.
+- manual Linux test also confirmed intro and campaign videos now play in Generals and Zero Hour.
+- no editor diagnostics remained in changed files.
+
 ## 2026-05-10: Fix macOS transparency regression in pillarbox path (Issue #131)
 
 Resolved the macOS transparency regression introduced by the pillarbox/offscreen presentation flow and validated behavior on a clean branch baseline.

--- a/docs/WORKDIR/lessons/2026-05-LESSONS.md
+++ b/docs/WORKDIR/lessons/2026-05-LESSONS.md
@@ -1,5 +1,12 @@
 # 2026-05 Lessons
 
+## 2026-05-11 - Asset-root fallback must preserve case-insensitive lookup semantics on Linux
+
+- Symptom: On Linux, default/action/attack cursors intermittently fell back to OS pointer; intro/campaign videos also showed inconsistent playback behavior.
+- Root cause: Relative file lookups that fail in cwd were retried from the asset root path, but that fallback did not apply case-insensitive traversal. Mixed-case data references (Windows-style) failed against lowercase files on disk.
+- Fix applied: In `StdLocalFileSystem::fixFilenameFromWindowsPath`, added Linux-only case-insensitive traversal for asset-root fallback paths before returning not found.
+- Prevention: Any new asset-root fallback path in cross-platform filesystem code must mirror the same case-resolution policy used by primary path traversal on Linux.
+
 ## 2026-05-09 - OpenAL positional voice playback must not drop multichannel aircraft samples
 
 - Symptom: Aircraft selection/order voice lines on Linux/macOS played only the radio-static portion while the spoken line never started.


### PR DESCRIPTION
## Summary
This PR fixes Linux asset lookup behavior when game data references mixed-case paths but files on disk differ only by case.

The root cause was in asset-root fallback resolution: the fallback path did not perform case-insensitive traversal, unlike the main local path resolution flow.

## What Changed
- Added Linux-only case-insensitive traversal to asset-root fallback in [Core/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp](Core/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp).
- Kept platform behavior isolated with `#ifdef __linux__` to avoid changing macOS behavior.
- Kept SDL3 cursor loading hardening in both products:
  - [GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp](GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp)
  - [Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp](Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp)
- Updated docs:
  - [docs/DEV_BLOG/2026-05-DIARY.md](docs/DEV_BLOG/2026-05-DIARY.md)
  - [docs/WORKDIR/lessons/2026-05-LESSONS.md](docs/WORKDIR/lessons/2026-05-LESSONS.md)

## Validation
Manual Linux validation confirmed:
- default/action/attack cursors render correctly (no fallback to OS pointer).
- intro playback works.
- campaign start videos play.

## Issues
Fixes #128
Fixes #103
