### PR TITLE
bugfix: Re-assert FP mode in mouse pick to fix wrong click location with audio active

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -68,6 +68,7 @@
 #include "GameLogic/AI.h"			///< For AI debug (yes, I'm cheating for now)
 #include "GameLogic/AIPathfind.h"			///< For AI debug (yes, I'm cheating for now)
 #include "GameLogic/ExperienceTracker.h"
+#include "GameLogic/FPUControl.h"							///< GeneralsX @bugfix costin-alupului 10/07/2026 setFPMode() to guard screen->world pick math against audio-thread FP env leaks
 #include "GameLogic/GameLogic.h"
 #include "GameLogic/Module/AIUpdate.h"
 #include "GameLogic/Module/BodyModule.h"
@@ -2520,6 +2521,9 @@ Drawable *W3DView::pickDrawable( const ICoord2D *screen, Bool forceAttack, PickT
 	if( screen == nullptr )
 		return nullptr;
 
+	// GeneralsX @bugfix costin-alupului 10/07/2026 Re-assert FP mode before the pick ray math (see screenToTerrain).
+	setFPMode();
+
 	// don't pick a drawable if there is a window under the cursor
 	GameWindow *window = nullptr;
 	if (TheWindowManager)
@@ -2574,6 +2578,14 @@ Bool W3DView::screenToTerrain( const ICoord2D *screen, Coord3D *world )
 {
 	if( screen == nullptr || world == nullptr || TheTerrainRenderObject == nullptr )
 		return false;
+
+	// GeneralsX @bugfix costin-alupului 10/07/2026 The screen->world ray/intersection math below
+	// relies on a consistent FP rounding/environment (same reason GameLogic::update() calls
+	// setFPMode()). On macOS/ARM the audio backend thread can leave the FP environment in a state
+	// that skews the fast float->int coordinate conversion, causing clicks to resolve to the wrong
+	// world tile (move/build fail unless the camera is moved/zoomed to force a recompute). Re-assert
+	// the engine's FP mode here so picks are correct regardless of audio-thread activity.
+	setFPMode();
 
 	if (m_cameraHasMovedSinceRequest) {
 		m_locationRequests.clear();


### PR DESCRIPTION
## Summary
Fixes #215. On macOS/ARM, move orders and building placement resolve to the **wrong world location whenever game audio is active** — selection/box-drag work (screen-space), but any screen→world terrain pick lands on the wrong tile. Disabling sound makes it disappear entirely.

## Root cause
The engine relies on a specific FPU mode for its fast float→int conversions; `GameLogic::update()` calls `setFPMode()` every frame for this. But `W3DView::screenToTerrain()` and `W3DView::pickDrawable()` do their ray/coordinate math with no such guard. On macOS/ARM the OpenAL audio thread leaves the FP environment in a state that skews these conversions, so picks resolve incorrectly while audio plays.

## Fix
Call the engine's existing `setFPMode()` at the top of both pick functions. 12 lines, no behavior change beyond re-asserting the mode the engine already expects. As `W3DView.cpp` is shared under `Core/`, this covers both Zero Hour and Generals.

## Testing
Verified in-game on latest `main` (post-Beta-14), audio on, on three displays at native fullscreen (2560×1440, 3440×1440, 5120×1440): move/build clicks land correctly across the whole screen, and an apparently-related camera-jump freeze is also resolved.

## Note on the mechanism
The audio-thread FP-env leak is inferred from the strong audio-on/off correlation and the fix working, not from instrumenting FP registers. If you'd prefer preventing the audio thread from altering the FP env at its source rather than re-asserting at point-of-use, happy to adjust.

## AI disclosure
Per CONTRIBUTING: change was authored with AI assistance (Claude). I reviewed, tested, and verified the code and vouch for its correctness.