### PR TITLE
SagePatch: pin target to C++17 so macOS builds

### DIFF
--- a/Patches/SagePatch/CMakeLists.txt
+++ b/Patches/SagePatch/CMakeLists.txt
@@ -42,6 +42,15 @@ endif()
 
 add_library(sage_patch SHARED ${SAGE_PATCH_SOURCES})
 
+# SagePatch sources use modern C++ (scoped enums, brace-init). The legacy engine
+# builds at C++98, and without pinning a standard here the target inherits it,
+# so a standards-strict compiler (e.g. AppleClang) fails to build sage_patch with
+# "scoped enumerations are a C++11 extension". Pin this target to C++17.
+set_target_properties(sage_patch PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)
+
 target_include_directories(sage_patch PRIVATE
     include
     ${CMAKE_BINARY_DIR}/_deps/sdl3-src/include


### PR DESCRIPTION
## Problem

Building `sage_patch` on macOS fails with:

```
error: scoped enumerations are a C++11 extension [-Wc++11-extensions]
error: expected ';' at end of declaration    (SDL_Rect bounds{};)
```

The `sage_patch` sources use modern C++ (scoped enums, brace-init), but the target sets no C++ standard, so it inherits the engine's global **C++98**. A standards-strict compiler (AppleClang) then rejects the C++11/17 constructs and the macOS build breaks.

## Fix

Pin the `sage_patch` target to C++17 (independent of the legacy engine's standard):

```cmake
set_target_properties(sage_patch PROPERTIES
    CXX_STANDARD 17
    CXX_STANDARD_REQUIRED ON
)
```

One-line behavior change, scoped to the `sage_patch` target only. Verified: the macOS `z_generals` build links cleanly with this in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)