### PR TITLE
cleanup: remove GX-ISSUE144 diagnostic logging

### DIFF
--- a/Core/GameEngine/Source/GameClient/GlobalLanguage.cpp
+++ b/Core/GameEngine/Source/GameClient/GlobalLanguage.cpp
@@ -151,24 +151,13 @@ GlobalLanguage::~GlobalLanguage()
 void GlobalLanguage::init()
 {
 	// GeneralsX @bugfix GitHubCopilot 27/05/2026 Implement Language.ini fallback chain so stock values fill missing override keys.
-	char log_buffer[512];
 	{
 		AsciiString registryLanguage = GetRegistryLanguage();
 		AsciiString fname;
 		fname.format("Data\\%s\\Language", registryLanguage.str());
 
-		sprintf(log_buffer,
-			"[GX-ISSUE144] GlobalLanguage init registryLanguage=%s primaryIni=%s",
-			registryLanguage.str(),
-			fname.str());
-		fprintf(stderr, "%s\n", log_buffer);
-
 		INI ini;
 		ini.loadFileDirectory( fname, INI_LOAD_OVERWRITE, nullptr );
-		sprintf(log_buffer,
-			"[GX-ISSUE144] GlobalLanguage init loaded primary unicodeFont=%s",
-			m_unicodeFontName.isNotEmpty() ? m_unicodeFontName.str() : "<empty>");
-		fprintf(stderr, "%s\n", log_buffer);
 
 		// GeneralsX @bugfix fbraz 04/06/2026 Only fall back to stock English if the primary language
 		// did not set UnicodeFontName. This protects two scenarios:
@@ -185,31 +174,9 @@ void GlobalLanguage::init()
 			stockFnameWithExt.concat(".ini");
 			if (TheFileSystem->doesFileExist(stockFnameWithExt.str()))
 			{
-				sprintf(log_buffer,
-					"[GX-ISSUE144] GlobalLanguage init loading stock fallback=%s",
-					stockFname.str());
-				fprintf(stderr, "%s\n", log_buffer);
 				ini.loadFileDirectory( stockFname, INI_LOAD_MULTIFILE, nullptr );
-				sprintf(log_buffer,
-					"[GX-ISSUE144] GlobalLanguage init fallback merged unicodeFont=%s (may have been filled)",
-					m_unicodeFontName.isNotEmpty() ? m_unicodeFontName.str() : "<empty>");
-				fprintf(stderr, "%s\n", log_buffer);
-			}
-			else
-			{
-				sprintf(log_buffer,
-					"[GX-ISSUE144] GlobalLanguage init stock fallback skipped, file not present: %s",
-					stockFnameWithExt.str());
-				fprintf(stderr, "%s\n", log_buffer);
 			}
 		}
-
-		sprintf(log_buffer,
-			"[GX-ISSUE144] GlobalLanguage init final unicodeFont=%s drawableCaption=%s defaultWindow=%s",
-			m_unicodeFontName.isNotEmpty() ? m_unicodeFontName.str() : "<empty>",
-			m_drawableCaptionFont.name.isNotEmpty() ? m_drawableCaptionFont.name.str() : "<empty>",
-			m_defaultWindowFont.name.isNotEmpty() ? m_defaultWindowFont.name.str() : "<empty>");
-		fprintf(stderr, "%s\n", log_buffer);
 	}
 
 	StringList::iterator it = m_localFonts.begin();
@@ -218,15 +185,7 @@ void GlobalLanguage::init()
 		AsciiString font = *it;
 		if(AddFontResource(font.str()) == 0)
 		{
-			sprintf(log_buffer, "[GX-ISSUE144] GlobalLanguage local font add FAILED file=%s", font.str());
-			fprintf(stderr, "%s\n", log_buffer);
 			DEBUG_CRASH(("GlobalLanguage::init Failed to add font %s", font.str()));
-		}
-		else
-		{
-			sprintf(log_buffer, "[GX-ISSUE144] GlobalLanguage local font add OK file=%s", font.str());
-			fprintf(stderr, "%s\n", log_buffer);
-			//SendMessage( HWND_BROADCAST, WM_FONTCHANGE, 0, 0);
 		}
 		++it;
 	}
@@ -234,12 +193,6 @@ void GlobalLanguage::init()
 	// override values with user preferences
 	OptionPreferences optionPref;
 	m_userResolutionFontSizeAdjustment = optionPref.getResolutionFontAdjustment();
-	sprintf(log_buffer,
-		"[GX-ISSUE144] GlobalLanguage resolutionAdjustment effective=%.3f user=%.3f base=%.3f",
-		getResolutionFontSizeAdjustment(),
-		m_userResolutionFontSizeAdjustment,
-		m_resolutionFontSizeAdjustment);
-	fprintf(stderr, "%s\n", log_buffer);
 }
 
 void GlobalLanguage::reset()

--- a/Core/Libraries/Source/WWVegas/WW3D2/render2dsentence.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/render2dsentence.cpp
@@ -1227,16 +1227,6 @@ FontCharsClass::Get_Char_Data (WCHAR ch)
 	}
  	else if ( AlternateUnicodeFont && this != AlternateUnicodeFont )
 	{
-		// GeneralsX @bugfix fbraz 03/06/2026 Log ALL Cyrillic delegations for diagnostics
-		if (ch >= 0x0400 && ch <= 0x04FF) {
-			char log_buffer[512];
-			sprintf(log_buffer,
-				"[GX-ISSUE144] Get_Char_Data delegate U+%04X from=%s to=%s",
-				(unsigned int)ch,
-				GDIFontName.str(),
-				AlternateUnicodeFont->GDIFontName.str());
-			fprintf(stderr, "%s\n", log_buffer);
-		}
 		return AlternateUnicodeFont->Get_Char_Data( glyph );
 	}
 	else
@@ -1788,19 +1778,6 @@ FontCharsClass::Create_Freetype_Font (const char *font_name)
 		return false;
 	}
 
-	// GeneralsX @bugfix fbraz 03/06/2026 Log FreeType font details for Cyrillic font issue
-	{
-		char log_buffer[512];
-		sprintf(log_buffer,
-			"[GX-ISSUE144] Freetype path=%s name=%s family=%s num_glyphs=%ld has_Cyrillic_Caps=%s",
-			font_path,
-			font_name,
-			FTFace->family_name ? FTFace->family_name : "<null>",
-			FTFace->num_glyphs,
-			FT_Get_Char_Index(FTFace, 0x0410) != 0 ? "YES" : "NO");
-		fprintf(stderr, "%s\n", log_buffer);
-	}
-
 	if ( doingGenerals ) {
 		CharOverhang = 0;
 	}
@@ -1829,17 +1806,6 @@ FontCharsClass::Store_Freetype_Char (WCHAR ch)
 	//	Get the glyph index for the character
 	//
 	FT_UInt glyph_index = FT_Get_Char_Index( FTFace, ch );
-
-	// GeneralsX @bugfix fbraz 03/06/2026 Log ALL Cyrillic character rendering attempts
-	if (ch >= 0x0400 && ch <= 0x04FF) {
-		char log_buffer[512];
-		sprintf(log_buffer,
-			"[GX-ISSUE144] Store_Freetype_Char U+%04X glyph_idx=%u font=%s",
-			(unsigned int)ch,
-			(unsigned int)glyph_index,
-			GDIFontName.str());
-		fprintf(stderr, "%s\n", log_buffer);
-	}
 
 	//
 	//	Load the glyph (without rendering yet)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -113,16 +113,12 @@ static_assert(ARRAY_SIZE(TheDrawableIconNames) == MAX_ICONS + 1, "Incorrect arra
 // GeneralsX @bugfix GitHubCopilot 24/05/2026 Resolve Drawable caption fonts through a deterministic fallback chain when localized font names are unavailable.
 // GeneralsX @bugfix FelipeBraz 03/06/2026 Preferred known Unicode-supporting fonts (Arial Unicode MS) over configured DrawableCaptionFont
 // to ensure Cyrillic and other non-Latin characters render correctly via DXVK on macOS.
-// GeneralsX @test FelipeBraz 03/06/2026 TEST: Hardcode Arial Unicode MS to verify 3D rendering
 static GameFont *ResolveDrawableCaptionFont()
 {
-	char log_buffer[512];
 	GameFont *font = nullptr;
 
 	if (TheFontLibrary == nullptr || TheInGameUI == nullptr)
 	{
-		sprintf(log_buffer, "[GX-ISSUE144] Drawable ResolveCaptionFont missing TheFontLibrary=%p TheInGameUI=%p", TheFontLibrary, TheInGameUI);
-		fprintf(stderr, "%s\n", log_buffer);
 		return nullptr;
 	}
 
@@ -130,16 +126,10 @@ static GameFont *ResolveDrawableCaptionFont()
 	const Int pointSize = TheGlobalLanguageData ? TheGlobalLanguageData->adjustFontSize(basePointSize) : basePointSize;
 	const Bool bold = TheInGameUI->isDrawableCaptionBold();
 
-	// TEST: hardcode Arial Unicode MS
 	font = TheFontLibrary->getFont("Arial Unicode MS", pointSize, bold);
-	sprintf(log_buffer, "[GX-ISSUE144] TEST ResolveCaptionFont Arial Unicode MS %s pointSize=%d bold=%d",
-		font ? "HIT" : "MISS", pointSize, bold);
-	fprintf(stderr, "%s\n", log_buffer);
 	if (font) return font;
 
 	font = TheFontLibrary->getFont("Arial", pointSize, bold);
-	sprintf(log_buffer, "[GX-ISSUE144] TEST ResolveCaptionFont Arial %s pointSize=%d bold=%d",
-		font ? "HIT" : "MISS", pointSize, bold);
 	return font;
 }
 
@@ -398,13 +388,6 @@ Drawable::Drawable( const ThingTemplate *thingTemplate, DrawableStatusBits statu
 	{
 		GameFont *ctorFont = ResolveDrawableCaptionFont();
 		m_constructDisplayString->setFont(ctorFont);
-		{
-			char _lb[256];
-			sprintf(_lb, "[GX-ISSUE144] Drawable ctor constructDS font=%s size=%d",
-				ctorFont ? ctorFont->nameString.str() : "NULL",
-				ctorFont ? ctorFont->pointSize : -1);
-			fprintf(stderr, "%s\n", _lb);
-		}
 	}
 
 	m_ambientSound = nullptr;
@@ -3668,8 +3651,6 @@ void Drawable::drawDisabled(const IRegion2D* healthBarRegion)
 //-------------------------------------------------------------------------------------------------
 void Drawable::drawConstructPercent( const IRegion2D *healthBarRegion )
 {
-	char log_buffer[512];
-
 	// this data is in an attached object
 	Object *obj = getObject();
 
@@ -3699,11 +3680,6 @@ void Drawable::drawConstructPercent( const IRegion2D *healthBarRegion )
 		if (m_constructDisplayString)
 		{
 			m_constructDisplayString->setFont(ResolveDrawableCaptionFont());
-			sprintf(log_buffer,
-				"[GX-ISSUE144] Drawable construct string allocated drawable=%p obj=%p",
-				this,
-				obj);
-			fprintf(stderr, "%s\n", log_buffer);
 		}
 	}
 
@@ -3712,43 +3688,11 @@ void Drawable::drawConstructPercent( const IRegion2D *healthBarRegion )
 	{
 		UnicodeString buffer;
 
-		// Log the raw format string from GameText before formatting
-		{
-			static bool _fetchLogged = false;
-			if (!_fetchLogged) {
-				_fetchLogged = true;
-				UnicodeString fetchResult = TheGameText->fetch("CONTROLBAR:UnderConstructionDesc");
-				const WideChar *fws = fetchResult.str();
-				char fnarrow[128] = {};
-				for (int _fi = 0; _fi < 64 && fws[_fi]; ++_fi)
-					fnarrow[_fi] = (fws[_fi] < 128) ? (char)fws[_fi] : '?';
-				sprintf(log_buffer,
-					"[GX-ISSUE144] fetch UnderConstructionDesc len=%d text=\"%s\"",
-					fetchResult.getLength(), fnarrow);
-				fprintf(stderr, "%s\n", log_buffer);
-			}
-		}
-
 		buffer.format( TheGameText->fetch("CONTROLBAR:UnderConstructionDesc"), obj->getConstructionPercent());
 		m_constructDisplayString->setText( buffer );
 
 		// record this percent as our last displayed so we don't un-necessarily rebuild the string
 		m_lastConstructDisplayed = obj->getConstructionPercent();
-
-		// Log actual text content (convert wchar to narrow for logging)
-		const WideChar *ws = buffer.str();
-		char narrow[128] = {};
-		for (int _i = 0; _i < 64 && ws[_i]; ++_i)
-			narrow[_i] = (ws[_i] < 128) ? (char)ws[_i] : '?';
-		GameFont *curFont = m_constructDisplayString->getFont();
-		sprintf(log_buffer,
-			"[GX-ISSUE144] Drawable construct text update drawable=%p pct=%g len=%d text=\"%s\" font=%s",
-			this,
-			(double)obj->getConstructionPercent(),
-			buffer.getLength(),
-			narrow,
-			curFont ? curFont->nameString.str() : "NULL");
-		fprintf(stderr, "%s\n", log_buffer);
 	}
 
 	// get center position in drawable
@@ -3766,16 +3710,6 @@ void Drawable::drawConstructPercent( const IRegion2D *healthBarRegion )
 	Color color = GameMakeColor( 255, 255, 255, 255 );
 	Color dropColor = GameMakeColor( 0, 0, 0, 255 );
 	Int tw = m_constructDisplayString->getWidth();
-	static bool _constructDrawLogged = false;
-	if (!_constructDrawLogged) {
-		GameFont *df = m_constructDisplayString->getFont();
-		sprintf(log_buffer,
-			"[GX-ISSUE144] Drawable construct draw drawable=%p screen=(%d,%d) width=%d font=%s",
-			this, screen.x, screen.y, tw,
-			df ? df->nameString.str() : "NULL");
-		fprintf(stderr, "%s\n", log_buffer);
-		_constructDrawLogged = true;
-	}
 	screen.x -= (tw / 2);
 	m_constructDisplayString->draw( screen.x, screen.y, color, dropColor );
 
@@ -4355,13 +4289,9 @@ const Matrix3D *Drawable::getTransformMatrix() const
 //-------------------------------------------------------------------------------------------------
 void Drawable::setCaptionText( const UnicodeString& captionText )
 {
-	char log_buffer[512];
-
 	if (captionText.isEmpty())
 	{
 		clearCaptionText();
-		sprintf(log_buffer, "[GX-ISSUE144] Drawable caption clear-request drawable=%p", this);
-		fprintf(stderr, "%s\n", log_buffer);
 		return;
 	}
 
@@ -4374,12 +4304,6 @@ void Drawable::setCaptionText( const UnicodeString& captionText )
 		GameFont *font = ResolveDrawableCaptionFont();
 		m_captionDisplayString->setFont( font );
 		m_captionDisplayString->setText( sanitizedString );
-		sprintf(log_buffer,
-			"[GX-ISSUE144] Drawable caption new drawable=%p textLength=%d font=%p",
-			this,
-			sanitizedString.getLength(),
-			font);
-		fprintf(stderr, "%s\n", log_buffer);
 	}
 	else
 	{
@@ -4387,11 +4311,6 @@ void Drawable::setCaptionText( const UnicodeString& captionText )
 		if( m_captionDisplayString->getText().compare(sanitizedString) != 0 )
 		{
 			m_captionDisplayString->setText( sanitizedString );
-			sprintf(log_buffer,
-				"[GX-ISSUE144] Drawable caption update drawable=%p textLength=%d",
-				this,
-				sanitizedString.getLength());
-			fprintf(stderr, "%s\n", log_buffer);
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarUnderConstruction.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarUnderConstruction.cpp
@@ -49,8 +49,6 @@
 //-------------------------------------------------------------------------------------------------
 void ControlBar::updateConstructionTextDisplay( Object *obj )
 {
-	// GeneralsX @tweak GitHubCopilot 27/05/2026 Trace under-construction text key usage and formatted output updates.
-	char log_buffer[512];
 	UnicodeString text;
 	static UnsignedInt descID = TheNameKeyGenerator->nameToKey( "ControlBar.wnd:UnderConstructionDesc" );
 	GameWindow *descWindow = TheWindowManager->winGetWindowFromId( nullptr, descID );
@@ -62,13 +60,6 @@ void ControlBar::updateConstructionTextDisplay( Object *obj )
 	text.format( TheGameText->fetch( "CONTROLBAR:UnderConstructionDesc" ),
 							 obj->getConstructionPercent() );
 	GadgetStaticTextSetText( descWindow, text );
-	sprintf(log_buffer,
-		"[GX-ISSUE144] UnderConstruction text update obj=%p percent=%d textLen=%d descWindow=%p",
-		obj,
-		obj->getConstructionPercent(),
-		text.getLength(),
-		descWindow);
-	fprintf(stderr, "%s\n", log_buffer);
 
 	// record this as the last percentage displayed
 	m_displayedConstructPercent = obj->getConstructionPercent();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarPopupDescription.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarPopupDescription.cpp
@@ -130,22 +130,8 @@ void ControlBarPopupDescriptionUpdateFunc( WindowLayout *layout, void *param )
 
 void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 {
-	// GeneralsX @tweak GitHubCopilot 27/05/2026 Trace command tooltip population and cost-line visibility decisions.
-	char log_buffer[512];
-	sprintf(log_buffer,
-		"[GX-ISSUE144] Tooltip show request cmdWindow=%p prevWindow=%p hidden=%d",
-		cmdButton,
-		prevWindow,
-		m_buildToolTipLayout ? m_buildToolTipLayout->isHidden() : -1);
-	fprintf(stderr, "%s\n", log_buffer);
-
 	if (TheInGameUI->areTooltipsDisabled() 	|| TheScriptEngine->isGameEnding())
 	{
-		sprintf(log_buffer,
-			"[GX-ISSUE144] Tooltip show blocked tooltipsDisabled=%d gameEnding=%d",
-			TheInGameUI->areTooltipsDisabled(),
-			TheScriptEngine->isGameEnding());
-		fprintf(stderr, "%s\n", log_buffer);
 		return;
 	}
 
@@ -196,8 +182,6 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 
 	if(!cmdButton)
 	{
-		sprintf(log_buffer, "[GX-ISSUE144] Tooltip show aborted null cmdButton");
-		fprintf(stderr, "%s\n", log_buffer);
 		return;
 	}
 	if(BitIsSet(cmdButton->winGetStyle(), GWS_PUSH_BUTTON))
@@ -206,8 +190,6 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 
 		if(!commandButton)
 		{
-			sprintf(log_buffer, "[GX-ISSUE144] Tooltip show aborted missing CommandButton window=%p", cmdButton);
-			fprintf(stderr, "%s\n", log_buffer);
 			return;
 		}
 
@@ -231,15 +213,6 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 		//	}
 
 		m_showBuildToolTipLayout = TRUE;
-		//	m_buildToolTipLayout = TheWindowManager->winCreateLayout( "ControlBarPopupDescription.wnd" );
-		//	m_buildToolTipLayout->setUpdate(ControlBarPopupDescriptionUpdateFunc);
-
-		sprintf(log_buffer,
-			"[GX-ISSUE144] Tooltip show command=%s textLabel=%s descriptionLabel=%s",
-			commandButton->getName().str(),
-			commandButton->getTextLabel().str(),
-			commandButton->getDescriptionLabel().str());
-		fprintf(stderr, "%s\n", log_buffer);
 
 		populateBuildTooltipLayout(commandButton);
 	}
@@ -248,8 +221,6 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 		// we're a generic window
 		if(!BitIsSet(cmdButton->winGetStyle(), GWS_USER_WINDOW) && !BitIsSet(cmdButton->winGetStyle(), GWS_STATIC_TEXT))
 			return;
-		sprintf(log_buffer, "[GX-ISSUE144] Tooltip show generic window style=0x%x", cmdButton->winGetStyle());
-		fprintf(stderr, "%s\n", log_buffer);
 		populateBuildTooltipLayout(nullptr, cmdButton);
 	}
 	m_buildToolTipLayout->hide(FALSE);
@@ -267,52 +238,30 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 
 void ControlBar::repopulateBuildTooltipLayout()
 {
-	char log_buffer[512];
 	if(!m_buildToolTipLayout)
 	{
-		sprintf(log_buffer,
-			"[GX-ISSUE144] Tooltip repopulate skipped layout=null");
-		fprintf(stderr, "%s\n", log_buffer);
 		return;
 	}
 	if(!prevWindow)
 	{
-		sprintf(log_buffer,
-			"[GX-ISSUE144] Tooltip repopulate skipped prevWindow=null layout=%p hidden=%d",
-			m_buildToolTipLayout,
-			m_buildToolTipLayout->isHidden());
-		fprintf(stderr, "%s\n", log_buffer);
 		return;
 	}
 	if(m_buildToolTipLayout->isHidden())
 	{
-		sprintf(log_buffer,
-			"[GX-ISSUE144] Tooltip repopulate skipped layout-hidden prevWindow=%p",
-			prevWindow);
-		fprintf(stderr, "%s\n", log_buffer);
 		return;
 	}
 	if(!BitIsSet(prevWindow->winGetStyle(), GWS_PUSH_BUTTON))
 	{
-		sprintf(log_buffer, "[GX-ISSUE144] Tooltip repopulate skipped non-push style=0x%x", prevWindow->winGetStyle());
-		fprintf(stderr, "%s\n", log_buffer);
 		return;
 	}
 	const CommandButton *commandButton = (const CommandButton *)GadgetButtonGetData(prevWindow);
-	sprintf(log_buffer,
-		"[GX-ISSUE144] Tooltip repopulate command=%s",
-		commandButton ? commandButton->getName().str() : "<null>");
-	fprintf(stderr, "%s\n", log_buffer);
 	populateBuildTooltipLayout(commandButton);
 }
 
 void ControlBar::populateBuildTooltipLayout( const CommandButton *commandButton, GameWindow *tooltipWin)
 {
-	char log_buffer[512];
 	if(!m_buildToolTipLayout)
 	{
-		sprintf(log_buffer, "[GX-ISSUE144] Tooltip populate skipped missing layout");
-		fprintf(stderr, "%s\n", log_buffer);
 		return;
 	}
 
@@ -326,14 +275,6 @@ void ControlBar::populateBuildTooltipLayout( const CommandButton *commandButton,
 
 	if(commandButton)
 	{
-		sprintf(log_buffer,
-			"[GX-ISSUE144] Tooltip populate command=%s type=%d textLabel=%s descriptionLabel=%s",
-			commandButton->getName().str(),
-			commandButton->getCommandType(),
-			commandButton->getTextLabel().str(),
-			commandButton->getDescriptionLabel().str());
-		fprintf(stderr, "%s\n", log_buffer);
-
 		const ThingTemplate *thingTemplate = commandButton->getThingTemplate();
 		const UpgradeTemplate *upgradeTemplate = commandButton->getUpgradeTemplate();
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -1381,18 +1381,8 @@ GameWindow *GameWindowManager::winCreate( GameWindow *parent,
 		window->winSetInstanceData( instData );
 
 	// set default font
-	// GeneralsX @tweak GitHubCopilot 27/05/2026 Trace window default font resolution to diagnose localized font propagation.
 	if (TheGlobalLanguageData && TheGlobalLanguageData->m_defaultWindowFont.name.isNotEmpty())
 	{
-		char log_buffer[512];
-		sprintf(log_buffer,
-			"[GX-ISSUE144] WinCreate default font localized name=%s size=%d bold=%d window=%p",
-			TheGlobalLanguageData->m_defaultWindowFont.name.str(),
-			TheGlobalLanguageData->m_defaultWindowFont.size,
-			TheGlobalLanguageData->m_defaultWindowFont.bold,
-			window);
-		fprintf(stderr, "%s\n", log_buffer);
-
 		window->winSetFont( winFindFont(
 			TheGlobalLanguageData->m_defaultWindowFont.name,
 			TheGlobalLanguageData->m_defaultWindowFont.size,
@@ -1400,9 +1390,6 @@ GameWindow *GameWindowManager::winCreate( GameWindow *parent,
 	}
 	else
 	{
-		char log_buffer[512];
-		sprintf(log_buffer, "[GX-ISSUE144] WinCreate default font fallback Times New Roman size=14 bold=0 window=%p", window);
-		fprintf(stderr, "%s\n", log_buffer);
 		window->winSetFont( winFindFont( "Times New Roman", 14, FALSE ) );
 	}
 
@@ -2867,15 +2854,6 @@ void GameWindowManager::assignDefaultGadgetLook( GameWindow *gadget,
 	{
 		if (TheGlobalLanguageData && TheGlobalLanguageData->m_defaultWindowFont.name.isNotEmpty())
 		{
-			char log_buffer[512];
-			sprintf(log_buffer,
-				"[GX-ISSUE144] assignDefaultGadgetLook localized font name=%s size=%d bold=%d gadget=%p",
-				TheGlobalLanguageData->m_defaultWindowFont.name.str(),
-				TheGlobalLanguageData->m_defaultWindowFont.size,
-				TheGlobalLanguageData->m_defaultWindowFont.bold,
-				gadget);
-			fprintf(stderr, "%s\n", log_buffer);
-
 			gadget->winSetFont( winFindFont(
 				TheGlobalLanguageData->m_defaultWindowFont.name,
 				TheGlobalLanguageData->m_defaultWindowFont.size,
@@ -2883,9 +2861,6 @@ void GameWindowManager::assignDefaultGadgetLook( GameWindow *gadget,
 		}
 		else
 		{
-			char log_buffer[512];
-			sprintf(log_buffer, "[GX-ISSUE144] assignDefaultGadgetLook fallback font Times New Roman size=14 bold=0 gadget=%p", gadget);
-			fprintf(stderr, "%s\n", log_buffer);
 			gadget->winSetFont( winFindFont( "Times New Roman", 14, FALSE ) );
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1309,13 +1309,8 @@ InGameUI::~InGameUI()
 //-------------------------------------------------------------------------------------------------
 void InGameUI::init()
 {
-	// GeneralsX @tweak GitHubCopilot 27/05/2026 Trace final in-game UI font slots after language overrides.
-	char log_buffer[512];
-
 	INI ini;
 	ini.loadFileDirectory( "Data\\INI\\InGameUI", INI_LOAD_OVERWRITE, nullptr );
-	sprintf(log_buffer, "[GX-ISSUE144] InGameUI init loaded Data\\INI\\InGameUI");
-	fprintf(stderr, "%s\\n", log_buffer);
 
 	//override INI values with language localized values:
 	if (TheGlobalLanguageData)
@@ -1375,22 +1370,6 @@ void InGameUI::init()
 			m_namedTimerReadyPointSize = TheGlobalLanguageData->m_namedTimerCountdownReadyFont.size;
 			m_namedTimerReadyBold = TheGlobalLanguageData->m_namedTimerCountdownReadyFont.bold;
 		}
-
-		sprintf(log_buffer,
-			"[GX-ISSUE144] InGameUI font override drawableCaption=%s size=%d bold=%d defaultWindow=%s size=%d bold=%d unicode=%s",
-			m_drawableCaptionFont.str(),
-			m_drawableCaptionPointSize,
-			m_drawableCaptionBold,
-			TheGlobalLanguageData->m_defaultWindowFont.name.str(),
-			TheGlobalLanguageData->m_defaultWindowFont.size,
-			TheGlobalLanguageData->m_defaultWindowFont.bold,
-			TheGlobalLanguageData->m_unicodeFontName.isNotEmpty() ? TheGlobalLanguageData->m_unicodeFontName.str() : "<empty>");
-		fprintf(stderr, "%s\\n", log_buffer);
-	}
-	else
-	{
-		sprintf(log_buffer, "[GX-ISSUE144] InGameUI init without TheGlobalLanguageData");
-		fprintf(stderr, "%s\\n", log_buffer);
 	}
 
 	/**@ todo we used to put in the hint spy translator, but it's difficult

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/W3DGameFont.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/W3DGameFont.cpp
@@ -59,24 +59,14 @@
 namespace
 {
 // GeneralsX @bugfix GitHubCopilot 20/05/2026 Resolve a usable Unicode fallback font on macOS/Linux when localized font names are unavailable.
-// GeneralsX @tweak GitHubCopilot 27/05/2026 Add explicit stderr tracing for Unicode fallback font lookup decisions.
 // GeneralsX @bugfix GitHubCopilot 29/05/2026 Prevent circular Unicode fallback when the localized unicode family equals the base font family.
 FontCharsClass *LoadUnicodeFallbackFont(Int size, Bool bold, const char *base_name)
 {
 	const char *preferred_name = nullptr;
-	char log_buffer[512];
 
 	if (TheGlobalLanguageData && TheGlobalLanguageData->m_unicodeFontName.isNotEmpty()) {
 		preferred_name = TheGlobalLanguageData->m_unicodeFontName.str();
 	}
-
-	sprintf(log_buffer,
-		"[GX-ISSUE144] W3DFont fallback start size=%d bold=%d preferred=%s base=%s",
-		size,
-		bold,
-		preferred_name ? preferred_name : "<none>",
-		base_name ? base_name : "<none>");
-	fprintf(stderr, "%s\n", log_buffer);
 
 	// Build candidate list: the localized preferred name first (may be a limited-coverage font like "Arial"),
 	// then known-good Unicode fonts. We iterate all candidates and pick the first that loads AND has a
@@ -102,37 +92,17 @@ FontCharsClass *LoadUnicodeFallbackFont(Int size, Bool bold, const char *base_na
 
 		FontCharsClass *font = WW3DAssetManager::Get_Instance()->Get_FontChars(font_name, size, bold);
 		if (font != nullptr) {
-			sprintf(log_buffer, "[GX-ISSUE144] W3DFont fallback hit list=%s", font_name);
-			fprintf(stderr, "%s\n", log_buffer);
 			return font;
 		}
-
-		sprintf(log_buffer, "[GX-ISSUE144] W3DFont fallback miss list=%s", font_name);
-		fprintf(stderr, "%s\n", log_buffer);
 	}
 
 	// Now try the localized preferred name as a last resort (it may load on some platforms)
 	if (preferred_name != nullptr && (base_name == nullptr || strcmp(preferred_name, base_name) != 0)) {
 		FontCharsClass *font = WW3DAssetManager::Get_Instance()->Get_FontChars(preferred_name, size, bold);
 		if (font != nullptr) {
-			sprintf(log_buffer, "[GX-ISSUE144] W3DFont fallback hit preferred=%s", preferred_name);
-			fprintf(stderr, "%s\n", log_buffer);
 			return font;
 		}
-
-		sprintf(log_buffer, "[GX-ISSUE144] W3DFont fallback miss preferred=%s", preferred_name);
-		fprintf(stderr, "%s\n", log_buffer);
 	}
-	else if (preferred_name != nullptr) {
-		sprintf(log_buffer, "[GX-ISSUE144] W3DFont fallback skip preferred=%s reason=same-as-base", preferred_name);
-		fprintf(stderr, "%s\n", log_buffer);
-	}
-
-	sprintf(log_buffer,
-		"[GX-ISSUE144] W3DFont fallback exhausted size=%d bold=%d",
-		size,
-		bold);
-	fprintf(stderr, "%s\n", log_buffer);
 
 	return nullptr;
 }
@@ -157,8 +127,6 @@ FontCharsClass *LoadUnicodeFallbackFont(Int size, Bool bold, const char *base_na
 //=============================================================================
 Bool W3DFontLibrary::loadFontData( GameFont *font )
 {
-	char log_buffer[512];
-
 	// sanity
 	if( font == nullptr )
 		return FALSE;
@@ -166,22 +134,15 @@ Bool W3DFontLibrary::loadFontData( GameFont *font )
 	const char* name = font->nameString.str();
 	const Int size = font->pointSize;
 	const Bool bold = font->bold;
-	sprintf(log_buffer, "[GX-ISSUE144] W3DFont load request name=%s size=%d bold=%d", name ? name : "<null>", size, bold);
-	fprintf(stderr, "%s\n", log_buffer);
 
 	// get the font data from the asset manager
 	FontCharsClass *fontChar = WW3DAssetManager::Get_Instance()->Get_FontChars( name, size, bold );
 
 	if( fontChar == nullptr )
 	{
-		sprintf(log_buffer, "[GX-ISSUE144] W3DFont load miss name=%s size=%d bold=%d", name ? name : "<null>", size, bold);
-		fprintf(stderr, "%s\n", log_buffer);
 		DEBUG_CRASH(( "Unable to find font '%s' in Asset Manager", name ));
 		return FALSE;
 	}
-
-	sprintf(log_buffer, "[GX-ISSUE144] W3DFont load hit name=%s size=%d bold=%d", name ? name : "<null>", size, bold);
-	fprintf(stderr, "%s\n", log_buffer);
 
 	// assign font data
 	font->fontData = fontChar;
@@ -211,11 +172,6 @@ Bool W3DFontLibrary::loadFontData( GameFont *font )
 			fontChar->AlternateUnicodeFont = LoadUnicodeFallbackFont(size, bold, name);
 		}
 	}
-	sprintf(log_buffer,
-		"[GX-ISSUE144] W3DFont alternate unicode %s for base=%s",
-		fontChar->AlternateUnicodeFont ? "assigned" : "missing",
-		name ? name : "<null>");
-	fprintf(stderr, "%s\n", log_buffer);
 
 	return TRUE;
 }


### PR DESCRIPTION
## Description
Remove all `[GX-ISSUE144]` diagnostic stderr logging that was added during issue #144 investigation. The instrumentation served its purpose but pollutes the log in production builds.

## Changes
- **55 log statements removed** across 8 files (320 lines deleted)
- Empty `if`/`else` blocks left by log removal were also cleaned up
- Unused `log_buffer` variables and single-use debug flags (`_fetchLogged`, `_constructDrawLogged`) removed
- No functional logic changed — only diagnostic output removed

### Files
| File | Functions cleaned |
|---|---|
| `W3DGameFont.cpp` | `LoadUnicodeFallbackFont`, `loadFontData` |
| `InGameUI.cpp` | `init` |
| `GameWindowManager.cpp` | `winCreate`, `assignDefaultGadgetLook` |
| `ControlBarPopupDescription.cpp` | `showBuildTooltipLayout`, `repopulateBuildTooltipLayout`, `populateBuildTooltipLayout` |
| `ControlBarUnderConstruction.cpp` | `updateConstructionTextDisplay` |
| `Drawable.cpp` | `ResolveDrawableCaptionFont`, ctor, `drawConstructPercent`, `setCaptionText` |
| `render2dsentence.cpp` | `Get_Char_Data`, `Init_FreeType`, `Store_Freetype_Char` |
| `GlobalLanguage.cpp` | `init` |

## Verification
- [x] `grep GX-ISSUE144` returns 0 hits in source code (1 in DEV_BLOG docs only)
- [x] Build GeneralsXZH (macos-vulkan) — 1460/1460 OK
- [x] Build GeneralsX (macos-vulkan) — 785/785 OK
