### PR TITLE
fix(contain): remove destroyed detached occupants

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1443,7 +1443,9 @@ void OpenContain::processDamageToContained(Real percentDamage)
 		if( !object->isEffectivelyDead() && killContained )
 			object->kill(); // in case we are carrying flame proof troops we have been asked to kill
 
-		if ( object->isEffectivelyDead() )
+		// TheSuperHackers @bugfix mreza0100 23/07/2026 A destroyed occupant cannot remove itself
+		// while the contain list is temporarily detached. Do not restore a pending dangling pointer.
+		if ( object->isEffectivelyDead() || object->isDestroyed() )
 		{
 			onRemoving( object );
 			object->onRemovedFrom( getObject() );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1443,7 +1443,7 @@ void OpenContain::processDamageToContained(Real percentDamage)
 		if( !object->isEffectivelyDead() && killContained )
 			object->kill(); // in case we are carrying flame proof troops we have been asked to kill
 
-		// TheSuperHackers @bugfix mreza0100 23/07/2026 A destroyed occupant cannot remove itself
+		// GeneralsX @bugfix mreza0100 23/07/2026 A destroyed occupant cannot remove itself
 		// while the contain list is temporarily detached. Do not restore a pending dangling pointer.
 		if ( object->isEffectivelyDead() || object->isDestroyed() )
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1587,7 +1587,9 @@ void OpenContain::processDamageToContained(Real percentDamage)
 		if( !object->isEffectivelyDead() && killContained )
 			object->kill(); // in case we are carrying flame proof troops we have been asked to kill
 
-		if ( object->isEffectivelyDead() )
+		// TheSuperHackers @bugfix mreza0100 23/07/2026 A destroyed occupant cannot remove itself
+		// while the contain list is temporarily detached. Do not restore a pending dangling pointer.
+		if ( object->isEffectivelyDead() || object->isDestroyed() )
 		{
 			onRemoving( object );
 			object->onRemovedFrom( getObject() );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1587,7 +1587,7 @@ void OpenContain::processDamageToContained(Real percentDamage)
 		if( !object->isEffectivelyDead() && killContained )
 			object->kill(); // in case we are carrying flame proof troops we have been asked to kill
 
-		// TheSuperHackers @bugfix mreza0100 23/07/2026 A destroyed occupant cannot remove itself
+		// GeneralsX @bugfix mreza0100 23/07/2026 A destroyed occupant cannot remove itself
 		// while the contain list is temporarily detached. Do not restore a pending dangling pointer.
 		if ( object->isEffectivelyDead() || object->isDestroyed() )
 		{

--- a/docs/WORKLOG/2026-07-DIARY.md
+++ b/docs/WORKLOG/2026-07-DIARY.md
@@ -1,5 +1,10 @@
 # July 2026
 
+## 23/07/2026
+### Prevent Stale Occupants After Contained Damage
+- Removed destroyed occupants before restoring the temporarily detached contain list, preventing deferred deletion from leaving dangling rider pointers in transports and garrisons.
+- Applied the same fix to Generals and Zero Hour while preserving the retail-compatible CRC path.
+
 ## 17/07/2026
 ### Fix Non-Deterministic Math in WWMath Matrix Classes
 - Traced the cross-platform desync at frame 100 to the `TrainCabUngarrisonable` object's translation matrix diverging between macOS (ARM64) and Linux (x86_64).


### PR DESCRIPTION
## Summary

- remove destroyed occupants before restoring a temporarily detached containment list
- mirror the fix in Generals and Zero Hour
- keep `RETAIL_COMPATIBLE_CRC` behavior unchanged

## Root cause

`OpenContain::processDamageToContained` temporarily swaps `m_containList` out to avoid iterator invalidation. A nested `destroyObject` call cannot deregister a rider while that list is detached. If the rider is marked destroyed without becoming effectively dead, the old code restores it; deferred deletion then leaves a dangling pointer. A later container eviction can call `TransportContain::onRemoving` on the destructed object and crash in `Object::onDisabledEdge` because `m_behaviors` is null.

The fix excludes both effectively-dead and explicitly destroyed occupants before restoring the detached list. The normal live-occupant path is unchanged.

## Validation

- macOS ARM64 Zero Hour target `z_generals` builds successfully
- macOS ARM64 Generals target `g_generals` builds successfully
- `git diff --check` passes
- retail-compatible CRC branch is unchanged

## AI assistance

The crash report and engine lifecycle were analyzed with AI assistance. The final logic change was manually scoped to the identified list-detachment invariant and verified against both game variants and full native builds.
