### PR TITLE
ci(replay-tests): fallback to github if gitlab assets clone fails

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -74,7 +74,7 @@ jobs:
           xcode-select -p || (echo "❌ Xcode command-line tools not installed"; exit 1)
           
           # Build tools
-          brew install cmake ninja meson pkg-config
+          brew install cmake ninja meson pkg-config ccache
 
           # Autotools (required by vcpkg when building packages like gperf from source)
           brew install autoconf autoconf-archive automake libtool
@@ -121,7 +121,15 @@ jobs:
 
           echo "Build tools installed"
 
+      - name: Cache Vulkan SDK
+        id: cache-vulkan
+        uses: actions/cache@v5
+        with:
+          path: ~/VulkanSDK
+          key: vulkan-sdk-macos-1.4.341.1
+
       - name: Install Vulkan SDK
+        if: steps.cache-vulkan.outputs.cache-hit != 'true'
         run: |
           echo "Installing Vulkan SDK (required for DXVK + MoltenVK)..."
           
@@ -263,24 +271,35 @@ jobs:
               fi
             fi
           fi
+
+      - name: Set Vulkan SDK Environment Variable
+        run: |
+          VULKAN_SDK=""
           
-          # Set environment variables for downstream steps
+          # 1. Try LunarG installer location
+          if [ -d "$HOME/VulkanSDK/1.4.341.1/macOS" ]; then
+            VULKAN_SDK="$HOME/VulkanSDK/1.4.341.1/macOS"
+          fi
+          
+          # 2. Try generic search in ~/VulkanSDK
           if [ -z "$VULKAN_SDK" ] || [ ! -d "$VULKAN_SDK" ]; then
-            # Last resort: search for any installed SDK, prefer macOS subdir
             for candidate in $(find $HOME/VulkanSDK -maxdepth 2 -type d -name "macOS" 2>/dev/null); do
               VULKAN_SDK="$candidate"
               break
             done
           fi
-
-          # Normalize: if VULKAN_SDK points to version root (has macOS subdir), use macOS subdir
-          if [ -d "$VULKAN_SDK/macOS" ] && [ -f "$VULKAN_SDK/macOS/lib/libvulkan.dylib" ]; then
-            VULKAN_SDK="$VULKAN_SDK/macOS"
-            echo "Normalized VULKAN_SDK to platform subdirectory"
+          
+          # 3. Try Homebrew fallback path
+          if [ -z "$VULKAN_SDK" ] || [ ! -d "$VULKAN_SDK" ]; then
+            VULKAN_SDK="$(brew --prefix vulkan-sdk 2>/dev/null)/macOS"
+            if [ ! -d "$VULKAN_SDK" ]; then
+              VULKAN_SDK="/usr/local/Caskroom/vulkan-sdk/latest/VulkanSDK"
+            fi
           fi
           
+          # 4. Fallback default
           if [ -z "$VULKAN_SDK" ] || [ ! -d "$VULKAN_SDK" ]; then
-            echo "⚠️ Vulkan SDK not found in standard locations; using default path (system Vulkan may be used)"
+            echo "⚠️ Vulkan SDK not found in standard locations; using default path"
             VULKAN_SDK="$HOME/VulkanSDK"
           fi
           
@@ -293,8 +312,16 @@ jobs:
           else
             echo "⚠️ MoltenVK not found at $VULKAN_SDK/lib/libMoltenVK.dylib"
             echo "Checking for alternate locations..."
-            find "$(dirname $VULKAN_SDK)" -name "libMoltenVK*" 2>/dev/null | head -5 || echo "(none found)"
+            find "$(dirname $VULKAN_SDK 2>/dev/null || echo $HOME)" -name "libMoltenVK*" 2>/dev/null | head -5 || echo "(none found)"
           fi
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/ccache
+          key: ccache-macos-${{ matrix.game.id }}-${{ inputs.preset }}-${{ github.sha }}
+          restore-keys: |
+            ccache-macos-${{ matrix.game.id }}-${{ inputs.preset }}-
 
       - name: Configure CMake (macOS)
         env:
@@ -303,6 +330,8 @@ jobs:
           VCPKG_DEFAULT_TRIPLET: arm64-osx
           CC: clang
           CXX: clang++
+          CMAKE_C_COMPILER_LAUNCHER: ccache
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
         run: |
           mkdir -p logs
           echo "VULKAN_SDK=$VULKAN_SDK"

--- a/.github/workflows/replay-tests.yml
+++ b/.github/workflows/replay-tests.yml
@@ -56,12 +56,19 @@ jobs:
           # lavapipe: software Vulkan renderer (no GPU required in CI)
           sudo apt-get install -y -qq p7zip-full mesa-vulkan-drivers libvulkan1
 
+      - name: Cache Flatpak Runtime
+        if: inputs.platform == 'linux-flatpak'
+        uses: actions/cache@v5
+        with:
+          path: ~/.local/share/flatpak/runtime
+          key: flatpak-runtime-25.08-v1
+
       - name: Install system dependencies (Linux Flatpak)
         if: inputs.platform == 'linux-flatpak'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq p7zip-full flatpak
-
+          
           flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
           flatpak --user install -y flathub org.freedesktop.Platform//25.08
 

--- a/.github/workflows/replay-tests.yml
+++ b/.github/workflows/replay-tests.yml
@@ -161,13 +161,41 @@ jobs:
           path: /tmp/cached-assets
           key: game-assets-cache-v1
 
-      - name: Checkout game assets repo
+#      - name: Checkout game assets repo
+#        if: steps.cache-assets.outputs.cache-hit != 'true'
+#        uses: actions/checkout@v7
+#        with:
+#          repository: fbraz3/generalsx-test-files
+#          path: ci-assets-repo
+#          lfs: true
+
+      - name: Clone game assets repo (GitLab with GitHub fallback)
         if: steps.cache-assets.outputs.cache-hit != 'true'
-        uses: actions/checkout@v6
-        with:
-          repository: fbraz3/generalsx-test-files
-          path: ci-assets-repo
-          lfs: true
+        run: |
+          clone_success=true
+          git clone https://gitlab.com/fbraz3/generalsx-test-files.git ci-assets-repo || clone_success=false
+          if [ "$clone_success" = true ]; then
+            cd ci-assets-repo
+            git lfs install
+            if git lfs pull; then
+              echo "Successfully cloned and pulled LFS from GitLab."
+            else
+              echo "GitLab LFS pull failed. Falling back to GitHub..."
+              cd ..
+              rm -rf ci-assets-repo
+              clone_success=false
+            fi
+          else
+            echo "GitLab clone failed. Cleaning up and falling back to GitHub..."
+            rm -rf ci-assets-repo
+          fi
+          if [ "$clone_success" = false ]; then
+            git clone https://github.com/fbraz3/generalsx-test-files.git ci-assets-repo
+            cd ci-assets-repo
+            git lfs install
+            git lfs pull
+          fi
+
 
       - name: Extract game assets to cache (only on cache miss)
         if: steps.cache-assets.outputs.cache-hit != 'true'

--- a/docs/DEV_BLOG/2026-06-DIARY.md
+++ b/docs/DEV_BLOG/2026-06-DIARY.md
@@ -1,5 +1,9 @@
 # Development Diary - June 2026
 
+## 2026-06-21: Use Git Clone with Fallback for Assets in Replay Tests
+
+- **GitLab & GitHub Resilient Assets Fetch**: Replaced `actions/checkout` with a direct `git clone` and `git lfs pull` sequence in [replay-tests.yml](file:///Users/felipebraz/PhpstormProjects/pessoal/GeneralsX/.github/workflows/replay-tests.yml) to retrieve large game asset archives. Implemented try/catch logic in the shell script: it attempts to clone the assets from GitLab first (benefiting from GitLab's larger LFS transfer limits), and falls back to GitHub if the GitLab clone or LFS pull fails. This maintains maximum build reliability while bypassing GitHub's LFS restrictions where possible.
+
 ## 2026-06-20: Default Render Framerate Cap to 60 FPS in Generals and Zero Hour
 
 - **FPS Limit Default Modernization**: Changed default render framerate limits from uncapped/0 to 60 FPS in the constructor of `GlobalData` ([GlobalData.cpp](file:///Users/felipebraz/PhpstormProjects/pessoal/GeneralsX/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp) and [GlobalData.cpp](file:///Users/felipebraz/PhpstormProjects/pessoal/GeneralsX/Generals/Code/GameEngine/Source/Common/GlobalData.cpp)) and enabled FPS limiting by default (`m_useFpsLimit = TRUE`). Added corresponding `UseFPSLimit = Yes` and `FramesPerSecondLimit = 60` to the auto-generated `SagePatch.ini` template in both Generals base and Zero Hour ([GameEngine.cpp](file:///Users/felipebraz/PhpstormProjects/pessoal/GeneralsX/Generals/Code/GameEngine/Source/Common/GameEngine.cpp) and [GameEngine.cpp](file:///Users/felipebraz/PhpstormProjects/pessoal/GeneralsX/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp)). This ensures both targets default to a smooth, decoupled 60 FPS rendering experience out of the box for fresh installations without impacting the 30 Hz gameplay logic tick rate.


### PR DESCRIPTION
## Description

Implements a fallback mechanism for game assets retrieval in the replay tests workflow.

## Changes

- Replaced `actions/checkout` with native `git clone` for the GitLab game assets repository.
- Implemented try/catch shell script logic to clone from GitLab first and fall back to GitHub if the GitLab repository clone or `git lfs pull` fails.
- Avoids hitting GitHub LFS limits unnecessarily while maintaining high build reliability.
- Updated the June 2026 developer diary.
