### PR TITLE
fix(input): resolve SDL3Mouse ODR violation causing dropped clicks

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -27,7 +27,7 @@
 
 #ifndef _WIN32
 
-#include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
+#include "Common/GameCommon.h" // Adicionado para corrigir ODR violation (traz DUMP_PERF_STATS)
 
 // GeneralsX @bugfix BenderAI 13/02/2026 Fix include path (fighter19 pattern)
 #include "SDL3Device/GameClient/SDL3Mouse.h"

--- a/Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -27,6 +27,8 @@
 
 #ifndef _WIN32
 
+#include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
+
 // GeneralsX @bugfix BenderAI 13/02/2026 Fix include path (fighter19 pattern)
 #include "SDL3Device/GameClient/SDL3Mouse.h"
 #include <cstdio>

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -27,7 +27,7 @@
 
 #ifndef _WIN32
 
-#include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
+#include "Common/GameCommon.h" // Adicionado para corrigir ODR violation (traz DUMP_PERF_STATS)
 
 // GeneralsX @bugfix BenderAI 13/02/2026 Fix include path (fighter19 pattern)
 #include "SDL3Device/GameClient/SDL3Mouse.h"

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -27,6 +27,8 @@
 
 #ifndef _WIN32
 
+#include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
+
 // GeneralsX @bugfix BenderAI 13/02/2026 Fix include path (fighter19 pattern)
 #include "SDL3Device/GameClient/SDL3Mouse.h"
 #include <cstdio>


### PR DESCRIPTION
## Description
Fixes #231

## Changes
- Add missing `#include "PreRTS.h"` in `SDL3Mouse.cpp` for both Generals and Zero Hour to resolve an ODR violation regarding the `DUMP_PERF_STATS` macro, ensuring the `SubsystemInterface` layout is correctly sized so the virtual `update()` dispatch executes.
