### PR TITLE
feat(framepacer): decouple logic from render fps and default to 60 fps

### DIFF
--- a/Core/GameEngine/Include/GameClient/GadgetSlider.h
+++ b/Core/GameEngine/Include/GameClient/GadgetSlider.h
@@ -78,6 +78,16 @@ inline void GadgetSliderGetMinMax( GameWindow *g, Int *min, Int *max )
 	*min = sData->minVal;
 
 }
+
+// GeneralsX @tweak felipebraz 20/06/2026 Add GadgetSliderSetMinMax to allow dynamically setting slider min/max bounds
+inline void GadgetSliderSetMinMax( GameWindow *win, Int min, Int max )
+{
+	TheWindowManager->winSendSystemMsg( win,
+																			GSM_SET_MIN_MAX,
+																			min,
+																			max );
+}
+
 inline GameWindow *GadgetSliderGetThumb( GameWindow *g ) { return g->winGetChild(); }
 
 inline void GadgetSliderSetPosition( GameWindow *win, Int pos )

--- a/Core/GameEngine/Source/Common/FramePacer.cpp
+++ b/Core/GameEngine/Source/Common/FramePacer.cpp
@@ -42,7 +42,8 @@ FramePacer::FramePacer()
 	m_logicTimeScaleFPS = LOGICFRAMES_PER_SECOND;
 	m_updateTime = 1.0f / (Real)BaseFps; // initialized to something to avoid division by zero on first use
 	m_enableFpsLimit = FALSE;
-	m_enableLogicTimeScale = FALSE;
+	// GeneralsX @tweak felipebraz 20/06/2026 Enable logic time scale by default to decouple gameplay tick rate from render FPS
+	m_enableLogicTimeScale = TRUE;
 	m_isTimeFrozen = FALSE;
 	m_isGameHalted = FALSE;
 }

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -439,6 +439,9 @@ void GameEngine::init()
 					"  KeyboardScrollSpeedFactor = 1.0\n"
 					"  ; ~5% more terrain drawn at max zoom to fix terrain pop-in.\n"
 					"  TerrainDrawDistanceScale = 1.05\n"
+					// GeneralsX @tweak felipebraz 20/06/2026 Default render FPS limit to 60 FPS in SagePatch.ini
+					"  UseFPSLimit = Yes\n"
+					"  FramesPerSecondLimit = 60\n"
 					"End\n"
 				);
 				fclose(f);
@@ -447,6 +450,35 @@ void GameEngine::init()
 
 		if (TheLocalFileSystem->doesFileExist(sagePatchPath.str()))
 		{
+			// Check and migrate existing SagePatch.ini for 60 FPS
+			FILE *f = fopen(sagePatchPath.str(), "rb");
+			if (f)
+			{
+				fseek(f, 0, SEEK_END);
+				long size = ftell(f);
+				fseek(f, 0, SEEK_SET);
+				char *buffer = new char[size + 1];
+				fread(buffer, 1, size, f);
+				buffer[size] = 0;
+				fclose(f);
+
+				if (!strstr(buffer, "FramesPerSecondLimit"))
+				{
+					char *endPos = strstr(buffer, "End");
+					if (endPos != nullptr)
+					{
+						*endPos = '\0';
+						FILE *fw = fopen(sagePatchPath.str(), "wb");
+						if (fw)
+						{
+							fprintf(fw, "%s  ; Migrated 60 FPS defaults\n  UseFPSLimit = Yes\n  FramesPerSecondLimit = 60\nEnd\n", buffer);
+							fclose(fw);
+						}
+					}
+				}
+				delete[] buffer;
+			}
+
 			ini.load(sagePatchPath, INI_LOAD_OVERWRITE, nullptr);
 		}
 	}

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -633,9 +633,10 @@ GlobalData::GlobalData()
 	m_useTreeSway = TRUE;
 	m_useDrawModuleLOD = FALSE;
 	m_useHeatEffects = TRUE;
-	m_useFpsLimit = FALSE;
+	// GeneralsX @tweak felipebraz 20/06/2026 Default render FPS limit to 60 FPS instead of uncapped/0.
+	m_useFpsLimit = TRUE;
 	m_dumpAssetUsage = FALSE;
-	m_framesPerSecondLimit = 0;
+	m_framesPerSecondLimit = 60;
 	m_chipSetType = 0;
 	m_headless = FALSE;
 	// GeneralsX @feature BenderAI 21/04/2026 Default to TRUE; user can override via Options.ini

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -141,7 +141,8 @@ static Bool justEntered = FALSE;
 static Bool buttonPushed = FALSE;
 void skirmishUpdateSlotList();
 static void populateSkirmishBattleHonors();
-enum{ GREATER_NO_FPS_LIMIT = 60};
+// GeneralsX @tweak felipebraz 20/06/2026 Change Skirmish speed limit to represent FPS limit (30..120)
+enum{ GREATER_NO_FPS_LIMIT = 120};
 Bool doUpdateSlotList = TRUE;
 
 static Int getNextSelectablePlayer(Int start)
@@ -415,8 +416,9 @@ void reallyDoStart()
 	DEBUG_LOG(("GameSpeedSlider was at %d", maxFPS));
 	if (maxFPS > GREATER_NO_FPS_LIMIT)
 		maxFPS = 1000;
-	if (maxFPS < 15)
-		maxFPS = 15;
+	// GeneralsX @tweak felipebraz 20/06/2026 Clamp FPS limit from skirmish game speed slider to 30..120
+	if (maxFPS < 30)
+		maxFPS = 30;
 
   TheWritableGlobalData->m_mapName = TheSkirmishGameInfo->getMap();
   TheSkirmishGameInfo->startGame(0);
@@ -1268,7 +1270,9 @@ void SkirmishGameOptionsMenuInit( WindowLayout *layout, void *userData )
 	// set up the game speed slider
 //	NameKeyType sliderGameSpeedID = TheNameKeyGenerator->nameToKey( "SkirmishGameOptionsMenu.wnd:SliderGameSpeed" );
 	GameWindow *sliderGameSpeed = TheWindowManager->winGetWindowFromId( parentSkirmishGameOptions, sliderGameSpeedID );
-	Int sliderPos = max(15,min(61,prefs.getInt("FPS", TheGlobalData->m_framesPerSecondLimit)));
+	// GeneralsX @tweak felipebraz 20/06/2026 Set up the skirmish slider to represent rendering FPS limit (30..120+)
+	GadgetSliderSetMinMax( sliderGameSpeed, 30, 121 );
+	Int sliderPos = max(30,min(121,prefs.getInt("FPS", TheGlobalData->m_framesPerSecondLimit)));
 	GadgetSliderSetPosition( sliderGameSpeed, sliderPos );
 	setFPSTextBox(sliderPos);
 	buttonStart->winSetText(TheGameText->fetch("GUI:Start"));

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -498,6 +498,9 @@ void GameEngine::init()
 					"  KeyboardScrollSpeedFactor = 1.0\n"
 					"  ; ~5% more terrain drawn at max zoom to fix terrain pop-in.\n"
 					"  TerrainDrawDistanceScale = 1.05\n"
+					// GeneralsX @tweak felipebraz 20/06/2026 Default render FPS limit to 60 FPS in SagePatch.ini
+					"  UseFPSLimit = Yes\n"
+					"  FramesPerSecondLimit = 60\n"
 					"End\n"
 				);
 				fclose(f);
@@ -506,6 +509,35 @@ void GameEngine::init()
 
 		if (TheLocalFileSystem->doesFileExist(sagePatchPath.str()))
 		{
+			// Check and migrate existing SagePatch.ini for 60 FPS
+			FILE *f = fopen(sagePatchPath.str(), "rb");
+			if (f)
+			{
+				fseek(f, 0, SEEK_END);
+				long size = ftell(f);
+				fseek(f, 0, SEEK_SET);
+				char *buffer = new char[size + 1];
+				fread(buffer, 1, size, f);
+				buffer[size] = 0;
+				fclose(f);
+
+				if (!strstr(buffer, "FramesPerSecondLimit"))
+				{
+					char *endPos = strstr(buffer, "End");
+					if (endPos != nullptr)
+					{
+						*endPos = '\0';
+						FILE *fw = fopen(sagePatchPath.str(), "wb");
+						if (fw)
+						{
+							fprintf(fw, "%s  ; Migrated 60 FPS defaults\n  UseFPSLimit = Yes\n  FramesPerSecondLimit = 60\nEnd\n", buffer);
+							fclose(fw);
+						}
+					}
+				}
+				delete[] buffer;
+			}
+
 			ini.load(sagePatchPath, INI_LOAD_OVERWRITE, nullptr);
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -647,9 +647,10 @@ GlobalData::GlobalData()
 	m_useTreeSway = TRUE;
 	m_useDrawModuleLOD = FALSE;
 	m_useHeatEffects = TRUE;
-	m_useFpsLimit = FALSE;
+	// GeneralsX @tweak felipebraz 20/06/2026 Default render FPS limit to 60 FPS instead of uncapped/0.
+	m_useFpsLimit = TRUE;
 	m_dumpAssetUsage = FALSE;
-	m_framesPerSecondLimit = 0;
+	m_framesPerSecondLimit = 60;
 	m_chipSetType = 0;
 	m_headless = FALSE;
 	m_checkForUpdates = TRUE;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -149,7 +149,8 @@ static Bool buttonPushed = FALSE;
 static Bool stillNeedsToSetOptions = FALSE;
 void skirmishUpdateSlotList();
 static void populateSkirmishBattleHonors();
-enum{ GREATER_NO_FPS_LIMIT = 60};
+// GeneralsX @tweak felipebraz 20/06/2026 Change Skirmish speed limit to represent FPS limit (30..120)
+enum{ GREATER_NO_FPS_LIMIT = 120};
 Bool doUpdateSlotList = TRUE;
 
 static Int getNextSelectablePlayer(Int start)
@@ -426,8 +427,9 @@ void reallyDoStart()
 	DEBUG_LOG(("GameSpeedSlider was at %d", maxFPS));
 	if (maxFPS > GREATER_NO_FPS_LIMIT)
 		maxFPS = 1000;
-	if (maxFPS < 15)
-		maxFPS = 15;
+	// GeneralsX @tweak felipebraz 20/06/2026 Clamp FPS limit from skirmish game speed slider to 30..120
+	if (maxFPS < 30)
+		maxFPS = 30;
 
   TheWritableGlobalData->m_mapName = TheSkirmishGameInfo->getMap();
   TheSkirmishGameInfo->startGame(0);
@@ -1353,7 +1355,9 @@ void SkirmishGameOptionsMenuInit( WindowLayout *layout, void *userData )
 	// set up the game speed slider
 //	NameKeyType sliderGameSpeedID = TheNameKeyGenerator->nameToKey( "SkirmishGameOptionsMenu.wnd:SliderGameSpeed" );
 	GameWindow *sliderGameSpeed = TheWindowManager->winGetWindowFromId( parentSkirmishGameOptions, sliderGameSpeedID );
-	Int sliderPos = max(15,min(61,prefs.getInt("FPS", TheGlobalData->m_framesPerSecondLimit)));
+	// GeneralsX @tweak felipebraz 20/06/2026 Set up the skirmish slider to represent rendering FPS limit (30..120+)
+	GadgetSliderSetMinMax( sliderGameSpeed, 30, 121 );
+	Int sliderPos = max(30,min(121,prefs.getInt("FPS", TheGlobalData->m_framesPerSecondLimit)));
 	GadgetSliderSetPosition( sliderGameSpeed, sliderPos );
 	setFPSTextBox(sliderPos);
 	buttonStart->winSetText(TheGameText->fetch("GUI:Start"));

--- a/docs/DEV_BLOG/2026-06-DIARY.md
+++ b/docs/DEV_BLOG/2026-06-DIARY.md
@@ -1,5 +1,9 @@
 # Development Diary - June 2026
 
+## 2026-06-20: Default Render Framerate Cap to 60 FPS in Generals and Zero Hour
+
+- **FPS Limit Default Modernization**: Changed default render framerate limits from uncapped/0 to 60 FPS in the constructor of `GlobalData` ([GlobalData.cpp](file:///Users/felipebraz/PhpstormProjects/pessoal/GeneralsX/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp) and [GlobalData.cpp](file:///Users/felipebraz/PhpstormProjects/pessoal/GeneralsX/Generals/Code/GameEngine/Source/Common/GlobalData.cpp)) and enabled FPS limiting by default (`m_useFpsLimit = TRUE`). Added corresponding `UseFPSLimit = Yes` and `FramesPerSecondLimit = 60` to the auto-generated `SagePatch.ini` template in both Generals base and Zero Hour ([GameEngine.cpp](file:///Users/felipebraz/PhpstormProjects/pessoal/GeneralsX/Generals/Code/GameEngine/Source/Common/GameEngine.cpp) and [GameEngine.cpp](file:///Users/felipebraz/PhpstormProjects/pessoal/GeneralsX/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp)). This ensures both targets default to a smooth, decoupled 60 FPS rendering experience out of the box for fresh installations without impacting the 30 Hz gameplay logic tick rate.
+
 ## 2026-06-19: Fix Audio Volume Settings in OpenAL and MiniAudio Backends
 
 - **Sound Volume Initialization Fix**: Solved issue where the game's volume settings were ignored when starting or looping sounds under both the OpenAL and MiniAudio backends (GitHub issue #163). In the OpenAL backend (`OpenALAudioManager`), initial `AL_GAIN` parameters are now correctly set during `playSample`, `playSample3D`, and `playStream` using `adjustPlayingVolume`. In the MiniAudio backend (`MiniAudioManager`), manual volume assignments in `playAudioEvent` and `startNextLoop` have been replaced with the unified `adjustPlayingVolume` call, ensuring that category settings (music, speech, SFX) and dynamic `volumeShift` variables are correctly applied when the sound starts.


### PR DESCRIPTION
## Description

This PR solves two key issues with our previous 60 FPS modernization:
1. **Game Speed Acceleration (Fast-Forward effect)**: By default, the simulation logic tick rate (30 Hz) was tied directly to the rendering FPS limit, causing the game to run at 200% speed on a 60 FPS cap. Enabling the logic time scale decouples them completely.
2. **SagePatch.ini Migration**: Existing configurations previously stuck to 30 FPS because their existing `SagePatch.ini` was not updated. We now auto-migrate existing setups by appending the 60 FPS limit defaults if they are missing.
3. **Skirmish FPS slider**: Redesigned the Skirmish menu options slider to control the rendering FPS cap directly (ranging from 30 FPS up to 120 FPS, with uncapped/`--` limit for values over 120 FPS).

## Changes

### Core / Shared
- **`FramePacer.cpp`**: Enabled `m_enableLogicTimeScale = TRUE` by default in the constructor so logic ticks at 30 Hz regardless of the render framerate.
- **`GadgetSlider.h`**: Added `GadgetSliderSetMinMax` to dynamically override the slider boundaries.

### Generals (Base) & Zero Hour (MD)
- **`GlobalData.cpp`**: Set the default `m_framesPerSecondLimit = 60` and `m_useFpsLimit = TRUE`.
- **`GameEngine.cpp`**: Added an auto-migration check to read and inject 60 FPS defaults into existing `SagePatch.ini` setups, and updated the default template for fresh setups.
- **`SkirmishGameOptionsMenu.cpp`**: Set up the "Game Speed" slider to act as an FPS limit slider with bounds `30` to `121` (where values > 120 represent uncapped `--`).

## Verification
- Both Zero Hour (`z_generals`) and base Generals (`g_generals`) targets successfully compiled on `macos-vulkan` preset.
- Source changes were annotated using the standard format: `// GeneralsX @tweak felipebraz 20/06/2026 ...`.
