### PR TITLE
bugfix(challenge): Fix Generals Challenge defeat during next mission intro cinematic

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -192,8 +192,18 @@ void populateSideInfo( UnicodeString side,ScoreGather *sg, Int pos, Color color)
 
 void startNextCampaignGame()
 {
-	TheShell->popImmediate();
-	TheShell->hideShell();
+	// GeneralsX @bugfix coolswood 18/07/2026 Fix Generals Challenge defeat during the next mission's intro cinematic.
+	// The previous ordering performed popImmediate()/hideShell() before queuing MSG_NEW_GAME(GAME_SINGLE_PLAYER).
+	// Hiding the shell triggers the next menu's init (e.g. SaveLoad), which calls Shell::showShellMap(TRUE),
+	// and showShellMap appends its own MSG_NEW_GAME(GAME_SHELL) for the shell map and overwrites m_pendingFile
+	// with the shell map name. That GAME_SHELL message then races ahead of the GAME_SINGLE_PLAYER message and
+	// is processed first by onNewGame(): with m_gameMode == GAME_SHELL the isChallengeCampaign check is false,
+	// TheGameInfo stays null, placeNetworkBuildingsForPlayer() is skipped, the local player never receives a
+	// starting base, and the map's "PLAYER_HAS_N_OR_FEWER_BUILDINGS" script fires doDefeat() a few frames after
+	// the map loads (visible as the defeat screen during the intro cinematic). Fix: set m_pendingFile and queue
+	// MSG_NEW_GAME(GAME_SINGLE_PLAYER) BEFORE the shell teardown so our message is first in the queue, and
+	// re-assert m_pendingFile afterwards in case Shell::showShellMap clobbered it. The shell's duplicate
+	// MSG_NEW_GAME(GAME_SHELL) now lands behind ours and is rejected by the onNewGame() guard.
 	TheWritableGlobalData->m_pendingFile = TheCampaignManager->getCurrentMap();
 	if (TheCampaignManager->getCurrentCampaign() && TheCampaignManager->getCurrentCampaign()->isChallengeCampaign())
 	{
@@ -215,11 +225,19 @@ void startNextCampaignGame()
 			TheGameLogic->clearGameData();
 	}
 
-	// send a message to the logic for a new game
+	// Queue MSG_NEW_GAME(GAME_SINGLE_PLAYER) before popImmediate()/hideShell(): this guarantees it sits ahead
+	// of any MSG_NEW_GAME(GAME_SHELL) that the shell teardown may append via Shell::showShellMap(TRUE).
 	GameMessage *msg = TheMessageStream->appendMessage( GameMessage::MSG_NEW_GAME );
 	msg->appendIntegerArgument(GAME_SINGLE_PLAYER);
 	msg->appendIntegerArgument(TheCampaignManager->getGameDifficulty());
 	msg->appendIntegerArgument(TheCampaignManager->getRankPoints());
+
+	TheShell->popImmediate();
+	TheShell->hideShell();
+
+	// Re-assert the real pending file: prepareNewGame() copies m_pendingFile into m_mapName, so the value
+	// present here is what actually loads. Shell::showShellMap(TRUE) may have overwritten it above.
+	TheWritableGlobalData->m_pendingFile = TheCampaignManager->getCurrentMap();
 
 	InitRandom(0);
 }


### PR DESCRIPTION
## Change

Fixes a defeat screen appearing during the intro cinematic when continuing from one Generals Challenge mission to the next via the score screen Continue button.

## Root cause

`startNextCampaignGame()` performed `popImmediate()`/`hideShell()` **before** queuing `MSG_NEW_GAME(GAME_SINGLE_PLAYER)`. Hiding the shell triggers the next menu's init (e.g. SaveLoad), which calls `Shell::showShellMap(TRUE)`. That appends its own `MSG_NEW_GAME(GAME_SHELL)` for the shell map and overwrites `m_pendingFile` with the shell map name.

That `GAME_SHELL` message then races ahead of the `GAME_SINGLE_PLAYER` message and is processed first by `onNewGame()`:
1. `m_gameMode` becomes `GAME_SHELL`
2. the `isChallengeCampaign` check in `tryStartNewGame()` evaluates to `false` (it requires `m_gameMode == GAME_SINGLE_PLAYER`)
3. `TheGameInfo` stays `null`
4. `placeNetworkBuildingsForPlayer()` is skipped
5. the local player never receives a starting base
6. the map's `PLAYER_HAS_N_OR_FEWER_BUILDINGS` script fires `doDefeat()` a few frames after the map loads, visible as the defeat screen during the intro cinematic

The actual `GAME_SINGLE_PLAYER` message is subsequently rejected by the `onNewGame()` guard (`isInGame || isLoadingMap`), so the wrong map/mode combination loads.

The bug only reproduces on the Continue path. Loading the same save directly via Load Game works because that path uses `MSG_NEW_GAME` with `GAME_SINGLE_PLAYER` and does not trigger the shell map race.

## Fix

Reorder `startNextCampaignGame()` so that:
- `m_pendingFile` is set to the current campaign map **before** any shell teardown
- `MSG_NEW_GAME(GAME_SINGLE_PLAYER)` is queued **before** `popImmediate()`/`hideShell()`, guaranteeing it sits ahead of any `MSG_NEW_GAME(GAME_SHELL)` appended by `Shell::showShellMap(TRUE)`
- `m_pendingFile` is re-asserted **after** the shell teardown, since `Shell::showShellMap(TRUE)` may have overwritten it with the shell map name (and `prepareNewGame()` copies `m_pendingFile` into `m_mapName`, so the value present at queue-drain time is what actually loads)

The shell's duplicate `MSG_NEW_GAME(GAME_SHELL)` now lands behind ours and is rejected by the existing `onNewGame()` guard.

## Verification

Tested on macOS (Apple Silicon), preset `macos-vulkan`:
- Before the fix: Load `gc_americaboss` -> win -> Continue -> next mission (`GC_TankGeneral`) loads and shows the defeat screen during the intro cinematic; the map has 0 objects owned by the local player.
- After the fix: same scenario -> next mission starts normally, the local player receives a starting base, no defeat during the cinematic.

Instrumented trace (added temporarily during investigation, not part of this PR) confirmed the message ordering: without the fix the first `onNewGame()` call received `gameMode == GAME_SHELL`; with the fix it receives `gameMode == GAME_SINGLE_PLAYER` and the shell's follow-up message is rejected.

## Scope

Single file, single function (`ScoreScreen.cpp::startNextCampaignGame()`). No gameplay balance, AI or rendering changes. Applies to Zero Hour only; the Generals replica can follow in a follow-up PR per the contribution guidelines if desired.

## AI generated code

The fix was authored with LLM assistance and polished/tested by the author (coolswood). The change is 21 inserted lines (one reorder plus explanatory comments) in a single function.