### PR TITLE
fix(ui): load game HUD overlay bug on macOS

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupSaveLoad.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupSaveLoad.cpp
@@ -398,7 +398,8 @@ static void doLoadGame()
 		return;
 
 	// when loading a game we also close the quit/esc menu for the user when in-game
-	if( TheShell->isShellActive() == FALSE )
+	// GeneralsX @bugfix fbraz 22/07/2026 Use isPopup to correctly identify if the load menu was invoked from the in-game popup menu or the main menu shell. TheShell->isShellActive() might have already been mutated to FALSE by a prior call to closeSaveMenu().
+	if( isPopup )
 	{
 		destroyQuitMenu();
 //		ToggleQuitMenu();

--- a/docs/WORKLOG/2026-07-DIARY.md
+++ b/docs/WORKLOG/2026-07-DIARY.md
@@ -1,5 +1,11 @@
 # July 2026
 
+## 22/07/2026
+### Fix Campaign Load HUD Overlay Bug (Issue 221)
+- Fixed an issue on macOS (and other platforms) where loading a normal save game from the Main Menu left the HUD overlay and Load/Save window on screen, making the game unplayable.
+- Resolved a state race condition in `PopupSaveLoad.cpp`: `doLoadGame()` was checking `TheShell->isShellActive() == FALSE` to determine if the load was triggered from an in-game menu. However, this flag was prematurely cleared by `closeSaveMenu()` when triggered from the Main Menu.
+- Replaced the failing check with the static `isPopup` flag, which reliably indicates the origin of the load menu (in-game vs fullscreen shell). This restores the proper `TheGameLogic->prepareNewGame(...)` teardown sequence.
+
 ## 17/07/2026
 ### Fix Non-Deterministic Math in WWMath Matrix Classes
 - Traced the cross-platform desync at frame 100 to the `TrainCabUngarrisonable` object's translation matrix diverging between macOS (ARM64) and Linux (x86_64).


### PR DESCRIPTION
## Description
Fixes #221

## Changes
- Fixed an issue on macOS (and other platforms) where loading a normal save game from the Main Menu left the HUD overlay and Load/Save window on screen, making the game unplayable.
- Resolved a state race condition in `PopupSaveLoad.cpp` where `doLoadGame()` was checking `TheShell->isShellActive() == FALSE` after it was prematurely cleared by `closeSaveMenu()`.
- Replaced the check with the static `isPopup` flag, which reliably indicates the origin of the load menu (in-game vs fullscreen shell). This restores the proper `TheGameLogic->prepareNewGame(...)` teardown sequence.
