### PR TITLE
Fix #187: Use A8R8G8B8 fallback for radar overlay and shroud formats

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -76,7 +76,7 @@ inline Bool legalRadarPoint( Int px, Int py )
 
 //-------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
-static WW3DFormat findFormat(const WW3DFormat formats[])
+static WW3DFormat findFormat(const WW3DFormat formats[], WW3DFormat fallback = WW3D_FORMAT_X8R8G8B8)
 {
 	for( Int i = 0; formats[ i ] != WW3D_FORMAT_UNKNOWN; i++ )
 	{
@@ -89,16 +89,16 @@ static WW3DFormat findFormat(const WW3DFormat formats[])
 		}
 
 	}
-	// GeneralsX @bugfix BenderAI 24/02/2026 W3DRadar: When DXVK/MoltenVK caps query returns no supported
-	// format (e.g. CheckDeviceFormat fails on macOS for R8G8B8/R5G6B5), fall back to X8R8G8B8 which
-	// is guaranteed to be supported on any modern Vulkan-capable GPU. Without this, texture creation
-	// silently produces a null D3D texture and crashes later in buildTerrainTexture.
+	// GeneralsX @bugfix W3DRadar: When DXVK/MoltenVK caps query returns no supported
+	// format (e.g. CheckDeviceFormat fails on macOS for R8G8B8/R5G6B5), fall back to 
+	// the provided fallback which is guaranteed to be supported on any modern Vulkan-capable GPU. 
+	// Without this, texture creation silently produces a null D3D texture and crashes later in buildTerrainTexture.
 #if !defined(_WIN32)
-	fprintf(stderr, "W3DRadar: findFormat: no supported format found in caps query - falling back to WW3D_FORMAT_X8R8G8B8\n");
+	fprintf(stderr, "W3DRadar: findFormat: no supported format found in caps query - falling back to %d\n", fallback);
 	fflush(stderr);
 #endif
 	DEBUG_CRASH(("WW3DRadar: No appropriate texture format") );
-	return WW3D_FORMAT_X8R8G8B8;
+	return fallback;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -130,13 +130,13 @@ void W3DRadar::initializeTextureFormats()
 	};
 
 	// find a format for the terrain texture
-	m_terrainTextureFormat = findFormat(terrainFormats);
+	m_terrainTextureFormat = findFormat(terrainFormats, WW3D_FORMAT_X8R8G8B8);
 
 	// find a format for the overlay texture
-	m_overlayTextureFormat = findFormat(overlayFormats);
+	m_overlayTextureFormat = findFormat(overlayFormats, WW3D_FORMAT_A8R8G8B8);
 
 	// find a format for the shroud texture
-	m_shroudTextureFormat = findFormat(shroudFormats);
+	m_shroudTextureFormat = findFormat(shroudFormats, WW3D_FORMAT_A8R8G8B8);
 
 }
 


### PR DESCRIPTION
## Description
Fixes #187.

On macOS (and potentially Linux) in fullscreen mode, the presentation format is negotiated as `D3D9Format::X8R8G8B8` (without an alpha channel).
When the game checks for texture support via `CheckDeviceFormat` using the backbuffer format, DXVK/MoltenVK returns that `A8R8G8B8` and `A4R4G4B4` are unsupported relative to `X8R8G8B8`.
This causes `W3DRadar::initializeTextureFormats()` to fall back to `WW3D_FORMAT_X8R8G8B8` (the only fallback in the original implementation of `findFormat`).
Because `X8R8G8B8` does not have an alpha channel, the overlay and shroud (fog of war) textures render as solid opaque screens, causing the minimap to appear completely black/dark.

## Changes
- Updated `findFormat` in `W3DRadar.cpp` to accept a `defaultFallback` parameter (defaulting to `WW3D_FORMAT_X8R8G8B8`).
- Changed the fallback for the radar overlay and shroud textures to `WW3D_FORMAT_A8R8G8B8`. Modern Vulkan devices support `A8R8G8B8` textures natively even if DXVK's capability checks return false under `X8R8G8B8` swapchains.
