### PR TITLE
Add HD terrain tile support (64->256px) with legacy-map fallback

### DIFF
--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/TileData.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/TileData.h
@@ -45,17 +45,25 @@ typedef struct {
 
 #define INVERTED_MASK	0x1		//AND this with TBlendTileInfo.inverted to get actual inverted state
 #define FLIPPED_MASK	0x2		//AND this with TBlendTileInfo.inverted to get forced flip state (for horizontal/vertical flips).
-#define TILE_PIXEL_EXTENT 64
+// GeneralsX @feature mrkinglollipop 11/07/2026 Bumps base tile resolution 64->256 (4x per axis, 16x pixels).
+// The mip chain grows from 6 fixed levels (32/16/8/4/2/1) to 8 chained levels
+// (128/64/32/16/8/4/2/1) so doMip() still halves exactly once per level down to 1x1.
+// LEGACY_TILE_PIXEL_EXTENT (see WorldHeightMap.cpp) is the pre-patch 64px grid cell
+// size that unmodified base/custom-map TGAs are still packed in; the loader detects
+// and nearest-neighbor upscales those on read so they keep working unmodified.
+#define TILE_PIXEL_EXTENT 256
 #define TILE_BYTES_PER_PIXEL 4
 #define DATA_LEN_BYTES TILE_PIXEL_EXTENT*TILE_PIXEL_EXTENT*TILE_BYTES_PER_PIXEL
 #define DATA_LEN_PIXELS TILE_PIXEL_EXTENT*TILE_PIXEL_EXTENT
-#define TILE_PIXEL_EXTENT_MIP1 32
-#define TILE_PIXEL_EXTENT_MIP2 16
-#define TILE_PIXEL_EXTENT_MIP3 8
-#define TILE_PIXEL_EXTENT_MIP4 4
-#define TILE_PIXEL_EXTENT_MIP5 2
-#define TILE_PIXEL_EXTENT_MIP6 1
-#define TEXTURE_WIDTH 2048 // was 1024 jba
+#define TILE_PIXEL_EXTENT_MIP1 128
+#define TILE_PIXEL_EXTENT_MIP2 64
+#define TILE_PIXEL_EXTENT_MIP3 32
+#define TILE_PIXEL_EXTENT_MIP4 16
+#define TILE_PIXEL_EXTENT_MIP5 8
+#define TILE_PIXEL_EXTENT_MIP6 4
+#define TILE_PIXEL_EXTENT_MIP7 2
+#define TILE_PIXEL_EXTENT_MIP8 1
+#define TEXTURE_WIDTH 8192 // GeneralsX @feature mrkinglollipop 11/07/2026 Bumps atlas TEXTURE_WIDTH 2048->8192 (was 2048). MoltenVK/Metal cap is 16384.
 
 /** This class holds the bitmap data from the .tga texture files.  It is used to
 create the D3D texture in the game and 3d windows, and to create DIB data for the
@@ -68,13 +76,15 @@ protected:
 	// Also, first byte is lower left pixel, not upper left pixel.
 	// so 0,0 is lower left, not upper left.
 	UnsignedByte m_tileData[DATA_LEN_BYTES];
-	/// Mipped down copies of the tile data.
-	UnsignedByte m_tileDataMip32[TILE_PIXEL_EXTENT_MIP1*TILE_PIXEL_EXTENT_MIP1*TILE_BYTES_PER_PIXEL];
-	UnsignedByte m_tileDataMip16[TILE_PIXEL_EXTENT_MIP2*TILE_PIXEL_EXTENT_MIP2*TILE_BYTES_PER_PIXEL];
-	UnsignedByte m_tileDataMip8[TILE_PIXEL_EXTENT_MIP3*TILE_PIXEL_EXTENT_MIP3*TILE_BYTES_PER_PIXEL];
-	UnsignedByte m_tileDataMip4[TILE_PIXEL_EXTENT_MIP4*TILE_PIXEL_EXTENT_MIP4*TILE_BYTES_PER_PIXEL];
-	UnsignedByte m_tileDataMip2[TILE_PIXEL_EXTENT_MIP5*TILE_PIXEL_EXTENT_MIP5*TILE_BYTES_PER_PIXEL];
-	UnsignedByte m_tileDataMip1[TILE_PIXEL_EXTENT_MIP6*TILE_PIXEL_EXTENT_MIP6*TILE_BYTES_PER_PIXEL];
+	/// Mipped down copies of the tile data. 8-level chain: 128/64/32/16/8/4/2/1.
+	UnsignedByte m_tileDataMip128[TILE_PIXEL_EXTENT_MIP1*TILE_PIXEL_EXTENT_MIP1*TILE_BYTES_PER_PIXEL];
+	UnsignedByte m_tileDataMip64[TILE_PIXEL_EXTENT_MIP2*TILE_PIXEL_EXTENT_MIP2*TILE_BYTES_PER_PIXEL];
+	UnsignedByte m_tileDataMip32[TILE_PIXEL_EXTENT_MIP3*TILE_PIXEL_EXTENT_MIP3*TILE_BYTES_PER_PIXEL];
+	UnsignedByte m_tileDataMip16[TILE_PIXEL_EXTENT_MIP4*TILE_PIXEL_EXTENT_MIP4*TILE_BYTES_PER_PIXEL];
+	UnsignedByte m_tileDataMip8[TILE_PIXEL_EXTENT_MIP5*TILE_PIXEL_EXTENT_MIP5*TILE_BYTES_PER_PIXEL];
+	UnsignedByte m_tileDataMip4[TILE_PIXEL_EXTENT_MIP6*TILE_PIXEL_EXTENT_MIP6*TILE_BYTES_PER_PIXEL];
+	UnsignedByte m_tileDataMip2[TILE_PIXEL_EXTENT_MIP7*TILE_PIXEL_EXTENT_MIP7*TILE_BYTES_PER_PIXEL];
+	UnsignedByte m_tileDataMip1[TILE_PIXEL_EXTENT_MIP8*TILE_PIXEL_EXTENT_MIP8*TILE_BYTES_PER_PIXEL];
 
 public:
 	ICoord2D	m_tileLocationInTexture;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/WorldHeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/WorldHeightMap.h
@@ -332,8 +332,12 @@ public:  // modify height value
 		if ((ndx>=0) && (ndx<m_dataSize) && m_data) m_data[ndx]=height;
 	};
 public: // Read tile utilities. jba [7/9/2003]
-	static Bool readTiles(InputStream *pStrm, TileData **tiles, Int numRows);
-	static Int countTiles(InputStream *pStrm, Bool *halfTile=nullptr);
+	// GeneralsX @feature mrkinglollipop 11/07/2026 Adds expectedTileCount/pIsLegacyGrid so the caller's
+	// INI-declared tile count can disambiguate legacy 64px-grid TGAs from native
+	// TILE_PIXEL_EXTENT (256px)-grid TGAs; isLegacyGrid must be forwarded from
+	// countTiles' result into readTiles so both use the same interpretation of the file.
+	static Bool readTiles(InputStream *pStrm, TileData **tiles, Int numRows, Bool isLegacyGrid=false);
+	static Int countTiles(InputStream *pStrm, Bool *halfTile=nullptr, Int expectedTileCount=0, Bool *pIsLegacyGrid=nullptr);
 
 protected:
 	void setCliffState(Int xIndex, Int yIndex, Bool state);

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/TileData.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/TileData.cpp
@@ -43,12 +43,17 @@ TileData::TileData()
 
 }
 
-#define TILE_PIXEL_EXTENT_MIP1 32
-#define TILE_PIXEL_EXTENT_MIP2 16
-#define TILE_PIXEL_EXTENT_MIP3 8
-#define TILE_PIXEL_EXTENT_MIP4 4
-#define TILE_PIXEL_EXTENT_MIP5 2
-#define TILE_PIXEL_EXTENT_MIP6 1
+// GeneralsX @feature mrkinglollipop 11/07/2026 Bumps this local mip-extent copy to match TileData.h's
+// 8-level chain (128/64/32/16/8/4/2/1); shadows the header's #defines (as it did
+// before this change) -- kept in sync manually.
+#define TILE_PIXEL_EXTENT_MIP1 128
+#define TILE_PIXEL_EXTENT_MIP2 64
+#define TILE_PIXEL_EXTENT_MIP3 32
+#define TILE_PIXEL_EXTENT_MIP4 16
+#define TILE_PIXEL_EXTENT_MIP5 8
+#define TILE_PIXEL_EXTENT_MIP6 4
+#define TILE_PIXEL_EXTENT_MIP7 2
+#define TILE_PIXEL_EXTENT_MIP8 1
 
 Bool TileData::hasRGBDataForWidth(Int width)
 {
@@ -59,29 +64,40 @@ Bool TileData::hasRGBDataForWidth(Int width)
 	if (width == TILE_PIXEL_EXTENT_MIP4) return(true);
 	if (width == TILE_PIXEL_EXTENT_MIP5) return(true);
 	if (width == TILE_PIXEL_EXTENT_MIP6) return(true);
+	if (width == TILE_PIXEL_EXTENT_MIP7) return(true);
+	if (width == TILE_PIXEL_EXTENT_MIP8) return(true);
 	return(false);
 }
 
 UnsignedByte * TileData::getRGBDataForWidth(Int width)
 {
 	// default
-	if (width == TILE_PIXEL_EXTENT_MIP1) return(m_tileDataMip32);
-	if (width == TILE_PIXEL_EXTENT_MIP2) return(m_tileDataMip16);
-	if (width == TILE_PIXEL_EXTENT_MIP3) return(m_tileDataMip8);
-	if (width == TILE_PIXEL_EXTENT_MIP4) return(m_tileDataMip4);
-	if (width == TILE_PIXEL_EXTENT_MIP5) return(m_tileDataMip2);
-	if (width == TILE_PIXEL_EXTENT_MIP6) return(m_tileDataMip1);
+	if (width == TILE_PIXEL_EXTENT_MIP1) return(m_tileDataMip128);
+	if (width == TILE_PIXEL_EXTENT_MIP2) return(m_tileDataMip64);
+	if (width == TILE_PIXEL_EXTENT_MIP3) return(m_tileDataMip32);
+	if (width == TILE_PIXEL_EXTENT_MIP4) return(m_tileDataMip16);
+	if (width == TILE_PIXEL_EXTENT_MIP5) return(m_tileDataMip8);
+	if (width == TILE_PIXEL_EXTENT_MIP6) return(m_tileDataMip4);
+	if (width == TILE_PIXEL_EXTENT_MIP7) return(m_tileDataMip2);
+	if (width == TILE_PIXEL_EXTENT_MIP8) return(m_tileDataMip1);
 	return(m_tileData);
 }
 
 void TileData::updateMips()
 {
-	doMip(m_tileData, TILE_PIXEL_EXTENT, m_tileDataMip32);
-	doMip(m_tileDataMip32, TILE_PIXEL_EXTENT_MIP1, m_tileDataMip16);
-	doMip(m_tileDataMip16, TILE_PIXEL_EXTENT_MIP2, m_tileDataMip8);
-	doMip(m_tileDataMip8, TILE_PIXEL_EXTENT_MIP3, m_tileDataMip4);
-	doMip(m_tileDataMip4, TILE_PIXEL_EXTENT_MIP4, m_tileDataMip2);
-	doMip(m_tileDataMip2, TILE_PIXEL_EXTENT_MIP5, m_tileDataMip1);
+	// GeneralsX @build mrkinglollipop 11/07/2026 Chains each mip level to exactly half the width of its
+	// parent, so doMip's hiRow/2 addressing stays correct all the way down to 1x1.
+	// A naive bump of TILE_PIXEL_EXTENT without adding the 128/64 levels would make
+	// the first doMip() call write a 128x128 result into the old 32x32
+	// m_tileDataMip32 buffer -- a heap/member buffer overflow. Do not collapse levels.
+	doMip(m_tileData, TILE_PIXEL_EXTENT, m_tileDataMip128);
+	doMip(m_tileDataMip128, TILE_PIXEL_EXTENT_MIP1, m_tileDataMip64);
+	doMip(m_tileDataMip64, TILE_PIXEL_EXTENT_MIP2, m_tileDataMip32);
+	doMip(m_tileDataMip32, TILE_PIXEL_EXTENT_MIP3, m_tileDataMip16);
+	doMip(m_tileDataMip16, TILE_PIXEL_EXTENT_MIP4, m_tileDataMip8);
+	doMip(m_tileDataMip8, TILE_PIXEL_EXTENT_MIP5, m_tileDataMip4);
+	doMip(m_tileDataMip4, TILE_PIXEL_EXTENT_MIP6, m_tileDataMip2);
+	doMip(m_tileDataMip2, TILE_PIXEL_EXTENT_MIP7, m_tileDataMip1);
 }
 
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -1011,7 +1011,8 @@ void WorldHeightMap::readTexClass(TXTextureClass *texClass, TileData **tileData)
 	if (theFile != nullptr) {
 		GDIFileStream theStream(theFile);
 		InputStream *pStr = &theStream;
-		Int numTiles = WorldHeightMap::countTiles(pStr);
+		Bool isLegacyGrid = false;
+		Int numTiles = WorldHeightMap::countTiles(pStr, nullptr, texClass->numTiles, &isLegacyGrid);
 		theFile->seek(0, File::START);
 		if (numTiles >= texClass->numTiles) {
 			numTiles = texClass->numTiles;
@@ -1022,7 +1023,7 @@ void WorldHeightMap::readTexClass(TXTextureClass *texClass, TileData **tileData)
 					break;
 				}
 			}
-			WorldHeightMap::readTiles(pStr, tileData+texClass->firstTile, width);
+			WorldHeightMap::readTiles(pStr, tileData+texClass->firstTile, width, isLegacyGrid);
 		}
 		theFile->close();
 	}
@@ -1301,17 +1302,69 @@ typedef struct {
 
 
 
+// GeneralsX @feature mrkinglollipop 11/07/2026 Adds legacy-grid detection so TGAs packed at the pre-patch
+// 64px cell size keep loading now that TILE_PIXEL_EXTENT is 256 (native HD grid cell).
+// Unmodified base-game and custom-map TGAs are still packed as NxN grids of
+// LEGACY_TILE_PIXEL_EXTENT (64px) cells -- the classic pre-patch tile size. Without a
+// fallback, a legacy file's imageWidth/TILE_PIXEL_EXTENT floors to 0 and the file is
+// silently rejected (0 tiles), breaking every unmodified map/mod.
+//
+// Detection rule (documented per plan): try the *native* 256px-cell grid first, but
+// only trust it when it alone can satisfy the texture class's INI-declared tile count
+// (expectedTileCount). This resolves the one genuinely ambiguous width -- 256px, which
+// is simultaneously a valid native 1x1 HD grid AND a valid legacy 4x4 grid of 64px
+// cells (16 tiles) -- because the base game genuinely ships 256px-wide legacy sheets
+// (width census: 32, 64, 128, 256, 640). Any other width where both interpretations
+// divide evenly is treated as legacy too (matches actual on-disk content) -- this is
+// the "treat legacy files as 64-grids by default" simplification. The old "halfTile"
+// sub-tile case (a lone 32x32 image = half of a legacy 64px cell) keeps keying off the
+// legacy half-extent (32), not a new native half-extent, so it matches the same files
+// it always did.
+#define LEGACY_TILE_PIXEL_EXTENT 64
+
+static Bool ChooseTileGrid(Short imageWidth, Short imageHeight, Int expectedTileCount,
+														Int &outTileWidth, Int &outTileHeight, Bool &outIsLegacyGrid)
+{
+	Int nativeW = imageWidth / TILE_PIXEL_EXTENT;
+	Int nativeH = imageHeight / TILE_PIXEL_EXTENT;
+	Bool nativeValid = (nativeW>=1 && nativeW<=10 && nativeH>=1 && nativeH<=10);
+
+	Int legacyW = imageWidth / LEGACY_TILE_PIXEL_EXTENT;
+	Int legacyH = imageHeight / LEGACY_TILE_PIXEL_EXTENT;
+	Bool legacyValid = (legacyW>=1 && legacyW<=10 && legacyH>=1 && legacyH<=10);
+
+	Bool useLegacy;
+	if (nativeValid && legacyValid) {
+		// Ambiguous width: only trust native when the class can't possibly want more
+		// tiles than the (smaller) native grid provides -- i.e. this really is a fresh
+		// HD single/few-tile replacement, not an unmodified legacy sheet.
+		useLegacy = !(expectedTileCount > 0 && expectedTileCount <= nativeW*nativeH);
+	} else if (legacyValid) {
+		useLegacy = true;
+	} else if (nativeValid) {
+		useLegacy = false;
+	} else {
+		return false;
+	}
+
+	outIsLegacyGrid = useLegacy;
+	outTileWidth = useLegacy ? legacyW : nativeW;
+	outTileHeight = useLegacy ? legacyH : nativeH;
+	return true;
+}
+
 /// Count how many tiles come in from a targa file.
-Int WorldHeightMap::countTiles(InputStream *pStr, Bool *halfTile)
+Int WorldHeightMap::countTiles(InputStream *pStr, Bool *halfTile, Int expectedTileCount, Bool *pIsLegacyGrid)
 {
 	TTargaHeader hdr;
 	if (halfTile) {
 		*halfTile = false;
 	}
+	if (pIsLegacyGrid) {
+		*pIsLegacyGrid = false;
+	}
 	Int len = pStr->read(&hdr,sizeof(hdr));
 	if (len!=sizeof(hdr)) return(0);
-	Int tileWidth = hdr.imageWidth/TILE_PIXEL_EXTENT;
-	Int tileHeight = hdr.imageHeight/TILE_PIXEL_EXTENT;
 
 	if (hdr.colorMapType != 0) {
 		return(0); // we don't do indexed at this time. jba.
@@ -1322,41 +1375,65 @@ Int WorldHeightMap::countTiles(InputStream *pStr, Bool *halfTile)
 
 	if (hdr.pixelDepth < 24) return(false);
 	if (hdr.pixelDepth > 32) return(false);
-	// 3x3 gives 9,
-	// 2x2 gives 4,
-	// 1x1 gives 1,
-	// else 0;
-	if (tileWidth>10 || tileHeight>10) return(0);  // don't do huge images, or bad files.
-	if (tileWidth>=10 && tileHeight >=10) return(100);
-	if (tileWidth>=9 && tileHeight >=9) return(81);
-	if (tileWidth>=8 && tileHeight >=8) return(64);
-	if (tileWidth>=7 && tileHeight >=7) return(49);
-	if (tileWidth>=6 && tileHeight >=6) return(36);
-	if (tileWidth>=5 && tileHeight >=5) return(25);
-	if (tileWidth>=4 && tileHeight >=4) return(16);
-	if (tileWidth>=3 && tileHeight >=3) return(9);
-	if (tileWidth>=2 && tileHeight >=2) return(4);
-	if (tileWidth>=1 && tileHeight >=1) return(1);
-	if (halfTile && hdr.imageHeight==TILE_PIXEL_EXTENT/2 && hdr.imageWidth==TILE_PIXEL_EXTENT/2) {
+
+	Int tileWidth, tileHeight;
+	Bool isLegacyGrid = false;
+	if (ChooseTileGrid(hdr.imageWidth, hdr.imageHeight, expectedTileCount, tileWidth, tileHeight, isLegacyGrid)) {
+		if (pIsLegacyGrid) *pIsLegacyGrid = isLegacyGrid;
+		// 3x3 gives 9,
+		// 2x2 gives 4,
+		// 1x1 gives 1,
+		// else 0;
+		if (tileWidth>=10 && tileHeight >=10) return(100);
+		if (tileWidth>=9 && tileHeight >=9) return(81);
+		if (tileWidth>=8 && tileHeight >=8) return(64);
+		if (tileWidth>=7 && tileHeight >=7) return(49);
+		if (tileWidth>=6 && tileHeight >=6) return(36);
+		if (tileWidth>=5 && tileHeight >=5) return(25);
+		if (tileWidth>=4 && tileHeight >=4) return(16);
+		if (tileWidth>=3 && tileHeight >=3) return(9);
+		if (tileWidth>=2 && tileHeight >=2) return(4);
+		if (tileWidth>=1 && tileHeight >=1) return(1);
+	}
+	// Neither native nor legacy full-cell grid fit -- last resort: a lone image half
+	// as wide/tall as one LEGACY cell (32x32), always legacy-scattered.
+	if (halfTile && hdr.imageHeight==LEGACY_TILE_PIXEL_EXTENT/2 && hdr.imageWidth==LEGACY_TILE_PIXEL_EXTENT/2) {
 		*halfTile = true;
+		if (pIsLegacyGrid) *pIsLegacyGrid = true;
 		return 1;
 	}
 	return(0);
 }
-/*Break down a .tga file into a collection of tiles.  numRows * numRows total tiles.*/
-Bool WorldHeightMap::readTiles(InputStream *pStr, TileData **tiles, Int numRows)
+/*Break down a .tga file into a collection of tiles.  numRows * numRows total tiles.
+	isLegacyGrid must be the interpretation countTiles() already chose for this same
+	file (via ChooseTileGrid) -- readTiles does not re-derive it, so the two stay
+	consistent even in the ambiguous-width case. */
+Bool WorldHeightMap::readTiles(InputStream *pStr, TileData **tiles, Int numRows, Bool isLegacyGrid)
 {
 	TTargaHeader hdr;
 	pStr->read(&hdr, sizeof(hdr));
-	Int tileWidth = hdr.imageWidth/TILE_PIXEL_EXTENT;
-	Int tileHeight = hdr.imageHeight/TILE_PIXEL_EXTENT;
 
-	if (hdr.imageHeight==TILE_PIXEL_EXTENT/2) {
+	// Effective source-cell pixel size for this file's grid. scale is how many times
+	// each decoded source pixel is nearest-neighbor replicated per axis into the
+	// native TILE_PIXEL_EXTENT destination cell; scale==1 (no scatter, byte-identical
+	// to the pre-patch loop) for native HD content.
+	Int srcCellExtent = isLegacyGrid ? LEGACY_TILE_PIXEL_EXTENT : TILE_PIXEL_EXTENT;
+
+	Int tileWidth = hdr.imageWidth/srcCellExtent;
+	Int tileHeight = hdr.imageHeight/srcCellExtent;
+
+	// Legacy "halfTile" sub-tile case: a lone image half as wide/tall as one legacy
+	// cell (32x32) represents a single tile; scatter it across the full native tile.
+	if (isLegacyGrid && hdr.imageHeight==srcCellExtent/2) {
 		tileHeight = 1;
 	}
-	if (hdr.imageWidth==TILE_PIXEL_EXTENT/2) {
+	if (isLegacyGrid && hdr.imageWidth==srcCellExtent/2) {
 		tileWidth = 1;
 	}
+	if (isLegacyGrid && (hdr.imageWidth==LEGACY_TILE_PIXEL_EXTENT/2 || hdr.imageHeight==LEGACY_TILE_PIXEL_EXTENT/2)) {
+		srcCellExtent = LEGACY_TILE_PIXEL_EXTENT/2;
+	}
+	Int scale = TILE_PIXEL_EXTENT / srcCellExtent;
 
 	if (tileWidth<numRows && tileHeight<numRows) {
 		return(false);
@@ -1379,7 +1456,7 @@ Bool WorldHeightMap::readTiles(InputStream *pStr, TileData **tiles, Int numRows)
 	int repeatCount = 0;
 //	Bool read = false;
 	Bool running = false;
-	for (row = 0; row < numRows*TILE_PIXEL_EXTENT; row++) {
+	for (row = 0; row < numRows*srcCellExtent; row++) {
 		for (column=0; column<hdr.imageWidth; column++) {
 			UnsignedByte r, g, b, a;
 			if (row < hdr.imageHeight) {
@@ -1408,18 +1485,27 @@ Bool WorldHeightMap::readTiles(InputStream *pStr, TileData **tiles, Int numRows)
 			} else {
 				r = g = b = a = 0;
 			}
-			if (column >= (numRows*TILE_PIXEL_EXTENT)) continue;
-			int tileNdx = (column/TILE_PIXEL_EXTENT) + numRows*(row/TILE_PIXEL_EXTENT);
-			int pixelNdx = (column%TILE_PIXEL_EXTENT) + TILE_PIXEL_EXTENT*(row%TILE_PIXEL_EXTENT);
+			if (column >= (numRows*srcCellExtent)) continue;
+			int tileNdx = (column/srcCellExtent) + numRows*(row/srcCellExtent);
+			int cellCol = column % srcCellExtent;
+			int cellRow = row % srcCellExtent;
 
-			UnsignedByte *pixel = tiles[tileNdx]->getDataPtr();
-
-			pixel += pixelNdx*TILE_BYTES_PER_PIXEL;
-			*pixel++ = b;
-			*pixel++ = g;
-			*pixel++ = r;
-			*pixel = a;
-
+			UnsignedByte *tileBase = tiles[tileNdx]->getDataPtr();
+			// Nearest-neighbor scatter: replicate this one decoded source pixel into
+			// its scale x scale destination block. No row lookahead needed -- the
+			// whole block is written immediately from the single decoded pixel.
+			for (int dy=0; dy<scale; dy++) {
+				int destRow = cellRow*scale+dy;
+				for (int dx=0; dx<scale; dx++) {
+					int destCol = cellCol*scale+dx;
+					int pixelNdx = destCol + TILE_PIXEL_EXTENT*destRow;
+					UnsignedByte *pixel = tileBase + pixelNdx*TILE_BYTES_PER_PIXEL;
+					pixel[0] = b;
+					pixel[1] = g;
+					pixel[2] = r;
+					pixel[3] = a;
+				}
+			}
 		}
 		DEBUG_ASSERTCRASH(repeatCount==0, ("Invalid tga."));
 	}


### PR DESCRIPTION
## Summary

Adds HD terrain support by lifting the hardcoded 64px terrain tile resolution to 256px, so terrain textures can be authored/upscaled at 4x. Stock and custom maps continue to work unchanged via a loader-side fallback.

## Background

`TILE_PIXEL_EXTENT` (64) is baked into `TileData`'s fixed-size mip arrays, and `WorldHeightMap::countTiles/readTiles` integer-divide a source TGA's width by it to infer the tile grid. As a result, simply supplying higher-resolution terrain TGAs does not render sharper — the loader reinterprets the larger image as extra 64px tile variants. Raising the ceiling requires engine changes.

## Changes (all in shared `Core/GameEngineDevice`, so both Generals and Zero Hour build it)

- Bumps `TILE_PIXEL_EXTENT` 64 -> 256 and the terrain atlas `TEXTURE_WIDTH` 2048 -> 8192 (within the 16384 Metal/D3D limit).
- Restructures the `TileData` mip chain from 6 fixed levels (32/16/8/4/2/1) to 8 chained levels (128/64/32/16/8/4/2/1). This is the load-bearing part: a naive constant bump makes the first `doMip()` write a 128x128 result into the old 32x32 member buffer — a buffer overflow. The chain is rebuilt so each level is exactly half its parent down to 1x1.
- Adds a loader-side fallback in `countTiles/readTiles`: legacy 64px-grid TGAs are detected (via the caller's INI-declared tile count) and nearest-neighbour expanded to 256px at load, so unmodified base terrain and existing custom maps keep working. HD terrain TGAs simply override the tiles they replace.

## Compatibility & cost

- Backward compatible: stock terrain and custom maps render via the fallback path; no map format change.
- Per-terrain-tile working memory grows ~16x (about 21 MB -> 333 MB worst case for a ~1000 distinct-tile map). Acceptable on modern hardware; real maps rarely approach that tile count.

## Testing

- Builds clean on macOS arm64 (Apple Silicon), Zero Hour target (`build-macos-zh.sh`), no new warnings.
- Boot-tested three ways, each ~100s to the shell with zero crash/assert markers: (1) patched engine + stock terrain (exercises the legacy fallback), (2) patched engine + 4x HD terrain pack (native 256px path), (3) full launcher run. Rendered-frame inspection of in-match terrain is still pending on the author's side.
- The buffer-overflow trap noted above was specifically checked for and avoided.

## AI-generated code disclosure

Per CONTRIBUTING: this change was developed with substantial LLM assistance (Claude Code) under my direction. Verification performed: full compile on the Zero Hour target, the runtime boot tests above, review of the diff against the engine's terrain/tile data flow, and confirmation the change is comment-and-logic scoped to the terrain tile path. I (the PR author) am responsible for its correctness and have kept the diff readable and commented in the project's `// GeneralsX @keyword` style. Happy to iterate on anything a maintainer flags.

Cut against the `GeneralsX-Beta-13` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
