### PR TITLE
merge: sync TheSuperHackers main into GeneralsX (2026-05-28)

### DIFF
--- a/Core/GameEngine/Include/Common/AudioRequest.h
+++ b/Core/GameEngine/Include/Common/AudioRequest.h
@@ -45,6 +45,8 @@ struct AudioRequest : public MemoryPoolObject
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( AudioRequest, "AudioRequest" )
 
 public:
+	AudioEventRTS* releasePendingEvent();
+
 	RequestType m_request;
 	union
 	{

--- a/Core/GameEngine/Include/Common/RandomValue.h
+++ b/Core/GameEngine/Include/Common/RandomValue.h
@@ -35,4 +35,24 @@ extern void InitRandom( UnsignedInt seed );
 extern UnsignedInt GetGameLogicRandomSeed();   ///< Get the seed (used for replays)
 extern UnsignedInt GetGameLogicRandomSeedCRC();///< Get the seed (used for CRCs)
 
+struct RandomValueClass
+{
+	virtual Int GetRandomValueInt( Int lo, Int hi, const char *file, Int line ) const = 0;
+	virtual Real GetRandomValueReal( Real lo, Real hi, const char *file, Int line ) const = 0;
+};
+struct LogicRandomValueClass final : RandomValueClass
+{
+	virtual Int GetRandomValueInt( Int lo, Int hi, const char *file, Int line ) const override;
+	virtual Real GetRandomValueReal( Real lo, Real hi, const char *file, Int line ) const override;
+};
+struct ClientRandomValueClass final : RandomValueClass
+{
+	virtual Int GetRandomValueInt( Int lo, Int hi, const char *file, Int line ) const override;
+	virtual Real GetRandomValueReal( Real lo, Real hi, const char *file, Int line ) const override;
+};
+
+// use these macros to access the random value functions
+#define RandomValueInt(randomValueClass, lo, hi) randomValueClass.GetRandomValueInt( lo, hi, __FILE__, __LINE__ )
+#define RandomValueReal(randomValueClass, lo, hi) randomValueClass.GetRandomValueReal( lo, hi, __FILE__, __LINE__ )
+
 //--------------------------------------------------------------------------------------------------------------

--- a/Core/GameEngine/Include/GameClient/ParticleSys.h
+++ b/Core/GameEngine/Include/GameClient/ParticleSys.h
@@ -753,6 +753,8 @@ public:
 	virtual void reset() override;									///< reset the manager and all particle systems
 	virtual void update() override;								///< update all particle systems
 
+	virtual Bool isDummy() const { return false; }
+
 	virtual Int getOnScreenParticleCount() = 0;   ///< returns the number of particles on screen
   virtual void setOnScreenParticleCount(int count);
 
@@ -761,8 +763,7 @@ public:
 	ParticleSystemTemplate *newTemplate( const AsciiString &name );
 
 	/// given a template, instantiate a particle system
-	ParticleSystem *createParticleSystem( const ParticleSystemTemplate *sysTemplate,
-																				Bool createSlaves = TRUE );
+	ParticleSystem *createParticleSystem( const ParticleSystemTemplate *sysTemplate, Bool createSlaves = TRUE );
 
 	/** given a template, instantiate a particle system.
 		if attachTo is not null, attach the particle system to the given object.
@@ -835,11 +836,24 @@ private:
 	ParticleSystemIDMap m_systemMap; ///< a hash map of all particle systems
 };
 
+
 // TheSuperHackers @feature bobtista 31/01/2026
 // ParticleSystemManager that does nothing. Used for Headless Mode.
+// Generally does not load particle system templates. Certainly does not create particle systems.
 class ParticleSystemManagerDummy : public ParticleSystemManager
 {
 public:
+#if RETAIL_COMPATIBLE_CRC
+	// Must not overload init to keep loading the particle system templates,
+	// which are unfortunately needed to preserve the correct logic crc.
+#else
+	virtual void init() override {}
+	virtual void reset() override {}
+#endif
+	virtual void update() override {}
+
+	virtual Bool isDummy() const override { return true; }
+
 	virtual Int getOnScreenParticleCount() override { return 0; }
 	virtual void doParticles(RenderInfoClass &rinfo) override {}
 	virtual void queueParticleRender() override {}

--- a/Core/GameEngine/Include/GameClient/ParticleSys.h
+++ b/Core/GameEngine/Include/GameClient/ParticleSys.h
@@ -753,6 +753,8 @@ public:
 	virtual void reset() override;									///< reset the manager and all particle systems
 	virtual void update() override;								///< update all particle systems
 
+	virtual Bool isDummy() const { return false; }
+
 	virtual Int getOnScreenParticleCount() = 0;   ///< returns the number of particles on screen
   virtual void setOnScreenParticleCount(int count);
 
@@ -761,8 +763,7 @@ public:
 	ParticleSystemTemplate *newTemplate( const AsciiString &name );
 
 	/// given a template, instantiate a particle system
-	ParticleSystem *createParticleSystem( const ParticleSystemTemplate *sysTemplate,
-																				Bool createSlaves = TRUE );
+	ParticleSystem *createParticleSystem( const ParticleSystemTemplate *sysTemplate, Bool createSlaves = TRUE );
 
 	/** given a template, instantiate a particle system.
 		if attachTo is not null, attach the particle system to the given object.
@@ -835,13 +836,24 @@ private:
 	ParticleSystemIDMap m_systemMap; ///< a hash map of all particle systems
 };
 
+
 // TheSuperHackers @feature bobtista 31/01/2026
 // ParticleSystemManager that does nothing. Used for Headless Mode.
+// Generally does not load particle system templates. Certainly does not create particle systems.
 class ParticleSystemManagerDummy : public ParticleSystemManager
 {
 public:
+#if RETAIL_COMPATIBLE_CRC
+	// Must not overload init to keep loading the particle system templates,
+	// which are unfortunately needed to preserve the correct logic crc.
+#else
+	virtual void init() override {}
+	virtual void reset() override {}
+#endif
 	// GeneralsX @bugfix fbraz 04/05/2026 Prevent headless replay from entering full particle update path.
 	virtual void update() override {}
+
+	virtual Bool isDummy() const override { return true; }
 	virtual Int getOnScreenParticleCount() override { return 0; }
 	virtual void doParticles(RenderInfoClass &rinfo) override {}
 	virtual void queueParticleRender() override {}

--- a/Core/GameEngine/Source/Common/Audio/AudioRequest.cpp
+++ b/Core/GameEngine/Source/Common/Audio/AudioRequest.cpp
@@ -30,5 +30,20 @@
 
 AudioRequest::~AudioRequest()
 {
+	if (m_usePendingEvent)
+	{
+		delete m_pendingEvent;
+	}
+}
 
+AudioEventRTS* AudioRequest::releasePendingEvent()
+{
+	if (m_usePendingEvent)
+	{
+		m_usePendingEvent = false;
+		AudioEventRTS* event = m_pendingEvent;
+		m_pendingEvent = nullptr;
+		return event;
+	}
+	return nullptr;
 }

--- a/Core/GameEngine/Source/Common/RandomValue.cpp
+++ b/Core/GameEngine/Source/Common/RandomValue.cpp
@@ -465,3 +465,24 @@ Real GameLogicRandomVariable::getValue() const
 			return 0.0f;
 	}
 }
+
+
+Int LogicRandomValueClass::GetRandomValueInt( Int lo, Int hi, const char *file, Int line ) const
+{
+	return GetGameLogicRandomValue(lo, hi, file, line);
+}
+
+Real LogicRandomValueClass::GetRandomValueReal( Real lo, Real hi, const char *file, Int line ) const
+{
+	return GetGameLogicRandomValueReal(lo, hi, file, line);
+}
+
+Int ClientRandomValueClass::GetRandomValueInt( Int lo, Int hi, const char *file, Int line ) const
+{
+	return GetGameClientRandomValue(lo, hi, file, line);
+}
+
+Real ClientRandomValueClass::GetRandomValueReal( Real lo, Real hi, const char *file, Int line ) const
+{
+	return GetGameClientRandomValueReal(lo, hi, file, line);
+}

--- a/Core/GameEngine/Source/Common/ReplaySimulation.cpp
+++ b/Core/GameEngine/Source/Common/ReplaySimulation.cpp
@@ -96,8 +96,6 @@ int ReplaySimulation::simulateReplaysInThisProcess(const std::vector<AsciiString
 			UnsignedInt totalTimeSec = TheRecorder->getPlaybackFrameCount() / LOGICFRAMES_PER_SECOND;
 			while (TheRecorder->isPlaybackInProgress())
 			{
-				TheGameClient->updateHeadless();
-
 				const int progressFrameInterval = 10*60*LOGICFRAMES_PER_SECOND;
 				if (TheGameLogic->getFrame() != 0 && TheGameLogic->getFrame() % progressFrameInterval == 0)
 				{

--- a/Core/GameEngine/Source/Common/ReplaySimulation.cpp
+++ b/Core/GameEngine/Source/Common/ReplaySimulation.cpp
@@ -86,8 +86,6 @@ int ReplaySimulation::simulateReplaysInThisProcess(const std::vector<AsciiString
 			UnsignedInt totalTimeSec = TheRecorder->getPlaybackFrameCount() / LOGICFRAMES_PER_SECOND;
 			while (TheRecorder->isPlaybackInProgress())
 			{
-				TheGameClient->updateHeadless();
-
 				const int progressFrameInterval = 10*60*LOGICFRAMES_PER_SECOND;
 				if (TheGameLogic->getFrame() != 0 && TheGameLogic->getFrame() % progressFrameInterval == 0)
 				{

--- a/Core/GameEngine/Source/GameClient/Drawable/Update/BeaconClientUpdate.cpp
+++ b/Core/GameEngine/Source/GameClient/Drawable/Update/BeaconClientUpdate.cpp
@@ -94,9 +94,7 @@ static ParticleSystem* createParticleSystem( Drawable *draw )
 			AsciiString templateName;
 			templateName.format("BeaconSmoke%6.6X", (0xffffff & obj->getIndicatorColor()));
 			const ParticleSystemTemplate *particleTemplate = TheParticleSystemManager->findTemplate( templateName );
-
-			DEBUG_ASSERTCRASH(particleTemplate, ("Could not find particle system %s", templateName.str()));
-
+			DEBUG_ASSERTCRASH(TheParticleSystemManager->isDummy() || particleTemplate, ("Could not find particle system %s", templateName.str()));
 			if (particleTemplate)
 			{
 				system = TheParticleSystemManager->createParticleSystem( particleTemplate );
@@ -107,7 +105,7 @@ static ParticleSystem* createParticleSystem( Drawable *draw )
 			{// THis this will whip up a new particle system to match the house color provided
 				templateName.format("BeaconSmokeFFFFFF");
 				const ParticleSystemTemplate *failsafeTemplate = TheParticleSystemManager->findTemplate( templateName );
-				DEBUG_ASSERTCRASH(failsafeTemplate, ("Doh, this is bad \n I Could not even find the white particle system to make a failsafe system out of."));
+				DEBUG_ASSERTCRASH(TheParticleSystemManager->isDummy() || failsafeTemplate, ("Doh, this is bad \n I Could not even find the white particle system to make a failsafe system out of."));
 				system = TheParticleSystemManager->createParticleSystem( failsafeTemplate );
 				if (system)
 				{

--- a/Core/GameEngine/Source/GameClient/FXList.cpp
+++ b/Core/GameEngine/Source/GameClient/FXList.cpp
@@ -600,7 +600,7 @@ protected:
 		}
 
 		const ParticleSystemTemplate *tmp = TheParticleSystemManager->findTemplate(m_name);
-		DEBUG_ASSERTCRASH(tmp, ("ParticleSystem %s not found",m_name.str()));
+		DEBUG_ASSERTCRASH(TheParticleSystemManager->isDummy() || tmp, ("ParticleSystem %s not found",m_name.str()));
 		if (tmp)
 		{
 			for (Int i = 0; i < m_count; i++ )

--- a/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+++ b/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
@@ -251,7 +251,7 @@ class MilesAudioManager : public AudioManager
 		void initSamplePools();
 		void processRequest( AudioRequest *req );
 
-		void playAudioEvent( AudioEventRTS *event );
+		void playAudioEvent( AudioRequest* req );
 		void stopAudioEvent( AudioHandle handle );
 		void pauseAudioEvent( AudioHandle handle );
 

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -652,8 +652,12 @@ void MilesAudioManager::pauseAmbient( Bool shouldPause )
 }
 
 //-------------------------------------------------------------------------------------------------
-void MilesAudioManager::playAudioEvent( AudioEventRTS *event )
+void MilesAudioManager::playAudioEvent( AudioRequest* req )
 {
+	DEBUG_ASSERTCRASH(req->m_usePendingEvent && req->m_pendingEvent, ("audio request was expected to contain a valid audio event"));
+
+	AudioEventRTS* event = req->m_pendingEvent;
+
 #ifdef INTENSIVE_AUDIO_DEBUG
 	DEBUG_LOG(("MILES (%d) - Processing play request: %d (%s)", TheGameLogic->getFrame(), event->getPlayingHandle(), event->getEventName().str()));
 #endif
@@ -709,7 +713,7 @@ void MilesAudioManager::playAudioEvent( AudioEventRTS *event )
 			}
 
 			// Put this on here, so that the audio event RTS will be cleaned up regardless.
-			audio->m_audioEventRTS = event;
+			audio->m_audioEventRTS = event = req->releasePendingEvent();
 			audio->m_stream = stream;
 			audio->m_type = PAT_Stream;
 
@@ -778,7 +782,7 @@ void MilesAudioManager::playAudioEvent( AudioEventRTS *event )
 					sample3D = nullptr;
 				}
 				// Push it onto the list of playing things
-				audio->m_audioEventRTS = event;
+				audio->m_audioEventRTS = event = req->releasePendingEvent();
 				audio->m_3DSample = sample3D;
 				audio->m_file = nullptr;
 				audio->m_type = PAT_3DSample;
@@ -849,7 +853,7 @@ void MilesAudioManager::playAudioEvent( AudioEventRTS *event )
 				}
 
 				// Push it onto the list of playing things
-				audio->m_audioEventRTS = event;
+				audio->m_audioEventRTS = event = req->releasePendingEvent();
 				audio->m_sample = sample;
 				audio->m_file = nullptr;
 				audio->m_type = PAT_Sample;
@@ -2930,7 +2934,7 @@ void MilesAudioManager::processRequest( AudioRequest *req )
 	{
 		case AR_Play:
 		{
-			playAudioEvent(req->m_pendingEvent);
+			playAudioEvent(req);
 			break;
 		}
 		case AR_Pause:

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -656,8 +656,12 @@ void MilesAudioManager::pauseAmbient( Bool shouldPause )
 }
 
 //-------------------------------------------------------------------------------------------------
-void MilesAudioManager::playAudioEvent( AudioEventRTS *event )
+void MilesAudioManager::playAudioEvent( AudioRequest* req )
 {
+	DEBUG_ASSERTCRASH(req->m_usePendingEvent && req->m_pendingEvent, ("audio request was expected to contain a valid audio event"));
+
+	AudioEventRTS* event = req->m_pendingEvent;
+
 #ifdef INTENSIVE_AUDIO_DEBUG
 	DEBUG_LOG(("MILES (%d) - Processing play request: %d (%s)", TheGameLogic->getFrame(), event->getPlayingHandle(), event->getEventName().str()));
 #endif
@@ -713,7 +717,7 @@ void MilesAudioManager::playAudioEvent( AudioEventRTS *event )
 			}
 
 			// Put this on here, so that the audio event RTS will be cleaned up regardless.
-			audio->m_audioEventRTS = event;
+			audio->m_audioEventRTS = event = req->releasePendingEvent();
 			audio->m_stream = stream;
 			audio->m_type = PAT_Stream;
 
@@ -782,7 +786,7 @@ void MilesAudioManager::playAudioEvent( AudioEventRTS *event )
 					sample3D = nullptr;
 				}
 				// Push it onto the list of playing things
-				audio->m_audioEventRTS = event;
+				audio->m_audioEventRTS = event = req->releasePendingEvent();
 				audio->m_3DSample = sample3D;
 				audio->m_file = nullptr;
 				audio->m_type = PAT_3DSample;
@@ -853,7 +857,7 @@ void MilesAudioManager::playAudioEvent( AudioEventRTS *event )
 				}
 
 				// Push it onto the list of playing things
-				audio->m_audioEventRTS = event;
+				audio->m_audioEventRTS = event = req->releasePendingEvent();
 				audio->m_sample = sample;
 				audio->m_file = nullptr;
 				audio->m_type = PAT_Sample;
@@ -2934,7 +2938,7 @@ void MilesAudioManager::processRequest( AudioRequest *req )
 	{
 		case AR_Play:
 		{
-			playAudioEvent(req->m_pendingEvent);
+			playAudioEvent(req);
 			break;
 		}
 		case AR_Pause:

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -179,7 +179,7 @@ static Int getRiverVertexDiffuse(W3DShroud *shroud, Real x, Real y, Real shadeR,
 		(Int)(shadeR * shroudScale),
 		(Int)(shadeG * shroudScale),
 		(Int)(shadeB * shroudScale),
-		(diffuse >> 24) & 0xff);
+		((diffuse >> 24) & 0xff) * shroudScale);
 }
 
 void doSkyBoxSet(Bool startDraw)
@@ -926,9 +926,11 @@ void WaterRenderObjClass::ReAcquireResources()
 			tex t1	\n\
 			tex t2	\n\
 			tex t3\n\
-			mul r0,v0,t0 ; blend vertex color into t0. \n\
+			mul r0.rgb, v0, t0 ; blend vertex color into t0. \n\
+			mov r0.a, t0 ; keep vertex alpha from fading the base water. \n\
 			mul r1, t1, t2 ; mul\n\
-			add r0.rgb, r0, t3\n\
+			add r1.rgb, r1, t3\n\
+			mul r1.rgb, r1, v0.a\n\
 			+mul r0.a, r0, t3\n\
 			add r0.rgb, r0, r1\n";
 		hr = D3DXAssembleShader( shader, strlen(shader), 0, nullptr, &compiledShader, nullptr);

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -181,7 +181,7 @@ static Int getRiverVertexDiffuse(W3DShroud *shroud, Real x, Real y, Real shadeR,
 		(Int)(shadeR * shroudScale),
 		(Int)(shadeG * shroudScale),
 		(Int)(shadeB * shroudScale),
-		(diffuse >> 24) & 0xff);
+		((diffuse >> 24) & 0xff) * shroudScale);
 }
 
 void doSkyBoxSet(Bool startDraw)
@@ -933,9 +933,11 @@ void WaterRenderObjClass::ReAcquireResources()
 			tex t1	\n\
 			tex t2	\n\
 			tex t3\n\
-			mul r0,v0,t0 ; blend vertex color into t0. \n\
+			mul r0.rgb, v0, t0 ; blend vertex color into t0. \n\
+			mov r0.a, t0 ; keep vertex alpha from fading the base water. \n\
 			mul r1, t1, t2 ; mul\n\
-			add r0.rgb, r0, t3\n\
+			add r1.rgb, r1, t3\n\
+			mul r1.rgb, r1, v0.a\n\
 			+mul r0.a, r0, t3\n\
 			add r0.rgb, r0, r1\n";
 		hr = D3DXAssembleShader( shader, strlen(shader), 0, nullptr, &compiledShader, nullptr);

--- a/Generals/Code/GameEngine/Include/Common/Geometry.h
+++ b/Generals/Code/GameEngine/Include/Common/Geometry.h
@@ -31,6 +31,7 @@
 
 #include "Lib/BaseType.h"
 #include "Common/AsciiString.h"
+#include "Common/RandomValue.h"
 #include "Common/Snapshot.h"
 
 class INI;
@@ -171,9 +172,8 @@ public:
 	/// get the 2d bounding box
 	void get2DBounds(const Coord3D& geomCenter, Real angle, Region2D& bounds	) const;
 
-	/// note that the pt is generated using game logic random, not game client random!
-	void makeRandomOffsetWithinFootprint(Coord3D& pt) const;
-	void makeRandomOffsetOnPerimeter(Coord3D& pt) const; //Chooses a random point on the extent border.
+	void makeRandomOffsetWithinFootprint(Coord3D& pt, const RandomValueClass& random = LogicRandomValueClass()) const;
+	void makeRandomOffsetOnPerimeter(Coord3D& pt) const; ///< Chooses a random point on the extent border. Uses game logic random!
 
 	void clipPointToFootprint(const Coord3D& geomCenter, Coord3D& ptToClip) const;
 

--- a/Generals/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/Generals/Code/GameEngine/Include/GameClient/GameClient.h
@@ -94,8 +94,6 @@ public:
 
 	void step(); ///< Do one fixed time step
 
-	void updateHeadless();
-
 	void addDrawableToLookupTable( Drawable *draw );			///< add drawable ID to hash lookup table
 	void removeDrawableFromLookupTable( Drawable *draw );	///< remove drawable ID from hash lookup table
 

--- a/Generals/Code/GameEngine/Source/Common/System/Geometry.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Geometry.cpp
@@ -376,7 +376,7 @@ Bool GeometryInfo::isPointInFootprint(const Coord3D& geomCenter, const Coord3D& 
 }
 
 //=============================================================================
-void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt) const
+void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt, const RandomValueClass& random) const
 {
 	switch(m_type)
 	{
@@ -390,14 +390,14 @@ void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt) const
 			Real distSqr;
 			do
 			{
-				pt.x = GameLogicRandomValueReal(-m_majorRadius, m_majorRadius);
-				pt.y = GameLogicRandomValueReal(-m_majorRadius, m_majorRadius);
+				pt.x = RandomValueReal(random, -m_majorRadius, m_majorRadius);
+				pt.y = RandomValueReal(random, -m_majorRadius, m_majorRadius);
 				pt.z = 0.0f;
 				distSqr = sqr(pt.x) + sqr(pt.y);
 			} while (distSqr > maxDistSqr);
 #else
-			Real radius = GameLogicRandomValueReal(0.0f, m_boundingCircleRadius);
-			Real angle = GameLogicRandomValueReal(-PI, PI);
+			Real radius = RandomValueReal(random, 0.0f, m_boundingCircleRadius);
+			Real angle = RandomValueReal(random, -PI, PI);
 			pt.x = radius * Cos(angle);
 			pt.y = radius * Sin(angle);
 			pt.z = 0.0f;
@@ -407,8 +407,8 @@ void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt) const
 
 		case GEOMETRY_BOX:
 		{
-			pt.x = GameLogicRandomValueReal(-m_majorRadius, m_majorRadius);
-			pt.y = GameLogicRandomValueReal(-m_minorRadius, m_minorRadius);
+			pt.x = RandomValueReal(random, -m_majorRadius, m_majorRadius);
+			pt.y = RandomValueReal(random, -m_minorRadius, m_minorRadius);
 			pt.z = 0.0f;
 			break;
 		}

--- a/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -750,15 +750,6 @@ void GameClient::step()
 	TheDisplay->step();
 }
 
-void GameClient::updateHeadless()
-{
-	// TheSuperHackers @info helmutbuhler 03/05/2025 bobtista 02/02/2026
-	// Update particles to prevent accumulation in headless mode. Particles are generated
-	// during GameLogic and only cleaned up during rendering. update() lets particles finish
-	// their lifecycle naturally instead of abruptly removing them with reset().
-	TheParticleSystemManager->update();
-}
-
 Bool GameClient::isMovieAbortRequested()
 {
 	if (TheGameEngine)

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
@@ -253,7 +253,7 @@ void TransitionDamageFX::onDelete()
 /** Given an FXLoc info struct, return the effect position that we are supposed to use.
 	* The position is local to to the object */
 //-------------------------------------------------------------------------------------------------
-static Coord3D getLocalEffectPos( const FXLocInfo *locInfo, Drawable *draw )
+static Coord3D getLocalEffectPos( const FXLocInfo *locInfo, Drawable *draw, const RandomValueClass &random = LogicRandomValueClass() )
 {
 
 	DEBUG_ASSERTCRASH( locInfo, ("getLocalEffectPos: locInfo is null") );
@@ -290,7 +290,7 @@ static Coord3D getLocalEffectPos( const FXLocInfo *locInfo, Drawable *draw )
 				return locInfo->loc;
 
 			// pick one of the bone positions
-			Int pick = GameLogicRandomValue( 0, boneCount - 1 );
+			Int pick = RandomValueInt( random, 0, boneCount - 1 );
 			return positions[ pick ];
 
 		}
@@ -387,6 +387,11 @@ void TransitionDamageFX::onBodyDamageStateChange( const DamageInfo* damageInfo,
 				if( lastDamageInfo == nullptr ||
 						getDamageTypeFlag( modData->m_damageParticleTypes, lastDamageInfo->in.m_damageType ) )
 				{
+#if RETAIL_COMPATIBLE_CRC
+					// TheSuperHackers @fix The particle system is now decoupled from the logic crc
+					// and the side effects on the logic random seed values are preserved for retail compatibility.
+					getLocalEffectPos( &modData->m_particleSystem[ newState ][ i ].locInfo, draw, LogicRandomValueClass() );
+#endif
 
 					// create a new particle system based on the template provided
 					ParticleSystem* pSystem = TheParticleSystemManager->createParticleSystem( pSystemT );
@@ -394,7 +399,7 @@ void TransitionDamageFX::onBodyDamageStateChange( const DamageInfo* damageInfo,
 					{
 
 						// get the what is the position we're going to played the effect at
-						pos = getLocalEffectPos( &modData->m_particleSystem[ newState ][ i ].locInfo, draw );
+						pos = getLocalEffectPos( &modData->m_particleSystem[ newState ][ i ].locInfo, draw, ClientRandomValueClass() );
 
 						//
 						// set position on system given any bone position provided, the bone position is

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
@@ -235,14 +235,24 @@ void EMPUpdate::doDisableAttack()
 
 					for (UnsignedInt e = 0 ; e < emitterCount; ++e)
 					{
+#if RETAIL_COMPATIBLE_CRC
+						// TheSuperHackers @fix The particle system is now decoupled from the logic crc
+						// and the side effects on the logic random seed values are preserved for retail compatibility.
+						{
+							Coord3D offs = {0,0,0};
+							curVictim->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, LogicRandomValueClass() );
+							GameLogicRandomValue(3, victimHeight);
+							GameLogicRandomValue(1, 100);
+						}
+#endif
 
 						ParticleSystem *sys = TheParticleSystemManager->createParticleSystem(tmp);
 
 						if (sys)
 						{
 							Coord3D offs = {0,0,0};
-							curVictim->getGeometryInfo().makeRandomOffsetWithinFootprint( offs );
-							offs.z = GameLogicRandomValue(3, victimHeight);
+							curVictim->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, ClientRandomValueClass() );
+							offs.z = GameClientRandomValue(3, victimHeight);
 
 							//This puts all the sparks within a quadrahemicycloid (rectangular dome) volume
 							//The same shape as a four cornered camping dome tent, for those with less Greek
@@ -259,7 +269,7 @@ void EMPUpdate::doDisableAttack()
 							sys->attachToObject(curVictim);
 							sys->setPosition( &offs );
 							sys->setSystemLifetime(MAX(0, data->m_disabledDuration - 30));
-							sys->setInitialDelay(GameLogicRandomValue(1,100));
+							sys->setInitialDelay(GameClientRandomValue(1,100));
 						}
 					}
 				}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -1263,11 +1263,20 @@ void SpecialAbilityUpdate::triggerAbilityEffect()
 				const ParticleSystemTemplate *tmp = data->m_disableFXParticleSystem;
 				if (tmp)
 				{
+#if RETAIL_COMPATIBLE_CRC
+					// TheSuperHackers @fix The particle system is now decoupled from the logic crc
+					// and the side effects on the logic random seed values are preserved for retail compatibility.
+					{
+						Coord3D offs = {0,0,0};
+						target->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, LogicRandomValueClass() );
+					}
+#endif
+
 					ParticleSystem *sys = TheParticleSystemManager->createParticleSystem(tmp);
 					if (sys)
 					{
 						Coord3D offs = {0,0,0};
-						target->getGeometryInfo().makeRandomOffsetWithinFootprint( offs );
+						target->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, ClientRandomValueClass() );
 
 						sys->attachToObject(target);
 						sys->setPosition( &offs );

--- a/GeneralsMD/Code/GameEngine/Include/Common/Geometry.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Geometry.h
@@ -31,6 +31,7 @@
 
 #include "Lib/BaseType.h"
 #include "Common/AsciiString.h"
+#include "Common/RandomValue.h"
 #include "Common/Snapshot.h"
 
 class INI;
@@ -171,9 +172,8 @@ public:
 	/// get the 2d bounding box
 	void get2DBounds(const Coord3D& geomCenter, Real angle, Region2D& bounds	) const;
 
-	/// note that the pt is generated using game logic random, not game client random!
-	void makeRandomOffsetWithinFootprint(Coord3D& pt) const;
-	void makeRandomOffsetOnPerimeter(Coord3D& pt) const; //Chooses a random point on the extent border.
+	void makeRandomOffsetWithinFootprint(Coord3D& pt, const RandomValueClass& random = LogicRandomValueClass()) const;
+	void makeRandomOffsetOnPerimeter(Coord3D& pt) const; ///< Chooses a random point on the extent border. Uses game logic random!
 
 	void clipPointToFootprint(const Coord3D& geomCenter, Coord3D& ptToClip) const;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
@@ -98,8 +98,6 @@ public:
 
 	void step(); ///< Do one fixed time step
 
-	void updateHeadless();
-
 	void addDrawableToLookupTable( Drawable *draw );			///< add drawable ID to hash lookup table
 	void removeDrawableFromLookupTable( Drawable *draw );	///< remove drawable ID from hash lookup table
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Geometry.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Geometry.cpp
@@ -376,7 +376,7 @@ Bool GeometryInfo::isPointInFootprint(const Coord3D& geomCenter, const Coord3D& 
 }
 
 //=============================================================================
-void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt) const
+void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt, const RandomValueClass& random) const
 {
 	switch(m_type)
 	{
@@ -390,14 +390,14 @@ void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt) const
 			Real distSqr;
 			do
 			{
-				pt.x = GameLogicRandomValueReal(-m_majorRadius, m_majorRadius);
-				pt.y = GameLogicRandomValueReal(-m_majorRadius, m_majorRadius);
+				pt.x = RandomValueReal(random, -m_majorRadius, m_majorRadius);
+				pt.y = RandomValueReal(random, -m_majorRadius, m_majorRadius);
 				pt.z = 0.0f;
 				distSqr = sqr(pt.x) + sqr(pt.y);
 			} while (distSqr > maxDistSqr);
 #else
-			Real radius = GameLogicRandomValueReal(0.0f, m_boundingCircleRadius);
-			Real angle = GameLogicRandomValueReal(-PI, PI);
+			Real radius = RandomValueReal(random, 0.0f, m_boundingCircleRadius);
+			Real angle = RandomValueReal(random, -PI, PI);
 			pt.x = radius * Cos(angle);
 			pt.y = radius * Sin(angle);
 			pt.z = 0.0f;
@@ -407,8 +407,8 @@ void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt) const
 
 		case GEOMETRY_BOX:
 		{
-			pt.x = GameLogicRandomValueReal(-m_majorRadius, m_majorRadius);
-			pt.y = GameLogicRandomValueReal(-m_minorRadius, m_minorRadius);
+			pt.x = RandomValueReal(random, -m_majorRadius, m_majorRadius);
+			pt.y = RandomValueReal(random, -m_minorRadius, m_minorRadius);
 			pt.z = 0.0f;
 			break;
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -797,15 +797,6 @@ void GameClient::step()
 	TheDisplay->step();
 }
 
-void GameClient::updateHeadless()
-{
-	// TheSuperHackers @info helmutbuhler 03/05/2025 bobtista 02/02/2026
-	// Update particles to prevent accumulation in headless mode. Particles are generated
-	// during GameLogic and only cleaned up during rendering. update() lets particles finish
-	// their lifecycle naturally instead of abruptly removing them with reset().
-	TheParticleSystemManager->update();
-}
-
 Bool GameClient::isMovieAbortRequested()
 {
 	if (TheGameEngine)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -787,15 +787,6 @@ void GameClient::step()
 	TheDisplay->step();
 }
 
-void GameClient::updateHeadless()
-{
-	// TheSuperHackers @info helmutbuhler 03/05/2025 bobtista 02/02/2026
-	// Update particles to prevent accumulation in headless mode. Particles are generated
-	// during GameLogic and only cleaned up during rendering. update() lets particles finish
-	// their lifecycle naturally instead of abruptly removing them with reset().
-	TheParticleSystemManager->update();
-}
-
 Bool GameClient::isMovieAbortRequested()
 {
 	if (TheGameEngine)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
@@ -253,7 +253,7 @@ void TransitionDamageFX::onDelete()
 /** Given an FXLoc info struct, return the effect position that we are supposed to use.
 	* The position is local to to the object */
 //-------------------------------------------------------------------------------------------------
-static Coord3D getLocalEffectPos( const FXLocInfo *locInfo, Drawable *draw )
+static Coord3D getLocalEffectPos( const FXLocInfo *locInfo, Drawable *draw, const RandomValueClass &random = LogicRandomValueClass() )
 {
 
 	DEBUG_ASSERTCRASH( locInfo, ("getLocalEffectPos: locInfo is null") );
@@ -290,7 +290,7 @@ static Coord3D getLocalEffectPos( const FXLocInfo *locInfo, Drawable *draw )
 				return locInfo->loc;
 
 			// pick one of the bone positions
-			Int pick = GameLogicRandomValue( 0, boneCount - 1 );
+			Int pick = RandomValueInt( random, 0, boneCount - 1 );
 			return positions[ pick ];
 
 		}
@@ -387,6 +387,11 @@ void TransitionDamageFX::onBodyDamageStateChange( const DamageInfo* damageInfo,
 				if( lastDamageInfo == nullptr ||
 						getDamageTypeFlag( modData->m_damageParticleTypes, lastDamageInfo->in.m_damageType ) )
 				{
+#if RETAIL_COMPATIBLE_CRC
+					// TheSuperHackers @fix The particle system is now decoupled from the logic crc
+					// and the side effects on the logic random seed values are preserved for retail compatibility.
+					getLocalEffectPos( &modData->m_particleSystem[ newState ][ i ].locInfo, draw, LogicRandomValueClass() );
+#endif
 
 					// create a new particle system based on the template provided
 					ParticleSystem* pSystem = TheParticleSystemManager->createParticleSystem( pSystemT );
@@ -394,7 +399,7 @@ void TransitionDamageFX::onBodyDamageStateChange( const DamageInfo* damageInfo,
 					{
 
 						// get the what is the position we're going to played the effect at
-						pos = getLocalEffectPos( &modData->m_particleSystem[ newState ][ i ].locInfo, draw );
+						pos = getLocalEffectPos( &modData->m_particleSystem[ newState ][ i ].locInfo, draw, ClientRandomValueClass() );
 
 						//
 						// set position on system given any bone position provided, the bone position is

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
@@ -304,14 +304,24 @@ void EMPUpdate::doDisableAttack()
 
 					for (UnsignedInt e = 0 ; e < emitterCount; ++e)
 					{
+#if RETAIL_COMPATIBLE_CRC
+						// TheSuperHackers @fix The particle system is now decoupled from the logic crc
+						// and the side effects on the logic random seed values are preserved for retail compatibility.
+						{
+							Coord3D offs = {0,0,0};
+							curVictim->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, LogicRandomValueClass() );
+							GameLogicRandomValue(3, victimHeight);
+							GameLogicRandomValue(1, 100);
+						}
+#endif
 
 						ParticleSystem *sys = TheParticleSystemManager->createParticleSystem(tmp);
 
 						if (sys)
 						{
 							Coord3D offs = {0,0,0};
-							curVictim->getGeometryInfo().makeRandomOffsetWithinFootprint( offs );
-							offs.z = GameLogicRandomValue(3, victimHeight);
+							curVictim->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, ClientRandomValueClass() );
+							offs.z = GameClientRandomValue(3, victimHeight);
 
 							//This puts all the sparks within a quadrahemicycloid (rectangular dome) volume
 							//The same shape as a four cornered camping dome tent, for those with less Greek
@@ -328,7 +338,7 @@ void EMPUpdate::doDisableAttack()
 							sys->attachToObject(curVictim);
 							sys->setPosition( &offs );
 							sys->setSystemLifetime(MAX(0, data->m_disabledDuration - 30));
-							sys->setInitialDelay(GameLogicRandomValue(1,100));
+							sys->setInitialDelay(GameClientRandomValue(1,100));
 						}
 					}
 				}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -1400,11 +1400,20 @@ void SpecialAbilityUpdate::triggerAbilityEffect()
         const ParticleSystemTemplate *tmp = data->m_disableFXParticleSystem;
         if (tmp)
         {
+#if RETAIL_COMPATIBLE_CRC
+          // TheSuperHackers @fix The particle system is now decoupled from the logic crc
+          // and the side effects on the logic random seed values are preserved for retail compatibility.
+          {
+            Coord3D offs = {0,0,0};
+            target->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, LogicRandomValueClass() );
+          }
+#endif
+
           ParticleSystem *sys = TheParticleSystemManager->createParticleSystem(tmp);
           if (sys)
           {
             Coord3D offs = {0,0,0};
-            target->getGeometryInfo().makeRandomOffsetWithinFootprint( offs );
+            target->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, ClientRandomValueClass() );
 
             sys->attachToObject(target);
             sys->setPosition( &offs );

--- a/docs/WORKDIR/planning/PLAN-2026-05-28_THESUPERHACKERS_SYNC.md
+++ b/docs/WORKDIR/planning/PLAN-2026-05-28_THESUPERHACKERS_SYNC.md
@@ -1,0 +1,159 @@
+# Plan: TheSuperHackers Upstream Sync (2026-05-28)
+
+## Context
+
+Branch: thesuperhackers-sync-05-28-2026
+
+Merge command executed:
+- git merge thesuperhackers/main
+
+Current merge state:
+- One unresolved conflict remains in Core/GameEngine/Include/GameClient/ParticleSys.h.
+- Additional non-conflict merge changes touched multiple files in Core, Generals, and GeneralsMD and still require semantic review.
+
+Why this merge is high risk:
+- Upstream keeps refining replay determinism and subsystem behavior.
+- GeneralsX must preserve SDL3 + DXVK + OpenAL + FFmpeg cross-platform architecture and avoid regressions in launch/render/audio startup paths.
+
+## Most Important Conflicts And How They Will Be Resolved
+
+### 1) Particle system dummy behavior
+
+File:
+- Core/GameEngine/Include/GameClient/ParticleSys.h
+
+Observed conflict:
+- Local side adds a headless safety update override to prevent full particle update path execution.
+- Upstream side adds CRC-aware behavior split:
+  - In RETAIL_COMPATIBLE_CRC mode, keep default init behavior to preserve particle-template-driven logic CRC.
+  - In non-retail mode, skip init/reset and keep dummy no-op behavior.
+
+Resolution strategy:
+- Keep both intents by composing behavior:
+  - Preserve upstream RETAIL_COMPATIBLE_CRC guard on init/reset.
+  - Preserve GeneralsX headless-safe no-op update behavior.
+  - Keep dummy identity and render no-op methods.
+
+Rationale:
+- Avoid replay determinism regressions from missing particle templates in retail CRC mode.
+- Keep headless runtime stable by ensuring the hot update path remains inert.
+
+Risk level:
+- High for replay compatibility and headless runtime stability.
+
+Mitigation:
+- Resolve with minimal semantic delta and no API shape changes.
+- Validate configure/build on macOS, then Linux sequentially.
+- Validate runtime smoke paths for GeneralsXZH and GeneralsX minimum main-loop entry/exit.
+
+## High-Risk Areas For Post-Merge Semantic Review
+
+These may not have textual conflicts but are operationally risky and will be reviewed after conflict resolution:
+
+1. Build system and presets:
+- CMakeLists.txt, CMakePresets.json, cmake/*, scripts/build/*, scripts/env/*
+
+2. Platform abstraction and render/audio stack:
+- Core/GameEngineDevice/*
+- SDL3/DXVK/OpenAL/FFmpeg integration paths
+
+3. Replay and logic determinism:
+- Core/GameEngine/Source/Common/*
+- INI parsing and file-load-order-sensitive code
+
+4. Unified Core migration impacts:
+- Any upstream move/unify changes between Generals*/ and Core/
+
+5. Runtime launch and integration wiring:
+- entry points, renderer startup, audio wiring, and asset/runtime path handling
+
+## Detailed Resolution Procedure
+
+### Phase A - Conflict Resolution
+
+1. Resolve ParticleSys conflict by combining upstream CRC guard and local headless safety update no-op.
+2. Stage the file and verify no unresolved U status remains.
+3. Verify no merge markers remain in repository.
+
+### Phase B - Semantic Validation Of Merge Result
+
+1. Inspect merged diff in risk areas for silent behavior regressions.
+2. Confirm no cross-platform stack downgrades were introduced.
+3. Confirm no platform-specific leakage into gameplay logic.
+
+### Phase C - Build And Runtime Validation (Sequential)
+
+1. macOS configure/build flow for both products:
+- configure/build GeneralsXZH first
+- configure/build GeneralsX second
+
+2. Linux configure/build flow for both products (after macOS completes).
+
+3. Runtime smoke:
+- GeneralsXZH main loop enters/exits cleanly
+- GeneralsX main loop enters/exits cleanly
+
+### Phase D - Finalization
+
+1. Remove generated artifacts (runtime caches and local build/run byproducts).
+2. Ensure clean merge state and no unresolved markers.
+3. Update dev blog with this sync session summary.
+4. Commit merge result.
+5. Push branch to origin.
+
+## Constraints And Special Considerations
+
+- No blanket keep-ours/keep-theirs strategy.
+- No sacrifice of SDL3 + DXVK + OpenAL + FFmpeg architecture for merge convenience.
+- INI and numeric parsing changes are treated as macOS high risk and require deliberate review.
+- If conflict resolution implies capability removal or downgrade, document explicit justification before acceptance.
+
+## Decision Log (to be updated during execution)
+
+- Decision A - ParticleSys conflict resolved with composed behavior.
+  - File: Core/GameEngine/Include/GameClient/ParticleSys.h
+  - Outcome:
+    - Kept upstream RETAIL_COMPATIBLE_CRC split (do not suppress template loading in retail-compatible mode).
+    - Kept local GeneralsX headless protection (`update()` remains no-op in dummy manager).
+    - Kept new polymorphic identity hook (`isDummy()`), with base false and dummy true.
+  - Why:
+    - Preserves replay/CRC-sensitive behavior while maintaining headless stability in cross-platform runtime paths.
+
+- Decision B - Replay headless update path removal accepted with risk note.
+  - Files:
+    - Core/GameEngine/Source/Common/ReplaySimulation.cpp
+    - Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+    - GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+  - Outcome:
+    - Accepted upstream removal of `GameClient::updateHeadless()` call and method bodies.
+  - Why:
+    - Upstream change is intentionally paired with particle-system dummy semantics to avoid lifecycle side effects.
+    - This avoids dual update semantics in headless replay loops.
+  - Follow-up risk mitigation:
+    - Runtime smoke for both products remains mandatory before finalizing.
+
+- Decision C - Audio request ownership hardening accepted.
+  - Files:
+    - Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+    - Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+  - Outcome:
+    - Accepted upstream API shift from `playAudioEvent(AudioEventRTS*)` to `playAudioEvent(AudioRequest*)`.
+    - Accepted `releasePendingEvent()` transfer points to centralize event ownership.
+  - Why:
+    - Reduces dangling/duplicate ownership risk in play request handling.
+
+- Decision D - Water rendering fixes accepted.
+  - File: Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+  - Outcome:
+    - Accepted river alpha + shroud scaling adjustment.
+    - Accepted shader combine fix for river visuals under shroud.
+  - Why:
+    - Aligns with recent upstream water bugfix intent without touching SDL3/DXVK integration boundaries.
+
+- Validation status:
+  - macOS configure: PASS.
+  - macOS build `z_generals`: PASS (exit code 0, warnings only).
+  - macOS build `g_generals`: PASS (exit code 0, warnings only).
+  - Linux configure/build: IN PROGRESS (Docker configure running).
+  - Runtime smoke: PENDING.
+  - Artifact cleanup, commit, push: PENDING.


### PR DESCRIPTION
## Summary
- Merge `thesuperhackers/main` into `GeneralsX` sync branch.
- Resolve merge conflict in `Core/GameEngine/Include/GameClient/ParticleSys.h` preserving:
  - upstream `RETAIL_COMPATIBLE_CRC` behavior
  - GeneralsX headless-safe no-op particle update behavior
- Keep upstream improvements for replay/audio/water paths while preserving cross-platform architecture.

## Conflict Resolution Highlights
- `ParticleSystemManagerDummy` composed with both upstream and GeneralsX intents.
- Accepted upstream replay headless path simplification.
- Accepted upstream MilesAudio request ownership flow updates.
- Accepted upstream river/water shader/shroud fixes.

## Validation
- macOS configure: ✅
- macOS build `z_generals`: ✅ (warnings only)
- macOS build `g_generals`: ✅ (warnings only)
- Linux configure/build: ⚠️ partially attempted (long-running Docker/vcpkg bootstrap), full run still pending
- Runtime smoke (`GeneralsXZH`/`GeneralsX` main-loop enter/exit): ⚠️ pending

## Follow-up Checklist
- [ ] Complete Linux Docker configure/build for both products
- [ ] Run runtime smoke for `GeneralsXZH` and `GeneralsX`
- [ ] Verify main menu/skirmish/campaign/audio/video/input/mod-loading paths
- [ ] Focused review on replay-headless, MilesAudio ownership, and water rendering deltas
