### PR TITLE
Fix game crash on Linux when some music files are missing

### DIFF
--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -947,28 +947,25 @@ Real AudioManager::getAudioLengthMS( const AudioEventRTS *event )
 //-------------------------------------------------------------------------------------------------
 Bool AudioManager::isMusicAlreadyLoaded() const
 {
-	const AudioEventInfo *musicToLoad = nullptr;
+	// GeneralsX @bugfix felipebraz 10/07/2026 Fix game crash on Linux when some music files are missing by checking until a valid one is found
 	AudioEventInfoHash::const_iterator it;
 	for (it = m_allAudioEventInfo.begin(); it != m_allAudioEventInfo.end(); ++it) {
 		if (it->second) {
 			const AudioEventInfo *aet = it->second;
 			if (aet->m_soundType == AT_Music) {
-				musicToLoad = aet;
+				AudioEventRTS aud;
+				aud.setAudioEventInfo(aet);
+				aud.generateFilename();
+				
+				AsciiString astr = aud.getFilename();
+				if (TheFileSystem->doesFileExist(astr.str())) {
+					return TRUE;
+				}
 			}
 		}
 	}
-
-	if (!musicToLoad) {
-		return FALSE;
-	}
-
-	AudioEventRTS aud;
-	aud.setAudioEventInfo(musicToLoad);
-	aud.generateFilename();
-
-	AsciiString astr = aud.getFilename();
-
-	return (TheFileSystem->doesFileExist(astr.str()));
+	
+	return FALSE;
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Fixes #196

## Changes
- Updated `AudioManager::isMusicAlreadyLoaded()` to search through all `AT_Music` events and return `TRUE` as soon as a valid, existing music file is found.
- Previously, it only checked the last iterated event in the hash map, which caused fatal startup errors on Linux if that specific file was missing or had case-sensitivity issues.
