### PR TITLE
fix(gui): prevent options menu crash due to null advanced display window

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -893,12 +893,18 @@ static void DestroyOptionsLayout() {
 
 static void showAdvancedOptions()
 {
-	WinAdvancedDisplay->winHide(FALSE);
+	if (WinAdvancedDisplay)
+	{
+		WinAdvancedDisplay->winHide(FALSE);
+	}
 }
 
 static void acceptAdvancedOptions()
 {
-	WinAdvancedDisplay->winHide(TRUE);
+	if (WinAdvancedDisplay)
+	{
+		WinAdvancedDisplay->winHide(TRUE);
+	}
 }
 
 static void cancelAdvancedOptions()
@@ -906,7 +912,10 @@ static void cancelAdvancedOptions()
 	//restore the detail selection back to initial state
 	GadgetComboBoxSetSelectedPos(comboBoxDetail, (Int)TheGameLODManager->getStaticLODLevel());
 
-	WinAdvancedDisplay->winHide(TRUE);
+	if (WinAdvancedDisplay)
+	{
+		WinAdvancedDisplay->winHide(TRUE);
+	}
 }
 
 // TheSuperHackers @tweak Now prints additional version information in the version label.
@@ -1041,7 +1050,10 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 	sliderParticleCapID = TheNameKeyGenerator->nameToKey( "OptionsMenu.wnd:ParticleCapSlider" );
   sliderParticleCap = TheWindowManager->winGetWindowFromId( nullptr, sliderParticleCapID );
 
-	WinAdvancedDisplay->winHide(TRUE);
+	if (WinAdvancedDisplay)
+	{
+		WinAdvancedDisplay->winHide(TRUE);
+	}
 
 	Color color =  GameMakeColor(255,255,255,255);
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -921,12 +921,18 @@ static void DestroyOptionsLayout() {
 
 static void showAdvancedOptions()
 {
-	WinAdvancedDisplay->winHide(FALSE);
+	if (WinAdvancedDisplay)
+	{
+		WinAdvancedDisplay->winHide(FALSE);
+	}
 }
 
 static void acceptAdvancedOptions()
 {
-	WinAdvancedDisplay->winHide(TRUE);
+	if (WinAdvancedDisplay)
+	{
+		WinAdvancedDisplay->winHide(TRUE);
+	}
 }
 
 static void cancelAdvancedOptions()
@@ -934,7 +940,10 @@ static void cancelAdvancedOptions()
 	//restore the detail selection back to initial state
 	GadgetComboBoxSetSelectedPos(comboBoxDetail, (Int)TheGameLODManager->getStaticLODLevel());
 
-	WinAdvancedDisplay->winHide(TRUE);
+	if (WinAdvancedDisplay)
+	{
+		WinAdvancedDisplay->winHide(TRUE);
+	}
 }
 
 // TheSuperHackers @tweak Now prints additional version information in the version label.
@@ -1076,7 +1085,10 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 	sliderParticleCapID = TheNameKeyGenerator->nameToKey( "OptionsMenu.wnd:ParticleCapSlider" );
   sliderParticleCap = TheWindowManager->winGetWindowFromId( nullptr, sliderParticleCapID );
 
-	WinAdvancedDisplay->winHide(TRUE);
+	if (WinAdvancedDisplay)
+	{
+		WinAdvancedDisplay->winHide(TRUE);
+	}
 
 	Color color =  GameMakeColor(255,255,255,255);
 

--- a/docs/WORKLOG/2026-07-DIARY.md
+++ b/docs/WORKLOG/2026-07-DIARY.md
@@ -38,3 +38,9 @@ Both issues have been resolved by adding proper counting filters in MiniAudio an
 - Preserved bone positioning logic in `SlavedUpdate.cpp` and fixed pointer dereferencing for `Coord3D` operations (`*obj->getPosition()`).
 - Accepted the upstream re-organization of GameClient UI code and removed deprecated ControlBar files.
 - Ensured deterministic math usage and successfully built the macOS target (`macos-vulkan`).
+
+## 13/07/2026
+### Options Menu Crash Fix
+- Fixed segmentation fault (Issue #192) when opening the Options menu in the base game (Command & Conquer Generals).
+- The crash was caused by unconditional calls to `winHide()` on `WinAdvancedDisplay`, which is null because `WinAdvancedDisplayOptions` only exists in Zero Hour's `OptionsMenu.wnd` and not in the base game's layout.
+- Added null checks before `WinAdvancedDisplay->winHide()` across `OptionsMenu.cpp` in both `GeneralsMD` and `Generals` codebases.


### PR DESCRIPTION
## Description
Fixes #192

## Context
When entering the Options menu in the base game (Command & Conquer Generals), the game crashes with a segmentation fault.

## Changes
- Wrapped all calls to `WinAdvancedDisplay->winHide()` inside `OptionsMenu.cpp` (both in `GeneralsMD` and `Generals`) with an `if (WinAdvancedDisplay)` check.
- The base game's layout does not define `WinAdvancedDisplayOptions`, which leads to the `WinAdvancedDisplay` pointer being `nullptr` and causing the segfault upon dereferencing.
