### PR TITLE
fix(build): add CNC_GENERALS_PATH fallback in zero hour wrappers

### DIFF
--- a/docs/WORKLOG/2026-07-DIARY.md
+++ b/docs/WORKLOG/2026-07-DIARY.md
@@ -1,6 +1,9 @@
 # July 2026
 
 ## 12/07/2026
+### Default CNC_GENERALS_PATH Fallback
+- Defined `CNC_GENERALS_PATH` to default to `~/GeneralsX/Generals` when the variable is empty in the `run.sh` scripts of Zero Hour to address issue #205. This affects the Linux flatpak, linux run/deploy scripts, and macOS bundle/run scripts.
+
 ### Cleanup LAN Lobby Instrumentation
 - Confirmed successful LAN lobby discovery between macOS and Linux.
 - Commented out the temporary debug logs (`fprintf(stderr)`) across network and GUI lobby sources.

--- a/flatpak/com.fbraz3.GeneralsXZH.yml
+++ b/flatpak/com.fbraz3.GeneralsXZH.yml
@@ -131,6 +131,11 @@ modules:
           export ALSOFT_DRIVERS="pulse,alsa,oss,jack,null,wave"
         fi
 
+        # GeneralsX @bugfix felipebraz 12/07/2026 Default CNC_GENERALS_PATH to ~/GeneralsX/Generals if empty (Issue #205)
+        if [[ -z "${CNC_GENERALS_PATH:-}" ]]; then
+          export CNC_GENERALS_PATH="${HOME}/GeneralsX/Generals"
+        fi
+
         if [[ -z "${CNC_GENERALS_INSTALLPATH:-}" ]]; then
           for candidate in \
             "${HOME}/GeneralsX/GeneralsZH" \

--- a/scripts/build/linux/deploy-linux-zh.sh
+++ b/scripts/build/linux/deploy-linux-zh.sh
@@ -202,6 +202,11 @@ if [[ -f "${SCRIPT_DIR}/libsage_patch.so" && "${SAGE_PATCH_DISABLED:-0}" != "1" 
     fi
 fi
 
+# GeneralsX @bugfix felipebraz 12/07/2026 Default CNC_GENERALS_PATH to ~/GeneralsX/Generals if empty (Issue #205)
+if [[ -z "${CNC_GENERALS_PATH:-}" ]]; then
+    export CNC_GENERALS_PATH="${HOME}/GeneralsX/Generals"
+fi
+
 # GeneralsX @feature felipebraz 25/02/2026 Auto-detect base Generals install path
 # Set CNC_GENERALS_INSTALLPATH if not already set and ../Generals/ exists
 if [[ -z "${CNC_GENERALS_INSTALLPATH:-}" && -d "${SCRIPT_DIR}/../Generals" ]]; then

--- a/scripts/build/linux/run-linux-zh.sh
+++ b/scripts/build/linux/run-linux-zh.sh
@@ -94,6 +94,11 @@ if [[ -z "${ALSOFT_DRIVERS:-}" ]]; then
     echo "INFO: OpenAL: ALSOFT_DRIVERS=$ALSOFT_DRIVERS (pipewire excluded)"
 fi
 
+# GeneralsX @bugfix felipebraz 12/07/2026 Default CNC_GENERALS_PATH to ~/GeneralsX/Generals if empty (Issue #205)
+if [[ -z "${CNC_GENERALS_PATH:-}" ]]; then
+    export CNC_GENERALS_PATH="${HOME}/GeneralsX/Generals"
+fi
+
 # GeneralsX @feature felipebraz 18/02/2026 - Base Generals path and language are
 # auto-detected by the game from filesystem (ZH_Generals/ or ../Generals/).
 # Override by setting CNC_GENERALS_INSTALLPATH and/or CNC_ZH_LANGUAGE explicitly.

--- a/scripts/build/macos/bundle-macos-zh.sh
+++ b/scripts/build/macos/bundle-macos-zh.sh
@@ -401,7 +401,10 @@ fi
 
 # GeneralsX @bugfix BenderAI 01/04/2026 Select default Zero Hour asset path by .big presence, with GeneralsMD fallback.
 # Default asset paths matching the standard macOS deploy layout (allow user override)
-export CNC_GENERALS_PATH="${CNC_GENERALS_PATH:-${HOME}/GeneralsX/Generals}"
+# GeneralsX @bugfix felipebraz 12/07/2026 Default CNC_GENERALS_PATH to ~/GeneralsX/Generals if empty (Issue #205)
+if [[ -z "${CNC_GENERALS_PATH:-}" ]]; then
+    export CNC_GENERALS_PATH="${HOME}/GeneralsX/Generals"
+fi
 if [[ -z "${CNC_GENERALS_ZH_PATH:-}" ]]; then
     if [[ -d "${HOME}/GeneralsX/GeneralsZH" && -n "$(compgen -G "${HOME}/GeneralsX/GeneralsZH/*.big" 2>/dev/null)" ]]; then
         export CNC_GENERALS_ZH_PATH="${HOME}/GeneralsX/GeneralsZH"

--- a/scripts/build/macos/deploy-macos-zh.sh
+++ b/scripts/build/macos/deploy-macos-zh.sh
@@ -216,6 +216,11 @@ if [[ -f "\${SCRIPT_DIR}/fontconfig/fonts.conf" ]]; then
     export FONTCONFIG_PATH="\${SCRIPT_DIR}/fontconfig"
 fi
 
+# GeneralsX @bugfix felipebraz 12/07/2026 Default CNC_GENERALS_PATH to ~/GeneralsX/Generals if empty (Issue #205)
+if [[ -z "\${CNC_GENERALS_PATH:-}" ]]; then
+    export CNC_GENERALS_PATH="\${HOME}/GeneralsX/Generals"
+fi
+
 # Auto-detect base Generals install path
 if [[ -z "\${CNC_GENERALS_INSTALLPATH:-}" && -d "\${SCRIPT_DIR}/../Generals" ]]; then
     export CNC_GENERALS_INSTALLPATH="\${SCRIPT_DIR}/../Generals/"

--- a/scripts/build/macos/run-macos-zh.sh
+++ b/scripts/build/macos/run-macos-zh.sh
@@ -79,6 +79,11 @@ else
     echo "WARNING: ${GAME_DIR}/fontconfig/fonts.conf not found; text rendering may fail."
 fi
 
+# GeneralsX @bugfix felipebraz 12/07/2026 Default CNC_GENERALS_PATH to ~/GeneralsX/Generals if empty (Issue #205)
+if [[ -z "${CNC_GENERALS_PATH:-}" ]]; then
+    export CNC_GENERALS_PATH="${HOME}/GeneralsX/Generals"
+fi
+
 # GeneralsX @tweak BenderAI 13/03/2026 Optional shader-cache reset for terrain debugging.
 # Use GX_CLEAR_DXVK_SHADER_CACHE=1 to force fresh shader compilation.
 if [[ "${GX_CLEAR_DXVK_SHADER_CACHE:-0}" == "1" ]]; then


### PR DESCRIPTION
## Description
Added fallback for \`CNC_GENERALS_PATH\` in Zero Hour deployment wrappers (Linux and macOS) as well as the Flatpak manifest, defaulting to \`~/GeneralsX/Generals\` when the environment variable is empty.

Fixes #205

## Changes
- Updated \`scripts/build/linux/run-linux-zh.sh\`
- Updated \`scripts/build/macos/run-macos-zh.sh\`
- Updated \`scripts/build/linux/deploy-linux-zh.sh\`
- Updated \`scripts/build/macos/deploy-macos-zh.sh\`
- Updated \`scripts/build/macos/bundle-macos-zh.sh\`
- Updated \`flatpak/com.fbraz3.GeneralsXZH.yml\`
- Documented changes in \`docs/WORKLOG/2026-07-DIARY.md\`
