### PR TITLE
docs(build): clarify linux proton install behavior

### DIFF
--- a/docs/BUILD/GETTING_THE_GAME_FILES.md
+++ b/docs/BUILD/GETTING_THE_GAME_FILES.md
@@ -8,9 +8,39 @@ Once you have the game files, see [INSTALLATION.md](INSTALLATION.md) for how to 
 
 ---
 
-## The Problem: Steam Does Not Offer a macOS / Linux Download
+## Steam Availability on macOS and Linux
 
-The original game is a Windows-only title on Steam. If you open Steam on macOS or Linux, the **Install** button will not appear. You need to obtain the Windows game files through one of the methods below and then copy them to your system.
+The game is a Windows-only title on Steam, but platform behavior is different:
+
+- **macOS**: Steam usually does not show an **Install** button for this title.
+- **Linux**: Steam may still allow installation through **Steam Play / Proton** (depending on your Steam settings).
+
+Because this can vary by setup, we document multiple ways to obtain the game files.
+
+---
+
+## Option 0 - Use an Existing Linux Steam/Proton Install
+
+If you already installed the game on Linux via Steam + Proton, you can use that data directly.
+
+1. Locate the installed game folder (common locations):
+   - `~/.steam/steam/steamapps/common/Command and Conquer Generals Zero Hour`
+   - `~/.local/share/Steam/steamapps/common/Command and Conquer Generals Zero Hour`
+   - `~/.steam/steam/steamapps/common/Command and Conquer Generals`
+   - `~/.local/share/Steam/steamapps/common/Command and Conquer Generals`
+2. Choose one of the following:
+   - Copy the folder(s) to the recommended layout:
+     - `$HOME/GeneralsX/GeneralsZH` for Zero Hour
+     - `$HOME/GeneralsX/Generals` for the base game
+   - Keep files in the Steam directory and provide paths via environment variables when launching (advanced):
+
+   ```bash
+   CNC_GENERALS_ZH_PATH="$HOME/.steam/steam/steamapps/common/Command and Conquer Generals Zero Hour" \
+   CNC_GENERALS_PATH="$HOME/.steam/steam/steamapps/common/Command and Conquer Generals" \
+   ./GeneralsXZH -win
+   ```
+
+   You can set these variables permanently in your shell profile if desired.
 
 ---
 

--- a/docs/BUILD/INSTALLATION.md
+++ b/docs/BUILD/INSTALLATION.md
@@ -4,7 +4,7 @@
 
 1. You must own a legitimate copy of the game. We build and test against the [Steam version](https://store.steampowered.com/app/2732960/Command__Conquer_Generals_Zero_Hour/). Other retail releases may work, but are not officially supported.
 
-   > **On macOS or Linux?** Steam does not offer a native download for this title on these platforms. See [GETTING_THE_GAME_FILES.md](GETTING_THE_GAME_FILES.md) for step-by-step instructions on how to obtain the game files.
+   > **On macOS or Linux?** This title is Windows-only on Steam. On macOS, Steam usually does not show an install option. On Linux, installation may be available via Steam Play/Proton depending on your configuration. See [GETTING_THE_GAME_FILES.md](GETTING_THE_GAME_FILES.md) for all supported ways to obtain game files.
 
 2. Copy the game data from your existing installation (for example, from `C:\Program Files (x86)\Steam\steamapps\common\Command & Conquer Generals - Zero Hour`) to a local folder on your Linux or macOS system. A recommended layout is:
    - `$HOME/GeneralsX/Generals` for Command & Conquer: Generals

--- a/docs/DEV_BLOG/2026-05-DIARY.md
+++ b/docs/DEV_BLOG/2026-05-DIARY.md
@@ -2,6 +2,19 @@
 
 ---
 
+## 2026-05-11: Clarify Linux Proton install behavior in game-files docs (Issue #132)
+
+Prepared documentation updates to clarify platform-specific Steam behavior and avoid incorrect guidance for Linux users.
+
+What was done:
+- updated game-file acquisition wording to reflect that Linux users may see the Steam Install button when Steam Play/Proton is enabled.
+- kept macOS guidance explicit that install availability is typically absent there for this title.
+- added environment-variable usage examples to support running directly from Steam default directories without copying assets.
+- coordinated issue communication and kept the issue open pending documentation PR creation/merge.
+
+Validation:
+- confirmed documentation changes are isolated to build/install docs and ready for a dedicated docs PR.
+
 ## 2026-05-11: Fix Linux case-sensitive asset lookup for cursors and movie playback
 
 Closed a Linux-only asset resolution gap where mixed-case file references in game data could fail against lowercase files on disk, causing cursor fallback and inconsistent video behavior.


### PR DESCRIPTION
## Summary
- clarify Steam behavior wording: macOS usually does not show install, Linux may allow install via Steam Play/Proton
- add a Linux-specific option for reusing existing Steam/Proton installs
- document environment-variable examples for running without copying assets
- align installation guide prerequisite wording with the updated behavior
- add dev diary entry for this documentation session

## Why
Issue #132 reported that Linux users can install through Steam/Proton, so the previous docs statement was too strict and potentially misleading.

## Validation
- reviewed updated docs for consistency between game-files and installation guides
- kept scope documentation-only

Fixes #132