### PR TITLE
CI: optimize to macOS + Flatpak only, Linux replay in Flatpak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
     outputs:
       zh-should-build: ${{ steps.filter.outputs.zh-should-build }}
       base-should-build: ${{ steps.filter.outputs.base-should-build }}
-      flatpak-should-build: ${{ steps.filter.outputs.flatpak-should-build }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -54,18 +53,6 @@ jobs:
               - 'CMakePresets.json'
               - '.github/workflows/build-*.yml'
               - '.github/workflows/ci.yml'
-            flatpak-should-build:
-              - 'flatpak/**'
-              - 'GeneralsMD/**'
-              - 'Generals/**'
-              - 'Core/**'
-              - 'Dependencies/**'
-              - 'cmake/**'
-              - 'CMakeLists.txt'
-              - 'CMakePresets.json'
-              - 'scripts/build/linux/build-linux-flatpak.sh'
-              - '.github/workflows/build-linux-flatpak.yml'
-              - '.github/workflows/ci.yml'
 
       - name: Build Trigger Summary
         run: |
@@ -83,30 +70,14 @@ jobs:
           else
             echo "| GeneralsX Base (Generals) | ⏭️ No changes |" >> $GITHUB_STEP_SUMMARY
           fi
-          if [ "${{ steps.filter.outputs.flatpak-should-build }}" = "true" ]; then
-            echo "| Linux Flatpak | ✅ Changes detected |" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "| Linux Flatpak | ⏭️ No changes |" >> $GITHUB_STEP_SUMMARY
-          fi
 
-  build-linux-gzip:
-    name: Build Linux gzip
+  build-linux-flatpak:
+    name: Build Linux Flatpak
     needs: detect-changes
     if: needs.detect-changes.outputs.zh-should-build == 'true' || needs.detect-changes.outputs.base-should-build == 'true' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/build-linux.yml
+    uses: ./.github/workflows/build-linux-flatpak.yml
     with:
       preset: linux64-deploy
-      package_format: gzip
-    secrets: inherit
-
-  build-linux-appimage:
-    name: Build Linux AppImage
-    needs: detect-changes
-    if: needs.detect-changes.outputs.zh-should-build == 'true' || needs.detect-changes.outputs.base-should-build == 'true' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/build-linux.yml
-    with:
-      preset: linux64-deploy
-      package_format: appimage
     secrets: inherit
 
   build-macos:
@@ -118,26 +89,17 @@ jobs:
       preset: macos-vulkan
     secrets: inherit
 
-  build-linux-flatpak:
-    name: Build Linux Flatpak
-    needs: detect-changes
-    if: needs.detect-changes.outputs.flatpak-should-build == 'true' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/build-linux-flatpak.yml
-    with:
-      preset: linux64-deploy
-    secrets: inherit
-
-  # GeneralsX @build BenderAI 07/05/2026 Deterministic replay tests run after gzip build on each platform.
+  # GeneralsX @build BenderAI 18/05/2026 Deterministic replay tests run after Flatpak build on Linux and app build on macOS.
   # Each job downloads the built artifact, extracts game assets (ASSETS_KEY secret) and
   # platform replays from fbraz3/GeneralsXReplays, then runs headless replay simulations.
   replay-test-linux:
     name: Replay Tests (linux)
-    needs: [build-linux-gzip]
-    if: needs.build-linux-gzip.result == 'success'
+    needs: [build-linux-flatpak]
+    if: needs.build-linux-flatpak.result == 'success'
     uses: ./.github/workflows/replay-tests.yml
     with:
-      platform: linux
-      game-artifact: linux-generalsxzh-linux64-bundle
+      platform: linux-flatpak
+      game-artifact: linux-flatpak-generalsxzh-linux64-deploy
     secrets:
       ASSETS_KEY: ${{ secrets.ASSETS_KEY }}
 
@@ -155,7 +117,7 @@ jobs:
   ci-summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [build-linux-gzip, build-linux-appimage, build-macos, build-linux-flatpak, replay-test-linux, replay-test-macos]
+    needs: [build-linux-flatpak, build-macos, replay-test-linux, replay-test-macos]
     if: always()
     steps:
       - name: Generate Summary
@@ -164,10 +126,8 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Platform | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Linux gzip (x86_64) | ${{ needs.build-linux-gzip.result == 'success' && '✅ Success' || needs.build-linux-gzip.result == 'skipped' && '⏭️ Skipped' || needs.build-linux-gzip.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Linux AppImage (x86_64) | ${{ needs.build-linux-appimage.result == 'success' && '✅ Success' || needs.build-linux-appimage.result == 'skipped' && '⏭️ Skipped' || needs.build-linux-appimage.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| macOS (arm64) | ${{ needs.build-macos.result == 'success' && '✅ Success' || needs.build-macos.result == 'skipped' && '⏭️ Skipped' || needs.build-macos.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Linux Flatpak | ${{ needs.build-linux-flatpak.result == 'success' && '✅ Success' || needs.build-linux-flatpak.result == 'skipped' && '⏭️ Skipped' || needs.build-linux-flatpak.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| macOS (arm64) | ${{ needs.build-macos.result == 'success' && '✅ Success' || needs.build-macos.result == 'skipped' && '⏭️ Skipped' || needs.build-macos.result == 'cancelled' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Replay Tests | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|--------------|--------|" >> $GITHUB_STEP_SUMMARY
@@ -176,10 +136,8 @@ jobs:
 
       - name: Fail if Any Build or Replay Test Failed
         if: |
-          needs.build-linux-gzip.result == 'failure' ||
-          needs.build-linux-appimage.result == 'failure' ||
-          needs.build-macos.result == 'failure' ||
           needs.build-linux-flatpak.result == 'failure' ||
+          needs.build-macos.result == 'failure' ||
           needs.replay-test-linux.result == 'failure' ||
           needs.replay-test-macos.result == 'failure'
         run: exit 1

--- a/.github/workflows/replay-tests.yml
+++ b/.github/workflows/replay-tests.yml
@@ -13,7 +13,7 @@ on:
       platform:
         required: true
         type: string
-        description: "Target platform: linux or macos"
+        description: "Target platform: linux, linux-flatpak or macos"
       game-artifact:
         required: true
         type: string
@@ -26,7 +26,7 @@ on:
 jobs:
   replay-test-zh:
     name: ZH Replay Tests (${{ inputs.platform }})
-    runs-on: ${{ inputs.platform == 'linux' && 'ubuntu-latest' || 'macos-latest' }}
+    runs-on: ${{ inputs.platform == 'macos' && 'macos-latest' || 'ubuntu-latest' }}
     timeout-minutes: 45
 
     steps:
@@ -49,6 +49,15 @@ jobs:
           sudo apt-get update -qq
           # lavapipe: software Vulkan renderer (no GPU required in CI)
           sudo apt-get install -y -qq p7zip-full mesa-vulkan-drivers libvulkan1
+
+      - name: Install system dependencies (Linux Flatpak)
+        if: inputs.platform == 'linux-flatpak'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq p7zip-full flatpak
+
+          flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak --user install -y flathub org.freedesktop.Platform//25.08
 
       - name: Install system dependencies (macOS)
         if: inputs.platform == 'macos'
@@ -115,6 +124,20 @@ jobs:
           echo "Game bundle contents (Resources):"
           ls -la "$APP_RESOURCES/"
 
+      - name: Install game bundle (Linux Flatpak)
+        if: inputs.platform == 'linux-flatpak'
+        run: |
+          FLATPAK_FILE=$(find /tmp/game-artifact -name "*.flatpak" -type f | head -1)
+          if [ -z "$FLATPAK_FILE" ] || [ ! -f "$FLATPAK_FILE" ]; then
+            echo "ERROR: Flatpak bundle not found in downloaded artifact"
+            find /tmp/game-artifact -maxdepth 5 -type f -print || true
+            exit 1
+          fi
+
+          echo "Installing Flatpak bundle: $FLATPAK_FILE"
+          flatpak --user install -y "$FLATPAK_FILE"
+          flatpak --user info com.fbraz3.GeneralsXZH
+
       # -----------------------------------------------------------------------
       # 4. Check out and extract game assets (password-protected 7z, uses LFS)
       # -----------------------------------------------------------------------
@@ -155,7 +178,7 @@ jobs:
           path: ci-replays-repo
 
       - name: Set up user data directories (Linux)
-        if: inputs.platform == 'linux'
+        if: inputs.platform == 'linux' || inputs.platform == 'linux-flatpak'
         run: |
           USER_DATA="$HOME/.local/share/GeneralsX/GeneralsZH"
           MAPS_DIR="$USER_DATA/Maps"
@@ -180,6 +203,15 @@ jobs:
           fi
 
           echo "USER_DATA=$USER_DATA" >> $GITHUB_ENV
+
+      - name: Extract game assets (Linux Flatpak)
+        if: inputs.platform == 'linux-flatpak'
+        run: |
+          # For Flatpak replay tests assets must be in xdg-data path visible to sandbox.
+          echo "Extracting generalszh.7z into: $USER_DATA"
+          7z x -p"${{ secrets.ASSETS_KEY }}" "$GITHUB_WORKSPACE/ci-assets-repo/generalszh.7z" -o"$USER_DATA" -y
+          echo "Big files found:"
+          ls "$USER_DATA/"*.big 2>/dev/null | head -10 || echo "(none found - verify archive contents)"
 
       - name: Set up user data directories (macOS)
         if: inputs.platform == 'macos'
@@ -271,6 +303,60 @@ jobs:
 
           if [ $FAIL -gt 0 ]; then
             echo "::error::$FAIL replay(s) failed on linux"
+            exit 1
+          fi
+          if [ $((PASS + FAIL)) -eq 0 ]; then
+            echo "::warning::No replay files were found to test"
+          fi
+
+      - name: Run headless replay tests (Linux Flatpak)
+        if: inputs.platform == 'linux-flatpak'
+        run: |
+          PASS=0
+          FAIL=0
+
+          export DXVK_LOG_LEVEL=none
+          export SDL_VIDEODRIVER=dummy
+          export SDL_AUDIODRIVER=dummy
+
+          # GeneralsX @bugfix GitHubCopilot 18/05/2026 Run deterministic Linux replay CI using Flatpak runtime instead of gzip bundle.
+          echo "### Replay Test Results (linux-flatpak)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Replay | Result | Details |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|--------|---------|" >> $GITHUB_STEP_SUMMARY
+
+          for rep in "$USER_DATA/Replays"/*.rep; do
+            [ -f "$rep" ] || continue
+            NAME=$(basename "$rep")
+            echo "=== $NAME ==="
+
+            set +e
+            OUTPUT=$(timeout 180 flatpak run --env=SDL_VIDEODRIVER=dummy --env=SDL_AUDIODRIVER=dummy --env=DXVK_LOG_LEVEL=none com.fbraz3.GeneralsXZH -headless -replay "$rep" 2>&1)
+            CODE=$?
+            set -e
+
+            echo "$OUTPUT" | grep -iE "\[GeneralsX\]|Simulating|Elapsed|CRC|MISMATCH|returned with code|FATAL" || true
+
+            if [ $CODE -eq 0 ]; then
+              PASS=$((PASS + 1))
+              echo "PASS"
+              echo "| \`$NAME\` | PASS | exit 0 |" >> $GITHUB_STEP_SUMMARY
+            else
+              FAIL=$((FAIL + 1))
+              DETAIL=$(echo "$OUTPUT" | grep -iE "Error|CRC|MISMATCH|Exiting|FATAL|returned with code" | tail -3 | tr '\n' ' ' | tr '|' '/')
+              [ -n "$DETAIL" ] || DETAIL="no filtered diagnostics"
+              echo "FAIL (exit $CODE)"
+              echo "| \`$NAME\` | FAIL | exit $CODE: $DETAIL |" >> $GITHUB_STEP_SUMMARY
+            fi
+
+            echo ""
+          done
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Results: $PASS passed, $FAIL failed**" >> $GITHUB_STEP_SUMMARY
+
+          if [ $FAIL -gt 0 ]; then
+            echo "::error::$FAIL replay(s) failed on linux-flatpak"
             exit 1
           fi
           if [ $((PASS + FAIL)) -eq 0 ]; then

--- a/docs/DEV_BLOG/2026-05-DIARY.md
+++ b/docs/DEV_BLOG/2026-05-DIARY.md
@@ -2,6 +2,30 @@
 
 ---
 
+## 2026-05-18: CI migration to macOS + Flatpak with Linux replay in Flatpak
+
+Migrated CI to keep only macOS and Linux Flatpak builds, and switched Linux
+headless replay tests to run inside Flatpak instead of the gzip bundle path.
+
+What was done:
+- removed Linux gzip and Linux AppImage jobs from `.github/workflows/ci.yml`
+- kept Linux Flatpak build and macOS build in the main CI workflow
+- changed Linux replay dependency from gzip build to Flatpak build
+- changed Linux replay execution input to `platform: linux-flatpak`
+- updated CI summary and failure gates to use macOS + Flatpak only
+- extended `.github/workflows/replay-tests.yml` with Linux Flatpak setup/run
+
+Rationale:
+- Linux replay validation should run in the same packaging/runtime path used by
+	Linux distribution (Flatpak sandbox)
+- remove duplicate Linux package work in CI while keeping platform coverage
+- preserve deterministic replay checks for Linux and macOS
+
+Impact:
+- simpler CI graph (fewer Linux package variants)
+- Linux replay tests now validate the Flatpak runtime path directly
+- macOS replay flow remains unchanged
+
 ## 2026-05-17: Restore replay pass/fail reports in CI (Linux + macOS)
 
 Restored the replay report output format used before the bugfix cycle so CI


### PR DESCRIPTION
## What changed

- Removed Linux gzip and AppImage jobs from CI
- Kept Linux Flatpak build and macOS build as the only CI gates
- Linux replay tests now run inside Flatpak (instead of gzip bundle)
- CI summary now shows only macOS and Linux Flatpak status

## Why

- Releases are published as Flatpak (Linux) and macOS app only
- Flatpak already has build and replay validation in CI
- gzip/AppImage are redundant for production release gates

## Validation

- Workflow diagnostics are clean
- Replay tests run in Flatpak runtime on Linux
- macOS replay path unchanged