### PR TITLE
UI: Scale fonts on high resolutions for tooltips and menus

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
+          export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
           echo "Installing macOS build dependencies..."
           
           # Update Homebrew to ensure fresh formulas

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -3843,8 +3843,13 @@ GameFont *ControlBar::overrideTooltipGadgetFont( GameWindow *win )
 	if( TheGlobalLanguageData && TheGlobalLanguageData->m_unicodeFontName.isNotEmpty() )
 		fontName = TheGlobalLanguageData->m_unicodeFontName;
 
-	// Get the font from the font library (12pt, not bold)
-	GameFont *newFont = TheFontLibrary->getFont( fontName, 12, FALSE );
+	// Scale the font size for high resolutions (Issue #183)
+	int baseSize = 12;
+	float scaleY = TheDisplay ? ((float)TheDisplay->getHeight() / 600.0f) : 1.0f;
+	int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY) : baseSize;
+
+	// Get the font from the font library (scaled size, not bold)
+	GameFont *newFont = TheFontLibrary->getFont( fontName, scaledSize, FALSE );
 	if( !newFont )
 		return nullptr;
 

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -3846,7 +3846,8 @@ GameFont *ControlBar::overrideTooltipGadgetFont( GameWindow *win )
 	// Scale the font size for high resolutions (Issue #183)
 	int baseSize = 12;
 	float scaleY = TheDisplay ? ((float)TheDisplay->getHeight() / 600.0f) : 1.0f;
-	int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY) : baseSize;
+	int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY * 0.70f) : baseSize;
+	if (scaledSize < baseSize) scaledSize = baseSize;
 
 	// Get the font from the font library (scaled size, not bold)
 	GameFont *newFont = TheFontLibrary->getFont( fontName, scaledSize, FALSE );

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -435,7 +435,8 @@ static void initLabelVersion()
 				// GeneralsX @tweak BenderAI 31/03/2026 Keep fallback watermark subtle and aligned to bottom-left target placement.
 				int baseSize = 12;
 				float scaleY = TheDisplay ? ((float)TheDisplay->getHeight() / 600.0f) : 1.0f;
-				int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY) : baseSize;
+				int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY * 0.70f) : baseSize;
+				if (scaledSize < baseSize) scaledSize = baseSize;
 				fallbackCreditLabel->winSetFont(TheWindowManager->winFindFont("Arial", scaledSize, FALSE));
 				fallbackCreditLabel->winSetEnabledTextColors(GameMakeColor(255, 220, 60, 255), GameMakeColor(0, 0, 0, 0));
 				GadgetStaticTextSetText(fallbackCreditLabel, creditText);
@@ -857,7 +858,8 @@ void MainMenuUpdate( WindowLayout *layout, void *userData )
 			{
 				int baseSize = 10;
 				float scaleY = TheDisplay ? ((float)TheDisplay->getHeight() / 600.0f) : 1.0f;
-				int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY) : baseSize;
+				int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY * 0.70f) : baseSize;
+				if (scaledSize < baseSize) scaledSize = baseSize;
 				GameFont* font = TheWindowManager->winFindFont("Arial", scaledSize, FALSE);
 				if (font)
 					updateNotifyButton->winSetFont(font);

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -433,7 +433,10 @@ static void initLabelVersion()
 			if (fallbackCreditLabel)
 			{
 				// GeneralsX @tweak BenderAI 31/03/2026 Keep fallback watermark subtle and aligned to bottom-left target placement.
-				fallbackCreditLabel->winSetFont(TheWindowManager->winFindFont("Arial", 12, FALSE));
+				int baseSize = 12;
+				float scaleY = TheDisplay ? ((float)TheDisplay->getHeight() / 600.0f) : 1.0f;
+				int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY) : baseSize;
+				fallbackCreditLabel->winSetFont(TheWindowManager->winFindFont("Arial", scaledSize, FALSE));
 				fallbackCreditLabel->winSetEnabledTextColors(GameMakeColor(255, 220, 60, 255), GameMakeColor(0, 0, 0, 0));
 				GadgetStaticTextSetText(fallbackCreditLabel, creditText);
 			}
@@ -852,7 +855,10 @@ void MainMenuUpdate( WindowLayout *layout, void *userData )
 
 			if (updateNotifyButton)
 			{
-				GameFont* font = TheWindowManager->winFindFont("Arial", 10, FALSE);
+				int baseSize = 10;
+				float scaleY = TheDisplay ? ((float)TheDisplay->getHeight() / 600.0f) : 1.0f;
+				int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY) : baseSize;
+				GameFont* font = TheWindowManager->winFindFont("Arial", scaledSize, FALSE);
 				if (font)
 					updateNotifyButton->winSetFont(font);
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -469,7 +469,8 @@ static void initLabelVersion()
 				// GeneralsX @tweak BenderAI 31/03/2026 Keep fallback watermark subtle and aligned to bottom-left target placement.
 				int baseSize = 12;
 				float scaleY = TheDisplay ? ((float)TheDisplay->getHeight() / 600.0f) : 1.0f;
-				int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY) : baseSize;
+				int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY * 0.70f) : baseSize;
+				if (scaledSize < baseSize) scaledSize = baseSize;
 				fallbackCreditLabel->winSetFont(TheWindowManager->winFindFont("Arial", scaledSize, FALSE));
 				fallbackCreditLabel->winSetEnabledTextColors(GameMakeColor(255, 220, 60, 255), GameMakeColor(0, 0, 0, 0));
 				GadgetStaticTextSetText(fallbackCreditLabel, creditText);
@@ -900,7 +901,8 @@ void MainMenuUpdate( WindowLayout *layout, void *userData )
 			{
 				int baseSize = 10;
 				float scaleY = TheDisplay ? ((float)TheDisplay->getHeight() / 600.0f) : 1.0f;
-				int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY) : baseSize;
+				int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY * 0.70f) : baseSize;
+				if (scaledSize < baseSize) scaledSize = baseSize;
 				GameFont* font = TheWindowManager->winFindFont("Arial", scaledSize, FALSE);
 				if (font)
 					updateNotifyButton->winSetFont(font);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -467,7 +467,10 @@ static void initLabelVersion()
 			if (fallbackCreditLabel)
 			{
 				// GeneralsX @tweak BenderAI 31/03/2026 Keep fallback watermark subtle and aligned to bottom-left target placement.
-				fallbackCreditLabel->winSetFont(TheWindowManager->winFindFont("Arial", 12, FALSE));
+				int baseSize = 12;
+				float scaleY = TheDisplay ? ((float)TheDisplay->getHeight() / 600.0f) : 1.0f;
+				int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY) : baseSize;
+				fallbackCreditLabel->winSetFont(TheWindowManager->winFindFont("Arial", scaledSize, FALSE));
 				fallbackCreditLabel->winSetEnabledTextColors(GameMakeColor(255, 220, 60, 255), GameMakeColor(0, 0, 0, 0));
 				GadgetStaticTextSetText(fallbackCreditLabel, creditText);
 			}
@@ -895,7 +898,10 @@ void MainMenuUpdate( WindowLayout *layout, void *userData )
 
 			if (updateNotifyButton)
 			{
-				GameFont* font = TheWindowManager->winFindFont("Arial", 10, FALSE);
+				int baseSize = 10;
+				float scaleY = TheDisplay ? ((float)TheDisplay->getHeight() / 600.0f) : 1.0f;
+				int scaledSize = (scaleY > 1.0f) ? (int)(baseSize * scaleY) : baseSize;
+				GameFont* font = TheWindowManager->winFindFont("Arial", scaledSize, FALSE);
 				if (font)
 					updateNotifyButton->winSetFont(font);
 

--- a/docs/WORKLOG/2026-07-DIARY.md
+++ b/docs/WORKLOG/2026-07-DIARY.md
@@ -38,3 +38,8 @@ Both issues have been resolved by adding proper counting filters in MiniAudio an
 - Preserved bone positioning logic in `SlavedUpdate.cpp` and fixed pointer dereferencing for `Coord3D` operations (`*obj->getPosition()`).
 - Accepted the upstream re-organization of GameClient UI code and removed deprecated ControlBar files.
 - Ensured deterministic math usage and successfully built the macOS target (`macos-vulkan`).
+
+## 13/07/2026
+### UI Font Scaling at High Resolutions
+- Addressed issue #183 where tooltip fonts, the update button, and the GeneralsX credits label appeared too small at resolutions > 1280x800.
+- Implemented dynamic scaling in `ControlBar::overrideTooltipGadgetFont` and `MainMenu.cpp` based on the display height relative to the design height of 600.


### PR DESCRIPTION
## Description
Fixes #183

## Changes
- Dynamically scale tooltip text based on display height relative to 600px
- Scale the Update Notify button size on MainMenu
- Scale the GeneralsX watermark/credits label size on MainMenu
