### PR TITLE
build: fix SagePatch requirement failure on non-SDL3 builds

### DIFF
--- a/cmake/config-build.cmake
+++ b/cmake/config-build.cmake
@@ -28,7 +28,9 @@ option(SAGE_USE_MOLTENVK "Use MoltenVK for Vulkan on macOS (Phase 5 macOS port)"
 # SagePatch — optional QoL features for casual play (screenshot, cursor lock,
 # brightness, camera/scroll INI overrides). Compiles to a separate shared lib
 # that is loaded via DYLD_INSERT_LIBRARIES (macOS) / LD_PRELOAD (Linux) at runtime.
-option(RTS_BUILD_OPTION_SAGE_PATCH "Build SagePatch QoL extras (macOS/Linux, requires SDL3)" ON)
+if(NOT DEFINED CACHE{RTS_BUILD_OPTION_SAGE_PATCH})
+    set(RTS_BUILD_OPTION_SAGE_PATCH "${SAGE_USE_SDL3}" CACHE BOOL "Build SagePatch QoL extras (macOS/Linux, requires SDL3)")
+endif()
 
 if(NOT RTS_BUILD_ZEROHOUR AND NOT RTS_BUILD_GENERALS)
     set(RTS_BUILD_ZEROHOUR TRUE)

--- a/docs/WORKLOG/2026-07-DIARY.md
+++ b/docs/WORKLOG/2026-07-DIARY.md
@@ -13,3 +13,4 @@ The issue stemmed from two places:
 2. **MiniAudio incorrect limits:** `MiniAudioManager::getNumAvailable2DSamples` was calculating available 2D samples against the size of the *entire* `m_playingSounds` list (which in MiniAudio includes 3D sounds and Streams/Music). This effectively kept the available samples at 0 at all times, making it always fall back to the broken priority handling.
 
 Both issues have been resolved by adding proper counting filters in MiniAudio and uncommenting `event->setHandleToKill` in both audio managers' priority checks.
+- Fixed issue #190: CMake configuration error `SagePatch requires SAGE_USE_SDL3=ON` for MinGW cross-builds by defaulting `RTS_BUILD_OPTION_SAGE_PATCH` to the status of `SAGE_USE_SDL3`.


### PR DESCRIPTION
## Description
Fixes #190

## Changes
- Made `RTS_BUILD_OPTION_SAGE_PATCH` inherit its default value from `SAGE_USE_SDL3` dynamically in `config-build.cmake`, avoiding errors in cross-builds like MinGW which have SDL3 disabled by default.
