### PR TITLE
Fix segfault in WaterRenderObjClass when skybox asset fails to load

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -1338,6 +1338,13 @@ void WaterRenderObjClass::update()
 //-------------------------------------------------------------------------------------------------
 void WaterRenderObjClass::replaceSkyboxTexture(const AsciiString& oldTexName, const AsciiString& newTextName)
 {
+	// GeneralsX @bugfix Claude 05/07/2026 Guard against null m_skyBox: replaceAssetTexture dereferences the
+	// render object unconditionally, so skip texture replacement when the skybox asset never loaded.
+	if (m_skyBox == nullptr)
+	{
+		return;
+	}
+
 	W3DAssetManager* assetManager = ((W3DAssetManager*)W3DAssetManager::Get_Instance());
 
 	assetManager->replacePrototypeTexture(m_skyBox, oldTexName.str(), newTextName.str());
@@ -1737,7 +1744,9 @@ void WaterRenderObjClass::Render(RenderInfoClass & rinfo)
 			break;
 	}
 
-	if (TheGlobalData && TheGlobalData->m_drawSkyBox)
+	// GeneralsX @bugfix Claude 05/07/2026 Guard against null m_skyBox: Create_Render_Obj("new_skybox") can fail
+	// when the skybox asset is unavailable (e.g. base Generals archives not found), causing a segfault here.
+	if (TheGlobalData && TheGlobalData->m_drawSkyBox && m_skyBox)
 	{	//center skybox around camera
 		Vector3 pos=rinfo.Camera.Get_Position();
 		pos.Z = TheGlobalData->m_skyBoxPositionZ;

--- a/Core/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -1321,6 +1321,11 @@ void TextureLoadTaskClass::Apply_Missing_Texture()
 		return;
 	}
 
+#ifndef _WIN32
+	// DIAG: log which textures fall back to the magenta placeholder
+	fprintf(stderr, "[TEX_MISSING] '%s'\n", static_cast<const char*>(Texture->Get_Full_Path()));
+#endif
+
 	D3DTexture = MissingTexture::_Get_Missing_Texture();
 	if (D3DTexture == nullptr)
 	{


### PR DESCRIPTION
## Problem

On macOS (Apple Silicon, `macos-vulkan` preset, Beta 12), the game segfaults as soon as the shell map — or any map with water — renders:

```
Thread 0 Crashed (SIGSEGV, address 0x0):
  WaterRenderObjClass::Render(RenderInfoClass&)
  DefaultStaticSortListClass::Render_And_Clear(RenderInfoClass&)
  WW3D::Render_And_Clear_Static_Sort_Lists(RenderInfoClass&)
  RTS3DScene::Flush(RenderInfoClass&)
  ...
```

## Root cause

`WaterRenderObjClass::Render()` dereferences `m_skyBox` whenever `TheGlobalData->m_drawSkyBox` is set, but `Create_Render_Obj("new_skybox")` returns null when the skybox asset is unavailable — e.g. when the base Generals archives aren't found at init (Steam layout without `ZH_Generals/`, or any partial-asset setup). Disassembly of the crash site confirms the null deref is the `m_skyBox->Set_Position()` / `m_skyBox->Render()` pair after the water-type switch.

`replaceSkyboxTexture()` has the same hazard: it passes `m_skyBox` into `replacePrototypeTexture()` → `replaceAssetTexture()`, which calls `robj->Class_ID()` unconditionally, so any map that swaps skybox textures crashes the same way.

## Fix

- Guard the `m_skyBox` use in `Render()` (null check alongside the existing `TheGlobalData` check)
- Early-return in `replaceSkyboxTexture()` when `m_skyBox` is null
- Add `[TEX_MISSING]` stderr logging in `Apply_Missing_Texture()` (guarded `#ifndef _WIN32`), as proposed in the Session 44 notes — this is what made the missing-asset root cause diagnosable here

## Testing

- Before: reproducible SIGSEGV on shell map load and on entering the USA campaign (macOS 26.5, M-series, Beta 12 + retail Steam ZH assets)
- After: shell map renders and plays fine; entering maps with water no longer crashes; when assets are complete the skybox renders as before (guard is a no-op)
- `[TEX_MISSING]` output confirmed: 247 missing textures with base archives absent → 1 (`trstrtholecvr.tga`, absent from retail archives) once `ZH_Generals/` is in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)