### PR TITLE
bugfix(macos): Invert the SDL3 mouse wheel reported as SDL_MOUSEWHEEL_FLIPPED

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -758,7 +758,13 @@ void SDL3Mouse::translateWheelEvent(const SDL_MouseWheelEvent& event, MouseIO *r
 
 	// SDL3 wheel: positive = up/away, negative = down/toward user
 	// Multiply by MOUSE_WHEEL_DELTA (120) to match Windows behavior
-	result->wheelPos = (Int)(event.y * MOUSE_WHEEL_DELTA);
+	// GeneralsX @bugfix msmesoft 17/06/2026 macOS "natural scrolling" makes SDL
+	// flag the wheel values as SDL_MOUSEWHEEL_FLIPPED; invert them so the in-game
+	// scroll direction matches the Windows convention regardless of the OS setting.
+	float wheelY = event.y;
+	if (event.direction == SDL_MOUSEWHEEL_FLIPPED)
+		wheelY = -wheelY;
+	result->wheelPos = (Int)(wheelY * MOUSE_WHEEL_DELTA);
 
 	result->leftState = MBS_None;
 	result->rightState = MBS_None;

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -757,7 +757,13 @@ void SDL3Mouse::translateWheelEvent(const SDL_MouseWheelEvent& event, MouseIO *r
 
 	// SDL3 wheel: positive = up/away, negative = down/toward user
 	// Multiply by MOUSE_WHEEL_DELTA (120) to match Windows behavior
-	result->wheelPos = (Int)(event.y * MOUSE_WHEEL_DELTA);
+	// GeneralsX @bugfix msmesoft 17/06/2026 macOS "natural scrolling" makes SDL
+	// flag the wheel values as SDL_MOUSEWHEEL_FLIPPED; invert them so the in-game
+	// scroll direction matches the Windows convention regardless of the OS setting.
+	float wheelY = event.y;
+	if (event.direction == SDL_MOUSEWHEEL_FLIPPED)
+		wheelY = -wheelY;
+	result->wheelPos = (Int)(wheelY * MOUSE_WHEEL_DELTA);
 
 	result->leftState = MBS_None;
 	result->rightState = MBS_None;


### PR DESCRIPTION
**Problem:** macOS natural scrolling flags wheel events as `SDL_MOUSEWHEEL_FLIPPED`, so the in-game zoom/scroll runs backwards regardless of the OS setting.

**Fix:** Invert the wheel delta when the `SDL_MOUSEWHEEL_FLIPPED` flag is set, in `SDL3Mouse::translateWheelEvent`, so the direction matches the Windows convention. Applied to both Zero Hour (GeneralsMD) and the base Generals SDL3 mouse backend, which share identical code (one commit each).

**Testing:** In a Zero Hour battle on Apple Silicon (M4 Pro), mouse wheel up zooms in and wheel down zooms out — matching the Windows behavior, with macOS natural scrolling enabled. The base Generals change is the identical mirror of the verified Zero Hour fix.

**AI assistance disclosure (per CONTRIBUTING):** Diagnosed and drafted with AI assistance (Claude Opus 4.8); I reviewed and adjusted every line and verified the behavior at runtime on Apple Silicon before submitting.
