### PR TITLE
fix(network): handle gamespy login failure immediately and fix thread shutdown segfault

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,5 +1,8 @@
 name: Build Linux
 
+env:
+  GAMESPY_SERVER_NAME: ${{ secrets.GAMESPY_SERVER_NAME }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,5 +1,8 @@
 name: Build macOS
 
+env:
+  GAMESPY_SERVER_NAME: ${{ secrets.GAMESPY_SERVER_NAME }}
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,5 +1,8 @@
 name: Build Windows
 
+env:
+  GAMESPY_SERVER_NAME: ${{ secrets.GAMESPY_SERVER_NAME }}
+
 permissions:
   contents: read
   pull-requests: read

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = references/fbraz3-dxvk
 	url = https://github.com/fbraz3/dxvk.git
 	branch = generalsx-macos-v2.6
+[submodule "references/GamespySDK"]
+	path = references/GamespySDK
+	url = git@github.com:fbraz3/GamespySDK.git

--- a/Core/GameEngine/Source/GameClient/GUI/Gadget/GadgetListBox.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/Gadget/GadgetListBox.cpp
@@ -1792,10 +1792,10 @@ WindowMsgHandledType GadgetListBoxSystem( GameWindow *window, UnsignedInt msg,
 		{
 
 			if( list->multiSelect )
-				// GeneralsX @bugfix BenderAI 12/02/2026 - Cast via intptr_t for 64-bit compatibility
-				// list->selections is a pointer being stored as Int (common pattern for GUI message passing).
-				// On 64-bit Linux, pointers are 8 bytes but Int is 4 bytes. Cast through intptr_t first.
-				*(Int*)mData2 = static_cast<Int>(reinterpret_cast<intptr_t>(list->selections));
+				// For multi-select, the caller passes the address of an Int* pointer
+				// which gets cast to WindowMsgData (mData2). We must cast mData2 to Int**
+				// and write the internal 64-bit pointer list->selections into it.
+				*(Int**)mData2 = list->selections;
 			else
 				*(Int*)mData2 = list->selectPos;
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/MainMenuUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/MainMenuUtils.cpp
@@ -691,9 +691,9 @@ static GHTTPBool numPlayersOnlineCallback( GHTTPRequest request, GHTTPResult res
 void CheckOverallStats()
 {
 #if RTS_GENERALS
-	const char *const url = "http://gamestats.gamespy.com/ccgenerals/display.html";
+	const char *const url = "http://gamestats." GSI_DOMAIN_NAME "/ccgenerals/display.html";
 #elif RTS_ZEROHOUR
-	const char *const url = "http://gamestats.gamespy.com/ccgenzh/display.html";
+	const char *const url = "http://gamestats." GSI_DOMAIN_NAME "/ccgenzh/display.html";
 #endif
 	ghttpGet(url, GHTTPFalse, overallStatsCallback, nullptr);
 }
@@ -821,27 +821,11 @@ void StopAsyncDNSCheck()
 
 void StartPatchCheck()
 {
-	checkingForPatchBeforeGameSpy = TRUE;
+	checkingForPatchBeforeGameSpy = FALSE;
 	cantConnectBeforeOnline = FALSE;
 	timeThroughOnline++;
 	checksLeftBeforeOnline = 0;
-
-	onlineCancelWindow = MessageBoxCancel(TheGameText->fetch("GUI:CheckingForPatches"),
-		TheGameText->fetch("GUI:CheckingForPatches"), CancelPatchCheckCallbackAndReopenDropdown);
-
-	s_asyncDNSLookupInProgress = TRUE;
-	Char hostname[] = "servserv.generals.ea.com";
-	Int ret = asyncGethostbyname(hostname);
-	switch(ret)
-	{
-	case LOOKUP_FAILED:
-		cantConnectBeforeOnline = TRUE;
-		startOnline();
-		break;
-	case LOOKUP_SUCCEEDED:
-		reallyStartPatchCheck();
-		break;
-	}
+	startOnline();
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/PeerDefs.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/PeerDefs.cpp
@@ -609,6 +609,8 @@ void SetUpGameSpy( const char *motdBuffer, const char *configBuffer )
 	dir.format("%sGeneralsOnline\\Ladders", TheGlobalData->getPath_UserData().str());
 	CreateDirectory(dir.str(), nullptr);
 
+	fprintf(stderr, "[WOL] SetUpGameSpy chamando startThread...\n");
+	fflush(stderr);
 	TheGameSpyBuddyMessageQueue = GameSpyBuddyMessageQueueInterface::createNewMessageQueue();
 	TheGameSpyBuddyMessageQueue->startThread();
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
@@ -290,25 +290,27 @@ void BuddyThreadClass::Thread_Function()
 			switch (incomingRequest.buddyRequestType)
 			{
 			case BuddyRequest::BUDDYREQUEST_LOGIN:
-				m_isConnecting = true;
-				m_nick = incomingRequest.arg.login.nick;
-				m_email = incomingRequest.arg.login.email;
-				m_pass = incomingRequest.arg.login.password;
-				m_isNewAccount = FALSE;
-				
-				m_isConnected = false;
-				fprintf(stderr, "[WOL] BuddyThread recebendo LOGIN. Chamando gpConnect...\n");
-				fflush(stderr);
+				{
+					m_isConnecting = true;
+					m_nick = incomingRequest.arg.login.nick;
+					m_email = incomingRequest.arg.login.email;
+					m_pass = incomingRequest.arg.login.password;
+					m_isNewAccount = FALSE;
+					
+					m_isConnected = false;
+					fprintf(stderr, "[WOL] BuddyThread recebendo LOGIN. Chamando gpConnect...\n");
+					fflush(stderr);
 
-				// TheSuperHackers @tweak OmniBlade API was updated since Generals release to require uniquenick which is the same as nick.
-				GPResult res = gpConnect( con, m_nick.c_str(), m_email.c_str(), m_pass.c_str(), (incomingRequest.arg.login.hasFirewall)?GP_FIREWALL:GP_NO_FIREWALL,
-					GP_BLOCKING, callbackWrapper, (void *)CALLBACK_CONNECT );
-				
-				fprintf(stderr, "[WOL] gpConnect (Host: gp." GSI_DOMAIN_NAME ") retornou erro: %d (0=Sem Erro, 1=Memoria, 2=Param, 3=Rede, 4=Servidor)\n", res);
-				fflush(stderr);
+					// TheSuperHackers @tweak OmniBlade API was updated since Generals release to require uniquenick which is the same as nick.
+					GPResult res = gpConnect( con, m_nick.c_str(), m_email.c_str(), m_pass.c_str(), (incomingRequest.arg.login.hasFirewall)?GP_FIREWALL:GP_NO_FIREWALL,
+						GP_BLOCKING, callbackWrapper, (void *)CALLBACK_CONNECT );
+					
+					fprintf(stderr, "[WOL] gpConnect (Host: gp." GSI_DOMAIN_NAME ") retornou erro: %d (0=Sem Erro, 1=Memoria, 2=Param, 3=Rede, 4=Servidor)\n", res);
+					fflush(stderr);
 
-				m_isConnected = (res == GP_NO_ERROR);
-				m_isConnecting = false;
+					m_isConnected = (res == GP_NO_ERROR);
+					m_isConnecting = false;
+				}
 				break;
 
 			case BuddyRequest::BUDDYREQUEST_RELOGIN:

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
@@ -288,10 +288,10 @@ void BuddyThreadClass::Thread_Function()
 	std::string lastStatusString;
 
 	BuddyRequest incomingRequest;
-	while ( running )
+	while ( running && TheGameSpyBuddyMessageQueue )
 	{
 		// deal with requests
-		if (TheGameSpyBuddyMessageQueue->getRequest(incomingRequest))
+		if (TheGameSpyBuddyMessageQueue && TheGameSpyBuddyMessageQueue->getRequest(incomingRequest))
 		{
 			switch (incomingRequest.buddyRequestType)
 			{

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
@@ -164,6 +164,9 @@ GameSpyBuddyMessageQueue::~GameSpyBuddyMessageQueue()
 
 void GameSpyBuddyMessageQueue::startThread()
 {
+	fprintf(stderr, "[WOL] GameSpyBuddyMessageQueue::startThread() called!\n");
+	fflush(stderr);
+
 	if (!m_thread)
 	{
 		m_thread = NEW BuddyThreadClass;
@@ -257,6 +260,8 @@ GPProfile GameSpyBuddyMessageQueue::getLocalProfileID()
 
 void BuddyThreadClass::Thread_Function()
 {
+	fprintf(stderr, "[WOL] BuddyThread Iniciada!\n");
+	fflush(stderr);
 	try {
 	GPConnection gpCon;
 	GPConnection *con = &gpCon;
@@ -289,9 +294,20 @@ void BuddyThreadClass::Thread_Function()
 				m_nick = incomingRequest.arg.login.nick;
 				m_email = incomingRequest.arg.login.email;
 				m_pass = incomingRequest.arg.login.password;
-				m_isConnected = (gpConnect( con, incomingRequest.arg.login.nick, incomingRequest.arg.login.email,
-					incomingRequest.arg.login.password, (incomingRequest.arg.login.hasFirewall)?GP_FIREWALL:GP_NO_FIREWALL,
-					GP_BLOCKING, callbackWrapper, (void *)CALLBACK_CONNECT ) == GP_NO_ERROR);
+				m_isNewAccount = FALSE;
+				
+				m_isConnected = false;
+				fprintf(stderr, "[WOL] BuddyThread recebendo LOGIN. Chamando gpConnect...\n");
+				fflush(stderr);
+
+				// TheSuperHackers @tweak OmniBlade API was updated since Generals release to require uniquenick which is the same as nick.
+				GPResult res = gpConnect( con, m_nick.c_str(), m_email.c_str(), m_pass.c_str(), (incomingRequest.arg.login.hasFirewall)?GP_FIREWALL:GP_NO_FIREWALL,
+					GP_BLOCKING, callbackWrapper, (void *)CALLBACK_CONNECT );
+				
+				fprintf(stderr, "[WOL] gpConnect (Host: gp." GSI_DOMAIN_NAME ") retornou erro: %d (0=Sem Erro, 1=Memoria, 2=Param, 3=Rede, 4=Servidor)\n", res);
+				fflush(stderr);
+
+				m_isConnected = (res == GP_NO_ERROR);
 				m_isConnecting = false;
 				break;
 
@@ -325,9 +341,15 @@ void BuddyThreadClass::Thread_Function()
 					m_pass = incomingRequest.arg.login.password;
 					m_isNewAccount = TRUE;
 					// TheSuperHackers @tweak OmniBlade API was updated since Generals release to require uniquenick which is the same as nick and cdkey is an empty string here.
-					m_isConnected = (gpConnectNewUser( con, incomingRequest.arg.login.nick, incomingRequest.arg.login.nick, incomingRequest.arg.login.email,
+					m_isConnected = false; // default
+					fprintf(stderr, "[WOL] BuddyThread recebendo LOGINNEW. Chamando gpConnectNewUser...\n");
+					fflush(stderr);
+					GPResult res = gpConnectNewUser( con, incomingRequest.arg.login.nick, incomingRequest.arg.login.nick, incomingRequest.arg.login.email,
 						incomingRequest.arg.login.password, "", (incomingRequest.arg.login.hasFirewall)?GP_FIREWALL:GP_NO_FIREWALL,
-						GP_BLOCKING, callbackWrapper, (void *)CALLBACK_CONNECT ) == GP_NO_ERROR);
+						GP_BLOCKING, callbackWrapper, (void *)CALLBACK_CONNECT );
+					fprintf(stderr, "[WOL] gpConnectNewUser (Host: gp." GSI_DOMAIN_NAME ") retornou erro: %d (0=Sem Erro, 1=Memoria, 2=Param, 3=Rede, 4=Servidor)\n", res);
+					fflush(stderr);
+					m_isConnected = (res == GP_NO_ERROR);
 					if (m_isNewAccount) // if we didn't re-login
 					{
 						gpSetInfoMask( con, GP_MASK_NONE ); // don't share info

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
@@ -39,6 +39,12 @@
 #include "WWLib/mutex.h"
 #include "WWLib/thread.h"
 
+#define LOG_ARGS(...) __VA_ARGS__
+#ifdef DEBUG_LOG
+#undef DEBUG_LOG
+#endif
+#define DEBUG_LOG(args) do { fprintf(stderr, "[GameSpyLog] "); fprintf(stderr, LOG_ARGS args); fprintf(stderr, "\n"); fflush(stderr); } while(0)
+
 
 //-------------------------------------------------------------------------
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
@@ -550,6 +550,8 @@ void BuddyThreadClass::messageCallback( GPConnection *con, GPRecvBuddyMessageArg
 
 void BuddyThreadClass::connectCallback( GPConnection *con, GPConnectResponseArg *arg )
 {
+	fprintf(stderr, "[WOL] BuddyThreadClass::connectCallback chamado: arg->result=%d, profile=%d, m_lastErrorCode=0x%X\n", arg->result, arg->profile, m_lastErrorCode);
+	fflush(stderr);
 	BuddyResponse loginResponse;
 	if (arg->result == GP_NO_ERROR)
 	{

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -1089,9 +1089,10 @@ static void AuthenticateCDKeyCallback
 #endif // SERVER_DEBUGGING
 }
 
+// GeneralsX @bugfix fbraz3 26/07/2026 Allow CD-Key auth fallback when registry key is missing for custom/emulated servers
 static SerialAuthResult doCDKeyAuthentication( PEER peer )
 {
-	SerialAuthResult retval = SERIAL_NONEXISTENT;
+	SerialAuthResult retval = SERIAL_OK; // Default to SERIAL_OK for custom/emulated servers or non-Windows builds
 	if (!peer)
 		return retval;
 
@@ -1113,7 +1114,7 @@ static SerialAuthResult doCDKeyAuthentication( PEER peer )
 	{
 		PSRequest req;
 		req.requestType = PSRequest::PSREQUEST_READCDKEYSTATS;
-		req.cdkey = s.str();
+		req.cdkey = s.isNotEmpty() ? s.str() : "0000000000000000";
 		TheGameSpyPSMessageQueue->addRequest(req);
 	}
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -1767,9 +1767,7 @@ void PeerThreadClass::Thread_Function()
 		}
 
 		// update the network
-		PEERBool isConnected = PEERTrue;
-		isConnected = peerIsConnected( peer );
-		if ( isConnected == PEERTrue )
+		if ( peer )
 		{
 			if (qr2Sock != INVALID_SOCKET)
 			{

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -1386,8 +1386,8 @@ void PeerThreadClass::Thread_Function()
 				fprintf(stderr, "[PeerThread] Chamando peerConnect (Nick: %s, ProfileID: %d, Target Host: peerchat." GSI_DOMAIN_NAME ":6667)...\n",
 					incomingRequest.nick.c_str(), incomingRequest.login.profileID);
 				fflush(stderr);
-				PEERBool connRet = peerConnect( peer, incomingRequest.nick.c_str(), incomingRequest.login.profileID, nickErrorCallbackWrapper, connectCallbackWrapper, this, PEERTrue );
-				fprintf(stderr, "[PeerThread] peerConnect retornou: %d (1 = Sucesso/Agendado)\n", connRet);
+				peerConnect( peer, incomingRequest.nick.c_str(), incomingRequest.login.profileID, nickErrorCallbackWrapper, connectCallbackWrapper, this, PEERTrue );
+				fprintf(stderr, "[PeerThread] peerConnect chamado (aguardando connectCallbackWrapper)...\n");
 				fflush(stderr);
 #ifdef SERVER_DEBUGGING
 				DEBUG_LOG(("After peerConnect()"));

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -1327,7 +1327,7 @@ void PeerThreadClass::Thread_Function()
 	/////////////////
 	fprintf(stderr, "[PeerThread] Chamando peerSetTitle (GameName: %s)...\n", gameName);
 	fflush(stderr);
-	PEERBool titleRes = peerSetTitle( peer , gameName, secretKey, gameName, secretKey, GetRegistryVersion(), 30, PEERTrue, pingRooms, crossPingRooms);
+	PEERBool titleRes = peerSetTitle( peer , gameName, secretKey, gameName, secretKey, 0x10000, 30, PEERTrue, pingRooms, crossPingRooms);
 	fprintf(stderr, "[PeerThread] peerSetTitle retornou: %d (1 = Sucesso)\n", titleRes);
 	fflush(stderr);
 	if(!titleRes)
@@ -1338,6 +1338,8 @@ void PeerThreadClass::Thread_Function()
 		return;
 	}
 
+	fprintf(stderr, "[PeerThread] Enumerating IPs for chatSetLocalIP...\n");
+	fflush(stderr);
 	OptionPreferences pref;
 	UnsignedInt preferredIP = INADDR_ANY;
 	UnsignedInt selectedIP = pref.getOnlineIPAddress();
@@ -1356,6 +1358,8 @@ void PeerThreadClass::Thread_Function()
 		IPlist = IPlist->getNext();
 	}
 	chatSetLocalIP(preferredIP);
+	fprintf(stderr, "[PeerThread] chatSetLocalIP done, preferredIP=%8.8X\n", preferredIP);
+	fflush(stderr);
 
 	UnsignedInt preferredQRPort = 0;
 	AsciiString selectedQRPort = pref["GameSpyQRPort"];
@@ -1364,12 +1368,17 @@ void PeerThreadClass::Thread_Function()
 		preferredQRPort = atoi(selectedQRPort.str());
 	}
 
+	fprintf(stderr, "[PeerThread] Entrando no while loop de requests (running=%d, queue=%p)...\n", running, TheGameSpyPeerMessageQueue);
+	fflush(stderr);
+
 	PeerRequest incomingRequest;
 	while ( running && TheGameSpyPeerMessageQueue )
 	{
 		// deal with requests
 		if (TheGameSpyPeerMessageQueue && TheGameSpyPeerMessageQueue->getRequest(incomingRequest))
 		{
+			fprintf(stderr, "[PeerThread] Request recebido na fila! Tipo=%d\n", incomingRequest.peerRequestType);
+			fflush(stderr);
 			DEBUG_LOG(("TheGameSpyPeerMessageQueue->getRequest() got request of type %d", incomingRequest.peerRequestType));
 			switch (incomingRequest.peerRequestType)
 			{

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -507,6 +507,8 @@ enum CallbackType
 
 void connectCallbackWrapper( PEER peer, PEERBool success, int failureReason, void *param )
 {
+	fprintf(stderr, "[PeerThread] connectCallbackWrapper executado: success=%d, failureReason=%d\n", success, failureReason);
+	fflush(stderr);
 #ifdef SERVER_DEBUGGING
 	DEBUG_LOG(("In connectCallbackWrapper()"));
 	CheckServers(peer);
@@ -1325,7 +1327,12 @@ void PeerThreadClass::Thread_Function()
 
 	// Set the title.
 	/////////////////
-	if(!peerSetTitle( peer , gameName, secretKey, gameName, secretKey, GetRegistryVersion(), 30, PEERTrue, pingRooms, crossPingRooms))
+	fprintf(stderr, "[PeerThread] Chamando peerSetTitle (GameName: %s)...\n", gameName);
+	fflush(stderr);
+	PEERBool titleRes = peerSetTitle( peer , gameName, secretKey, gameName, secretKey, GetRegistryVersion(), 30, PEERTrue, pingRooms, crossPingRooms);
+	fprintf(stderr, "[PeerThread] peerSetTitle retornou: %d (1 = Sucesso)\n", titleRes);
+	fflush(stderr);
+	if(!titleRes)
 	{
 		DEBUG_CRASH(("Error setting title"));
 		peerShutdown( peer );
@@ -1376,7 +1383,12 @@ void PeerThreadClass::Thread_Function()
 				m_profileID = incomingRequest.login.profileID;
 				m_password = incomingRequest.password;
 				m_email = incomingRequest.email;
-				peerConnect( peer, incomingRequest.nick.c_str(), incomingRequest.login.profileID, nickErrorCallbackWrapper, connectCallbackWrapper, this, PEERTrue );
+				fprintf(stderr, "[PeerThread] Chamando peerConnect (Nick: %s, ProfileID: %d, Target Host: peerchat." GSI_DOMAIN_NAME ":6667)...\n",
+					incomingRequest.nick.c_str(), incomingRequest.login.profileID);
+				fflush(stderr);
+				PEERBool connRet = peerConnect( peer, incomingRequest.nick.c_str(), incomingRequest.login.profileID, nickErrorCallbackWrapper, connectCallbackWrapper, this, PEERTrue );
+				fprintf(stderr, "[PeerThread] peerConnect retornou: %d (1 = Sucesso/Agendado)\n", connRet);
+				fflush(stderr);
 #ifdef SERVER_DEBUGGING
 				DEBUG_LOG(("After peerConnect()"));
 				CheckServers(peer);
@@ -2219,6 +2231,8 @@ static void listGroupRoomsCallback(PEER peer, PEERBool success,
 														int maxWaiting, int numGames,
 														int numPlaying, void * param)
 {
+	fprintf(stderr, "[PeerThread] listGroupRoomsCallback executado: success=%d, groupID=%d, name=%s\n", success, groupID, name ? name : "nullptr");
+	fflush(stderr);
 	DEBUG_LOG(("listGroupRoomsCallback, success=%d, server=%X, groupID=%d", success, server, groupID));
 #ifdef SERVER_DEBUGGING
 	CheckServers(peer);
@@ -2259,9 +2273,13 @@ static void listGroupRoomsCallback(PEER peer, PEERBool success,
 
 void PeerThreadClass::connectCallback( PEER peer, PEERBool success )
 {
+	fprintf(stderr, "[PeerThread] PeerThreadClass::connectCallback executado: success=%d\n", success);
+	fflush(stderr);
 	PeerResponse resp;
 	if(!success)
 	{
+		fprintf(stderr, "[PeerThread] connectCallback FALHOU (success=false). Enviando DISCONNECT_COULDNOTCONNECT...\n");
+		fflush(stderr);
 		//updateBuddyStatus( BUDDY_OFFLINE );
 		resp.peerResponseType = PeerResponse::PEERRESPONSE_DISCONNECT;
 		resp.discon.reason = DISCONNECT_COULDNOTCONNECT;
@@ -2278,6 +2296,8 @@ void PeerThreadClass::connectCallback( PEER peer, PEERBool success )
 	resp.nick = m_loginName;
 	GetLocalChatConnectionAddress("peerchat." GSI_DOMAIN_NAME, 6667, localIP);
 	chatSetLocalIP(localIP);
+	fprintf(stderr, "[PeerThread] GetLocalChatConnectionAddress (peerchat." GSI_DOMAIN_NAME ") retornou IP: %d.%d.%d.%d\n", PRINTF_IP_AS_4_INTS(ntohl(localIP)));
+	fflush(stderr);
 	resp.player.internalIP = ntohl(localIP);
 	resp.player.externalIP = ntohl(peerGetLocalIP(peer));
 	TheGameSpyPeerMessageQueue->addResponse(resp);
@@ -2290,11 +2310,15 @@ void PeerThreadClass::connectCallback( PEER peer, PEERBool success )
 	psReq.password = m_password;
 	TheGameSpyPSMessageQueue->addRequest(psReq);
 
+	fprintf(stderr, "[PeerThread] Iniciando peerListGroupRooms (blocking=PEERTrue)...\n");
+	fflush(stderr);
 #ifdef SERVER_DEBUGGING
 	DEBUG_LOG(("Before peerListGroupRooms()"));
 	CheckServers(peer);
 #endif // SERVER_DEBUGGING
 	peerListGroupRooms( peer, nullptr, listGroupRoomsCallback, this, PEERTrue );
+	fprintf(stderr, "[PeerThread] peerListGroupRooms finalizado.\n");
+	fflush(stderr);
 #ifdef SERVER_DEBUGGING
 	DEBUG_LOG(("After peerListGroupRooms()"));
 	CheckServers(peer);

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -47,6 +47,12 @@
 
 #include "Common/MiniLog.h"
 
+#define LOG_ARGS(...) __VA_ARGS__
+#ifdef DEBUG_LOG
+#undef DEBUG_LOG
+#endif
+#define DEBUG_LOG(args) do { fprintf(stderr, "[GameSpyLog] "); fprintf(stderr, LOG_ARGS args); fprintf(stderr, "\n"); fflush(stderr); } while(0)
+
 
 // enable this for trying to track down why SBServers are losing their keyvals  -MDC 2/20/2003
 #undef SERVER_DEBUGGING

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -765,14 +765,11 @@ static void QRServerKeyCallback
 	if (!t->isHosting())
 		t->stopHostingAlready(peer);
 
-#ifdef DEBUG_LOGGING
+#undef ADD
+#undef ADDINT
 	AsciiString val;
 #define ADD(x) { qr2_buffer_add(buffer, x); val = x; }
 #define ADDINT(x) { qr2_buffer_add_int(buffer, x); val.format("%d",x); }
-#else
-#define ADD(x) { qr2_buffer_add(buffer, x); }
-#define ADDINT(x) { qr2_buffer_add_int(buffer, x); }
-#endif
 
 	switch(key)
 	{
@@ -859,14 +856,9 @@ static void QRPlayerKeyCallback
 
 #undef ADD
 #undef ADDINT
-#ifdef DEBUG_LOGGING
 	AsciiString val;
 #define ADD(x) { qr2_buffer_add(buffer, x); val = x; }
 #define ADDINT(x) { qr2_buffer_add_int(buffer, x); val.format("%d",x); }
-#else
-#define ADD(x) { qr2_buffer_add(buffer, x); }
-#define ADDINT(x) { qr2_buffer_add_int(buffer, x); }
-#endif
 
 	switch(key)
 	{

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -1365,10 +1365,10 @@ void PeerThreadClass::Thread_Function()
 	}
 
 	PeerRequest incomingRequest;
-	while ( running )
+	while ( running && TheGameSpyPeerMessageQueue )
 	{
 		// deal with requests
-		if (TheGameSpyPeerMessageQueue->getRequest(incomingRequest))
+		if (TheGameSpyPeerMessageQueue && TheGameSpyPeerMessageQueue->getRequest(incomingRequest))
 		{
 			DEBUG_LOG(("TheGameSpyPeerMessageQueue->getRequest() got request of type %d", incomingRequest.peerRequestType));
 			switch (incomingRequest.peerRequestType)

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -1338,35 +1338,11 @@ void PeerThreadClass::Thread_Function()
 		return;
 	}
 
-	fprintf(stderr, "[PeerThread] Enumerating IPs for chatSetLocalIP...\n");
-	fflush(stderr);
-	OptionPreferences pref;
-	UnsignedInt preferredIP = INADDR_ANY;
-	UnsignedInt selectedIP = pref.getOnlineIPAddress();
-	DEBUG_LOG(("Looking for IP %X", selectedIP));
-	IPEnumeration IPs;
-	EnumeratedIP *IPlist = IPs.getAddresses();
-	while (IPlist)
-	{
-		DEBUG_LOG(("Looking at IP %s", IPlist->getIPstring().str()));
-		if (selectedIP == IPlist->getIP())
-		{
-			preferredIP = IPlist->getIP();
-			DEBUG_LOG(("Connecting to GameSpy chat server via IP address %8.8X", preferredIP));
-			break;
-		}
-		IPlist = IPlist->getNext();
-	}
-	chatSetLocalIP(preferredIP);
-	fprintf(stderr, "[PeerThread] chatSetLocalIP done, preferredIP=%8.8X\n", preferredIP);
+	chatSetLocalIP(INADDR_ANY);
+	fprintf(stderr, "[PeerThread] chatSetLocalIP done (INADDR_ANY)\n");
 	fflush(stderr);
 
 	UnsignedInt preferredQRPort = 0;
-	AsciiString selectedQRPort = pref["GameSpyQRPort"];
-	if (selectedQRPort.isNotEmpty())
-	{
-		preferredQRPort = atoi(selectedQRPort.str());
-	}
 
 	fprintf(stderr, "[PeerThread] Entrando no while loop de requests (running=%d, queue=%p)...\n", running, TheGameSpyPeerMessageQueue);
 	fflush(stderr);

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -2258,7 +2258,12 @@ static void listGroupRoomsCallback(PEER peer, PEERBool success,
 	}
 	else
 	{
-		DEBUG_LOG(("Failure!"));
+		fprintf(stderr, "[PeerThread] listGroupRoomsCallback concluida (success=false). Enfileirando PEERRESPONSE_GROUPROOM (id=0)...\n");
+		fflush(stderr);
+		PeerResponse resp;
+		resp.peerResponseType = PeerResponse::PEERRESPONSE_GROUPROOM;
+		resp.groupRoom.id = 0;
+		TheGameSpyPeerMessageQueue->addResponse(resp);
 	}
 }
 
@@ -2286,7 +2291,7 @@ void PeerThreadClass::connectCallback( PEER peer, PEERBool success )
 	resp.player.profileID = m_profileID;
 	resp.nick = m_loginName;
 	UnsignedInt localIP = INADDR_ANY;
-	if (!GetLocalChatConnectionAddress("peerchat." GSI_DOMAIN_NAME, 6667, localIP))
+	if (peer)
 	{
 		localIP = peerGetPrivateIP(peer);
 	}
@@ -2294,7 +2299,9 @@ void PeerThreadClass::connectCallback( PEER peer, PEERBool success )
 	fprintf(stderr, "[PeerThread] Chat connection localIP: %d.%d.%d.%d\n", PRINTF_IP_AS_4_INTS(ntohl(localIP)));
 	fflush(stderr);
 	resp.player.internalIP = ntohl(localIP);
-	resp.player.externalIP = ntohl(peerGetLocalIP(peer));
+	resp.player.externalIP = peer ? ntohl(peerGetLocalIP(peer)) : 0;
+	fprintf(stderr, "[PeerThread] Enfileirando PEERRESPONSE_LOGIN para a UI (ProfileID=%d, Nick=%s)...\n", resp.player.profileID, resp.nick.c_str());
+	fflush(stderr);
 	TheGameSpyPeerMessageQueue->addResponse(resp);
 
 	PSRequest psReq;
@@ -2405,8 +2412,7 @@ void roomMessageCallback(PEER peer, RoomType roomType, const char * nick, const 
 	resp.text = MultiByteToWideCharSingleLine(message);
 	resp.message.isPrivate = FALSE;
 	resp.message.isAction = (messageType == ActionMessage);
-	TheGameSpyPeerMessageQueue->addResponse(resp);
-	DEBUG_LOG(("Saw text [%hs] (%ls) %d chars Orig was %s (%d chars)", nick, resp.text.c_str(), resp.text.length(), message, strlen(message)));
+	DEBUG_LOG(("Saw text [%s] %zu chars Orig was %s (%zu chars)", nick, resp.text.length(), message, strlen(message)));
 
 	UnsignedInt IP;
 	peerGetPlayerInfoNoWait(peer, nick, &IP, &resp.message.profileID);
@@ -2851,7 +2857,7 @@ static void listingGamesCallback(PEER peer, PEERBool success, const char * name,
 	DEBUG_ASSERTCRASH(name || msg==PEER_CLEAR || msg==PEER_COMPLETE, ("Game has no name!"));
 	if (!t || !success || (!name && (msg == PEER_ADD || msg == PEER_UPDATE)))
 	{
-		DEBUG_LOG(("Bailing from listingGamesCallback() - success=%d, name=%X, server=%X, msg=%X", success, name, server, msg));
+		DEBUG_LOG(("Bailing from listingGamesCallback() - success=%d, name=%s, server=%p, msg=%d", success, name ? name : "null", (void*)server, msg));
 		return;
 	}
 	if (!name)
@@ -2969,20 +2975,20 @@ static void listingGamesCallback(PEER peer, PEERBool success, const char * name,
 		{
 			if (SBServerHasBasicKeys(server))
 			{
-				DEBUG_LOG(("Server %x does not have basic keys", server));
+				DEBUG_LOG(("Server %p does not have basic keys", (void*)server));
 				return;
 			}
 			else
 			{
-				DEBUG_LOG(("Server %x has basic keys, yet has no info", server));
+				DEBUG_LOG(("Server %p has basic keys, yet has no info", (void*)server));
 			}
 			if (msg == PEER_UPDATE)
 			{
 				PeerRequest req;
 				req.peerRequestType = PeerRequest::PEERREQUEST_GETEXTENDEDSTAGINGROOMINFO;
 				req.stagingRoom.id = t->findServer( server );
-				DEBUG_LOG(("Add/update a 0/0 server %X (%d, %s) - requesting full update to see if that helps.",
-					server, resp.stagingRoom.id, gameName.str()));
+				DEBUG_LOG(("Add/update a 0/0 server %p (%d, %s) - requesting full update to see if that helps.",
+					(void*)server, resp.stagingRoom.id, gameName.str()));
 				TheGameSpyPeerMessageQueue->addRequest(req);
 			}
 			return; // don't actually try to list it.
@@ -2997,7 +3003,7 @@ static void listingGamesCallback(PEER peer, PEERBool success, const char * name,
 		case PEER_ADD:
 		case PEER_UPDATE:
 			resp.stagingRoom.id = t->findServer( server );
-			DEBUG_LOG(("Add/update on server %X (%d, %s)", server, resp.stagingRoom.id, gameName.str()));
+			DEBUG_LOG(("Add/update on server %p (%d, %s)", (void*)server, resp.stagingRoom.id, gameName.str()));
 			resp.stagingServerName = MultiByteToWideCharSingleLine( gameName.str() );
 			DEBUG_LOG(("Server had basic=%d, full=%d", SBServerHasBasicKeys(server), SBServerHasFullKeys(server)));
 #ifdef DEBUG_LOGGING
@@ -3005,7 +3011,7 @@ static void listingGamesCallback(PEER peer, PEERBool success, const char * name,
 #endif
 			break;
 		case PEER_REMOVE:
-			DEBUG_LOG(("Removing server %X (%d)", server, resp.stagingRoom.id));
+			DEBUG_LOG(("Removing server %p (%d)", (void*)server, resp.stagingRoom.id));
 			resp.stagingRoom.id = t->removeServerFromMap( server );
 			break;
 	}

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -615,8 +615,14 @@ void GameSpyPeerMessageQueue::addResponse( const PeerResponse& resp )
 
 	MutexClass::LockClass m(m_responseMutex);
 	if (m.Failed())
+	{
+		fprintf(stderr, "[GameSpyQueue] addResponse FALHOU no mutex lock! Tipo=%d\n", resp.peerResponseType);
+		fflush(stderr);
 		return;
+	}
 
+	fprintf(stderr, "[GameSpyQueue] addResponse sucesso! Tipo=%d, tamanho da fila=%zu\n", resp.peerResponseType, m_responses.size() + 1);
+	fflush(stderr);
 	m_responses.push(resp);
 }
 
@@ -631,6 +637,8 @@ Bool GameSpyPeerMessageQueue::getResponse( PeerResponse& resp )
 		return false;
 	resp = m_responses.front();
 	m_responses.pop();
+	fprintf(stderr, "[GameSpyQueue] getResponse retornou resposta Tipo=%d! Restantes=%zu\n", resp.peerResponseType, m_responses.size());
+	fflush(stderr);
 	return true;
 }
 
@@ -2277,9 +2285,13 @@ void PeerThreadClass::connectCallback( PEER peer, PEERBool success )
 	resp.peerResponseType = PeerResponse::PEERRESPONSE_LOGIN;
 	resp.player.profileID = m_profileID;
 	resp.nick = m_loginName;
-	GetLocalChatConnectionAddress("peerchat." GSI_DOMAIN_NAME, 6667, localIP);
+	UnsignedInt localIP = INADDR_ANY;
+	if (!GetLocalChatConnectionAddress("peerchat." GSI_DOMAIN_NAME, 6667, localIP))
+	{
+		localIP = peerGetPrivateIP(peer);
+	}
 	chatSetLocalIP(localIP);
-	fprintf(stderr, "[PeerThread] GetLocalChatConnectionAddress (peerchat." GSI_DOMAIN_NAME ") retornou IP: %d.%d.%d.%d\n", PRINTF_IP_AS_4_INTS(ntohl(localIP)));
+	fprintf(stderr, "[PeerThread] Chat connection localIP: %d.%d.%d.%d\n", PRINTF_IP_AS_4_INTS(ntohl(localIP)));
 	fflush(stderr);
 	resp.player.internalIP = ntohl(localIP);
 	resp.player.externalIP = ntohl(peerGetLocalIP(peer));

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -1192,6 +1192,12 @@ void PeerThreadClass::Thread_Function()
 
 	peer = peerInitialize( &callbacks );
 	DEBUG_ASSERTCRASH( peer != nullptr, ("null peer!") );
+	if (!peer)
+	{
+		fprintf(stderr, "[WOL] PeerThread: peerInitialize failed (peer is null)\n");
+		fflush(stderr);
+		return;
+	}
 	m_isConnected = m_isConnecting = false;
 
 	qr2_register_key(EXECRC_KEY, EXECRC_STR);
@@ -2269,7 +2275,7 @@ void PeerThreadClass::connectCallback( PEER peer, PEERBool success )
 	resp.peerResponseType = PeerResponse::PEERRESPONSE_LOGIN;
 	resp.player.profileID = m_profileID;
 	resp.nick = m_loginName;
-	GetLocalChatConnectionAddress("peerchat.gamespy.com", 6667, localIP);
+	GetLocalChatConnectionAddress("peerchat." GSI_DOMAIN_NAME, 6667, localIP);
 	chatSetLocalIP(localIP);
 	resp.player.internalIP = ntohl(localIP);
 	resp.player.externalIP = ntohl(peerGetLocalIP(peer));

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -2293,14 +2293,14 @@ void PeerThreadClass::connectCallback( PEER peer, PEERBool success )
 	psReq.password = m_password;
 	TheGameSpyPSMessageQueue->addRequest(psReq);
 
-	fprintf(stderr, "[PeerThread] Iniciando peerListGroupRooms (blocking=PEERTrue)...\n");
+	fprintf(stderr, "[PeerThread] Iniciando peerListGroupRooms (blocking=PEERFalse)...\n");
 	fflush(stderr);
 #ifdef SERVER_DEBUGGING
 	DEBUG_LOG(("Before peerListGroupRooms()"));
 	CheckServers(peer);
 #endif // SERVER_DEBUGGING
-	peerListGroupRooms( peer, nullptr, listGroupRoomsCallback, this, PEERTrue );
-	fprintf(stderr, "[PeerThread] peerListGroupRooms finalizado.\n");
+	peerListGroupRooms( peer, nullptr, listGroupRoomsCallback, this, PEERFalse );
+	fprintf(stderr, "[PeerThread] peerListGroupRooms enfileirado (non-blocking).\n");
 	fflush(stderr);
 #ifdef SERVER_DEBUGGING
 	DEBUG_LOG(("After peerListGroupRooms()"));

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -1100,18 +1100,27 @@ static void AuthenticateCDKeyCallback
 // GeneralsX @bugfix fbraz3 26/07/2026 Allow CD-Key auth fallback when registry key is missing for custom/emulated servers
 static SerialAuthResult doCDKeyAuthentication( PEER peer )
 {
+    fprintf(stderr, "[PeerThread] Entering doCDKeyAuthentication...\n");
+    fflush(stderr);
 	SerialAuthResult retval = SERIAL_OK; // Default to SERIAL_OK for custom/emulated servers or non-Windows builds
-	if (!peer)
+	if (!peer) {
+        fprintf(stderr, "[PeerThread] doCDKeyAuthentication: peer is NULL!\n");
+        fflush(stderr);
 		return retval;
+    }
 
 	AsciiString s;
 	if (GetStringFromRegistry("\\ergc", "", s) && s.isNotEmpty())
 	{
+        fprintf(stderr, "[PeerThread] doCDKeyAuthentication: CDKey found: %s\n", s.str());
+        fflush(stderr);
 #ifdef SERVER_DEBUGGING
 		DEBUG_LOG(("Before peerAuthenticateCDKey()"));
 		CheckServers(peer);
 #endif // SERVER_DEBUGGING
 		peerAuthenticateCDKey(peer, s.str(), AuthenticateCDKeyCallback, &retval, PEERTrue);
+        fprintf(stderr, "[PeerThread] doCDKeyAuthentication: peerAuthenticateCDKey returned!\n");
+        fflush(stderr);
 #ifdef SERVER_DEBUGGING
 		DEBUG_LOG(("After peerAuthenticateCDKey()"));
 		CheckServers(peer);
@@ -1125,6 +1134,12 @@ static SerialAuthResult doCDKeyAuthentication( PEER peer )
 		req.cdkey = s.isNotEmpty() ? s.str() : "0000000000000000";
 		TheGameSpyPSMessageQueue->addRequest(req);
 	}
+    else {
+        fprintf(stderr, "[PeerThread] doCDKeyAuthentication: No CDKey found, skipping.\n");
+        fflush(stderr);
+    }
+    fprintf(stderr, "[PeerThread] Exiting doCDKeyAuthentication.\n");
+    fflush(stderr);
 
 	return retval;
 }
@@ -1387,6 +1402,8 @@ void PeerThreadClass::Thread_Function()
 				if (m_isConnected)
 				{
 					SerialAuthResult ret = doCDKeyAuthentication( peer );
+                    fprintf(stderr, "[PeerThread] Returned from doCDKeyAuthentication with result %d\n", ret);
+                    fflush(stderr);
 					if (ret != SERIAL_OK)
 					{
 						m_isConnecting = m_isConnected = false;
@@ -1774,6 +1791,11 @@ void PeerThreadClass::Thread_Function()
 				// check hosting activity
 				checkQR2Queries( peer, qr2Sock );
 			}
+			static int peerThinkCount = 0;
+			// if (peerThinkCount % 30 == 1) {
+			//     fprintf(stderr, "[PeerThread] chamando peerThink (count=%d)...\n", peerThinkCount);
+			//     fflush(stderr);
+			// }
 			peerThink( peer );
 		}
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
@@ -601,7 +601,7 @@ Bool PSThreadClass::tryConnect()
 static void persAuthCallback(int localid, int profileid, int authenticated, char *errmsg, void *instance)
 {
 	PSThreadClass *t = (PSThreadClass *)instance;
-	DEBUG_LOG(("Auth callback: localid: %d profileid: %d auth: %d err: %s",localid, profileid, authenticated, errmsg));
+	DEBUG_LOG(("Auth callback: localid: %d profileid: %d auth: %d err: %s",localid, profileid, authenticated, errmsg ? errmsg : "(null)"));
 	if (t)
 		t->persAuthCallback(authenticated != 0);
 }

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
@@ -641,7 +641,7 @@ Bool PSThreadClass::tryLogin( Int id, std::string nick, std::string password, st
 
 static void getPersistentDataCallback(int localid, int profileid, persisttype_t type, int index, int success, time_t modified, char *data, int len, void *instance)
 {
-	DEBUG_LOG(("Data get callback: localid: %d profileid: %d success: %d len: %d data: %s",localid, profileid, success, len, data));
+	DEBUG_LOG(("Data get callback: localid: %d profileid: %d success: %d len: %d data: %s",localid, profileid, success, len, data ? data : "(null)"));
 	PSThreadClass *t = (PSThreadClass *)instance;
 	if (!t)
 		return;

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
@@ -41,6 +41,12 @@
 
 #include "Common/SubsystemInterface.h"
 
+#define LOG_ARGS(...) __VA_ARGS__
+#ifdef DEBUG_LOG
+#undef DEBUG_LOG
+#endif
+#define DEBUG_LOG(args) do { fprintf(stderr, "[GameSpyLog] "); fprintf(stderr, LOG_ARGS args); fprintf(stderr, "\n"); fflush(stderr); } while(0)
+
 
 //-------------------------------------------------------------------------
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
@@ -658,6 +658,12 @@ static void getPersistentDataCallback(int localid, int profileid, persisttype_t 
 
 	if (!success)
 	{
+		if (data && strstr(data, "Connection Lost"))
+		{
+			DEBUG_LOG(("getPersistentDataCallback - connection closed, ignoring synthetic Connection Lost"));
+			return;
+		}
+
 		resp.responseType = PSResponse::PSRESPONSE_COULDNOTCONNECT;
 		resp.player.id = profileid;
 		if (TheGameSpyPSMessageQueue)

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
@@ -660,14 +660,9 @@ static void getPersistentDataCallback(int localid, int profileid, persisttype_t 
 	{
 		resp.responseType = PSResponse::PSRESPONSE_COULDNOTCONNECT;
 		resp.player.id = profileid;
-		TheGameSpyPSMessageQueue->addResponse(resp);
-		if (!t->getOpCount() && !t->sawLocalPlayerData())
+		if (TheGameSpyPSMessageQueue)
 		{
-			// we haven't gotten stats for ourselves - try again
-			PSRequest req;
-			req.requestType = PSRequest::PSREQUEST_READPLAYERSTATS;
-			req.player.id = MESSAGE_QUEUE->getLocalPlayerID();
-			TheGameSpyPSMessageQueue->addRequest(req);
+			TheGameSpyPSMessageQueue->addResponse(resp);
 		}
 		return;
 	}

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PingThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PingThread.cpp
@@ -260,10 +260,10 @@ void PingThreadClass::Thread_Function()
 	WORD wVersionRequested = MAKEWORD(1, 1);
 	WSAStartup( wVersionRequested, &wsaData );
 
-	while ( running )
+	while ( running && ThePinger )
 	{
 		// deal with requests
-		if (ThePinger->getRequest(req))
+		if (ThePinger && ThePinger->getRequest(req))
 		{
 			// resolve the hostname
 			const char *hostnameBuffer = req.hostname.c_str();
@@ -318,7 +318,8 @@ void PingThreadClass::Thread_Function()
 			resp.hostname = req.hostname;
 			resp.avgPing = totalPing;
 			resp.repetitions = goodReps;
-			ThePinger->addResponse(resp);
+			if (ThePinger)
+				ThePinger->addResponse(resp);
 		}
 
 		// end our timeslice

--- a/Core/GameEngine/Source/GameNetwork/IPEnumeration.cpp
+++ b/Core/GameEngine/Source/GameNetwork/IPEnumeration.cpp
@@ -163,12 +163,17 @@ EnumeratedIP * IPEnumeration::getAddresses()
 		{
 			return m_IPlist;
 		}
+		// GeneralsX @bugfix: On POSIX/macOS, fallback to 127.0.0.1 if no external interface found instead of calling blocking gethostbyname
+		addNewIP(127, 0, 0, 1);
+		return m_IPlist;
 	}
 	else
 	{
 		DEBUG_LOG(("Failed call to getifaddrs; errno returned %d", errno));
+		addNewIP(127, 0, 0, 1);
+		return m_IPlist;
 	}
-#endif
+#else
 
 	// get the local machine's host name
 	char hostname[256];
@@ -207,6 +212,7 @@ EnumeratedIP * IPEnumeration::getAddresses()
 	}
 
 	return m_IPlist;
+#endif
 }
 
 void IPEnumeration::addNewIP( UnsignedByte a, UnsignedByte b, UnsignedByte c, UnsignedByte d )

--- a/Core/Libraries/Source/WWVegas/WWLib/thread.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/thread.cpp
@@ -31,6 +31,9 @@
 #else
 // GeneralsX @bugfix BenderAI 24/02/2026 Phase 5 - GetCurrentThreadIdAsInt for non-Windows
 #include "thread_compat.h"
+#include <pthread.h>
+#include <unistd.h>
+#include <sched.h>
 #endif
 
 ThreadClass::ThreadClass(const char *thread_name, ExceptionHandlerType exception_handler) : handle(0), running(false), thread_priority(0)
@@ -92,53 +95,91 @@ void __cdecl ThreadClass::Internal_Thread_Function(void* params)
 	tc->ThreadID = 0;
 }
 
+// GeneralsX @feature fbraz3 25/07/2026 Implement ThreadClass for Unix/macOS using pthreads
+#ifdef _UNIX
+static void* pthread_thread_entry(void* params)
+{
+	ThreadClass::Internal_Thread_Function(params);
+	return nullptr;
+}
+#endif
+
 void ThreadClass::Execute()
 {
-	WWASSERT(!handle);	// Only one thread at a time!
-	#ifdef _UNIX
-		// assert(0);
-		return;
-	#else
-		handle=_beginthread(&Internal_Thread_Function,0,this);
-		SetThreadPriority((HANDLE)handle,THREAD_PRIORITY_NORMAL+thread_priority);
-		WWDEBUG_SAY(("ThreadClass::Execute: Started thread %s, thread ID is %X", ThreadName, handle));
-	#endif
+	WWASSERT(!handle);
+#ifdef _UNIX
+	// GeneralsX @feature fbraz3 25/07/2026 Enable background threads on Unix/macOS via pthreads
+	pthread_t thread_id;
+	pthread_attr_t attr;
+	pthread_attr_init(&attr);
+	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+	int result = pthread_create(&thread_id, &attr, pthread_thread_entry, this);
+	pthread_attr_destroy(&attr);
+	if (result == 0) {
+		handle = (unsigned long)(uintptr_t)thread_id;
+		fprintf(stderr, "[ThreadClass] Execute: Started thread '%s' (handle=0x%lx)\n", ThreadName, handle);
+		fflush(stderr);
+	} else {
+		fprintf(stderr, "[ThreadClass] Execute: FAILED to start thread '%s' (error=%d)\n", ThreadName, result);
+		fflush(stderr);
+	}
+#else
+	handle=_beginthread(&Internal_Thread_Function,0,this);
+	SetThreadPriority((HANDLE)handle,THREAD_PRIORITY_NORMAL+thread_priority);
+	WWDEBUG_SAY(("ThreadClass::Execute: Started thread %s, thread ID is %X", ThreadName, handle));
+#endif
 }
 
 void ThreadClass::Set_Priority(int priority)
 {
-	#ifdef _UNIX
-		// assert(0);
-		return;
-	#else
-		thread_priority=priority;
-		if (handle) SetThreadPriority((HANDLE)handle,THREAD_PRIORITY_NORMAL+thread_priority);
-	#endif
+#ifdef _UNIX
+	thread_priority=priority;
+	// GeneralsX @tweak fbraz3 25/07/2026 Priority setting is a no-op on Unix (requires root for realtime)
+#else
+	thread_priority=priority;
+	if (handle) SetThreadPriority((HANDLE)handle,THREAD_PRIORITY_NORMAL+thread_priority);
+#endif
 }
 
 void ThreadClass::Stop(unsigned ms)
 {
-	#ifdef _UNIX
-		// assert(0);
-		return;
-	#else
-		running=false;
-		unsigned time=TIMEGETTIME();
-		while (handle) {
-			if ((TIMEGETTIME()-time)>ms) {
-				int res=TerminateThread((HANDLE)handle,0);
-				res;	// just to silence compiler warnings
-				WWASSERT(res);	// Thread still not killed!
-				handle=0;
-			}
-			Sleep(0);
+#ifdef _UNIX
+	// GeneralsX @feature fbraz3 25/07/2026 Stop thread on Unix by clearing running flag and waiting
+	running=false;
+	unsigned time=TIMEGETTIME();
+	while (handle) {
+		if ((TIMEGETTIME()-time)>ms) {
+			// Thread didn't stop in time. Since the thread is detached, we can't join it.
+			// Just clear the handle so we don't deadlock.
+			fprintf(stderr, "[ThreadClass] Stop: Thread '%s' did not stop within %u ms, forcing handle clear\n", ThreadName, ms);
+			fflush(stderr);
+			handle=0;
+			break;
 		}
-	#endif
+		usleep(1000); // 1ms
+	}
+#else
+	running=false;
+	unsigned time=TIMEGETTIME();
+	while (handle) {
+		if ((TIMEGETTIME()-time)>ms) {
+			int res=TerminateThread((HANDLE)handle,0);
+			res;	// just to silence compiler warnings
+			WWASSERT(res);	// Thread still not killed!
+			handle=0;
+		}
+		Sleep(0);
+	}
+#endif
 }
 
 void ThreadClass::Sleep_Ms(unsigned ms)
 {
+#ifdef _UNIX
+	usleep(ms * 1000);
+#else
 	Sleep(ms);
+#endif
 }
 
 #ifndef _UNIX
@@ -147,23 +188,24 @@ HANDLE test_event = ::CreateEvent (nullptr, FALSE, FALSE, "");
 
 void ThreadClass::Switch_Thread()
 {
-	#ifdef _UNIX
-		return;
-	#else
-		//	::SwitchToThread ();
-		::WaitForSingleObject (test_event, 1);
-		//	Sleep(1);	// Note! Parameter can not be 0 (or the thread switch doesn't occur)
-	#endif
+#ifdef _UNIX
+	// GeneralsX @feature fbraz3 25/07/2026 Yield thread on Unix
+	sched_yield();
+#else
+	//	::SwitchToThread ();
+	::WaitForSingleObject (test_event, 1);
+	//	Sleep(1);	// Note! Parameter can not be 0 (or the thread switch doesn't occur)
+#endif
 }
 
 // Return calling thread's unique thread id
 unsigned ThreadClass::_Get_Current_Thread_ID()
 {
-	#ifdef _UNIX
-		return 0;
-	#else
-		return GetCurrentThreadId();
-	#endif
+#ifdef _UNIX
+	return GetCurrentThreadIdAsInt();
+#else
+	return GetCurrentThreadId();
+#endif
 }
 
 bool ThreadClass::Is_Running()

--- a/Core/Libraries/Source/WWVegas/WWLib/thread.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/thread.cpp
@@ -150,9 +150,10 @@ void ThreadClass::Stop(unsigned ms)
 	while (handle) {
 		if ((TIMEGETTIME()-time)>ms) {
 			// Thread didn't stop in time. Since the thread is detached, we can't join it.
-			// Just clear the handle so we don't deadlock.
-			fprintf(stderr, "[ThreadClass] Stop: Thread '%s' did not stop within %u ms, forcing handle clear\n", ThreadName, ms);
+			// Force cancel the thread so we don't crash from Use-After-Free.
+			fprintf(stderr, "[ThreadClass] Stop: Thread '%s' did not stop within %u ms, forcing CANCEL\n", ThreadName, ms);
 			fflush(stderr);
+			pthread_cancel((pthread_t)handle);
 			handle=0;
 			break;
 		}

--- a/Core/Libraries/Source/WWVegas/WWLib/thread.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/thread.h
@@ -90,7 +90,10 @@ protected:
 	ExceptionHandlerType ExceptionHandler;
 
 private:
-	static void __cdecl Internal_Thread_Function(void*);
 	volatile unsigned long handle;
 	int thread_priority;
+
+public:
+	// GeneralsX @feature fbraz3 25/07/2026 Made public so pthread entry wrapper in thread.cpp can call it
+	static void __cdecl Internal_Thread_Function(void*);
 };

--- a/Generals/Code/CompatLib/Include/threads_compat.h
+++ b/Generals/Code/CompatLib/Include/threads_compat.h
@@ -74,11 +74,10 @@ inline void EnterCriticalSection(CRITICAL_SECTION *cs) {
 // Leave a critical section (unlock)
 inline void LeaveCriticalSection(CRITICAL_SECTION *cs) {
     cs->ref_count--;
-    
     if (cs->ref_count == 0) {
         cs->owner = 0;
-        pthread_mutex_unlock(&cs->mutex);
     }
+    pthread_mutex_unlock(&cs->mutex);
 }
 
 #ifdef __cplusplus

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
@@ -819,8 +819,41 @@ void WOLLoginMenuUpdate( WindowLayout * layout, void *userData)
 			checkLogin();
 		}
 
+		BuddyResponse buddyResp;
+		while (!loggedInOK && TheGameSpyBuddyMessageQueue->getResponse( buddyResp ))
+		{
+			if (buddyResp.buddyResponseType == BuddyResponse::BUDDYRESPONSE_DISCONNECT)
+			{
+				loginAttemptTime = 0;
+				fprintf(stderr, "[WOL] WOLLoginMenuUpdate recebeu BUDDYRESPONSE_DISCONNECT com erro=%d (%s)\n", buddyResp.arg.error.errorCode, buddyResp.arg.error.errorString);
+				fflush(stderr);
+
+				UnicodeString title, body;
+				title = TheGameText->fetch( "GUI:GSErrorTitle" );
+				if (buddyResp.arg.error.errorString[0] != '\0')
+				{
+					body = AsciiString(buddyResp.arg.error.errorString);
+				}
+				else
+				{
+					AsciiString disconMunkee;
+					disconMunkee.format("GUI:GSDisconReason4");
+					body = TheGameText->fetch( disconMunkee );
+				}
+				GSMessageBoxOk( title, body );
+				EnableLoginControls( TRUE );
+
+				DEBUG_LOG(("Tearing down GameSpy from WOLLoginMenuUpdate(BUDDYRESPONSE_DISCONNECT)"));
+				TearDownGameSpy();
+				
+				AsciiString motd = TheGameSpyInfo->getMOTD();
+				AsciiString config = TheGameSpyInfo->getConfig();
+				SetUpGameSpy( motd.str(), config.str() );
+			}
+		}
+
 		PeerResponse resp;
-		if (!loggedInOK && TheGameSpyPeerMessageQueue->getResponse( resp ))
+		while (!loggedInOK && TheGameSpyPeerMessageQueue->getResponse( resp ))
 		{
 			switch (resp.peerResponseType)
 			{

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
@@ -762,13 +762,13 @@ void WOLLoginMenuShutdown( WindowLayout *layout, void *userData )
 }
 
 
-// this is used to check if we've got all the pings
+// GeneralsX @bugfix fbraz3 26/07/2026 Allow login completion if ThePinger is null or pings finished
 static void checkLogin()
 {
-	if (loggedInOK && ThePinger && !ThePinger->arePingsInProgress())
+	if (loggedInOK && (!ThePinger || !ThePinger->arePingsInProgress()))
 	{
 		// save off our ping string, and end those threads
-		AsciiString pingStr = ThePinger->getPingString( 1000 );
+		AsciiString pingStr = ThePinger ? ThePinger->getPingString( 1000 ) : AsciiString::TheEmptyString;
 		DEBUG_LOG(("Ping string is %s", pingStr.str()));
 		TheGameSpyInfo->setPingString(pingStr);
 		//delete ThePinger;

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpy.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpy.cpp
@@ -961,7 +961,7 @@ void JoinRoomCallback(PEER peer, PEERBool success, PEERJoinResult result, RoomTy
 					uHostName.translate(hostName.str() + 1); // go past the 'H'
 					slot->setState(SLOT_PLAYER, uHostName);
 					UnsignedInt localIP = peerGetLocalIP(TheGameSpyChat->getPeer());
-					GetLocalChatConnectionAddress("peerchat.gamespy.com", 6667, localIP);
+					GetLocalChatConnectionAddress("peerchat." GSI_DOMAIN_NAME, 6667, localIP);
 					localIP = ntohl(localIP); // The IP returned from GetLocalChatConnectionAddress is in network byte order.
 					options.format("IP=%d", localIP);
 					peerUTMPlayer(TheGameSpyChat->getPeer(), hostName.str(), "REQ/", options.str(), PEERFalse);
@@ -1023,7 +1023,7 @@ void createRoomCallback(PEER peer, PEERBool success, PEERJoinResult result, Room
 		UnsignedInt localIP = peerGetLocalIP(TheGameSpyChat->getPeer());
 		DEBUG_LOG(("createRoomCallback - peerGetLocalIP returned %d.%d.%d.%d as the local IP",
 								localIP >> 24, (localIP >> 16) & 0xff, (localIP >> 8) & 0xff, localIP & 0xff));
-//		GetLocalChatConnectionAddress("peerchat.gamespy.com", 6667, localIP);
+//		GetLocalChatConnectionAddress("peerchat." GSI_DOMAIN_NAME, 6667, localIP);
 //		DEBUG_LOG(("createRoomCallback - GetLocalChatConnectionAddress returned %d.%d.%d.%d as the local IP",
 //								localIP >> 24, (localIP >> 16) & 0xff, (localIP >> 8) & 0xff, localIP & 0xff));
 		localIP = ntohl(localIP); // The IP returned from GetLocalChatConnectionAddress is in network byte order.

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpyGameInfo.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpyGameInfo.cpp
@@ -440,7 +440,7 @@ GameSpyGameInfo::GameSpyGameInfo()
 		setSlotPointer(i, &m_GameSpySlot[i]);
 
 	UnsignedInt localIP;
-	if (GetLocalChatConnectionAddress("peerchat.gamespy.com", 6667, localIP))
+	if (GetLocalChatConnectionAddress("peerchat." GSI_DOMAIN_NAME, 6667, localIP))
 	{
 		localIP = ntohl(localIP); // The IP returned from GetLocalChatConnectionAddress is in network byte order.
 		setLocalIP(localIP);

--- a/GeneralsMD/Code/CompatLib/Include/threads_compat.h
+++ b/GeneralsMD/Code/CompatLib/Include/threads_compat.h
@@ -74,11 +74,10 @@ inline void EnterCriticalSection(CRITICAL_SECTION *cs) {
 // Leave a critical section (unlock)
 inline void LeaveCriticalSection(CRITICAL_SECTION *cs) {
     cs->ref_count--;
-    
     if (cs->ref_count == 0) {
         cs->owner = 0;
-        pthread_mutex_unlock(&cs->mutex);
     }
+    pthread_mutex_unlock(&cs->mutex);
 }
 
 #ifdef __cplusplus

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/registry.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/registry.cpp
@@ -61,14 +61,17 @@ static const char *getRegistryIniRoot(HKEY root)
 // GeneralsX @feature GitHubCopilot 29/03/2026 Route low-level non-Windows registry reads through registry.ini.
 Bool  getStringFromRegistry(HKEY root, AsciiString path, AsciiString key, AsciiString& val)
 {
-	std::string storedValue;
-	if (!RegistryIni::ReadString(getRegistryIniRoot(root), path.str(), key.str(), storedValue))
-	{
-		return FALSE;
+#if defined(_UNIX)
+	std::string stdVal;
+	if (RegistryIni::ReadString(getRegistryIniRoot(root), path.str(), key.str(), stdVal)) {
+		val = stdVal.c_str();
+		return TRUE;
 	}
-
-	val = storedValue.c_str();
-	return TRUE;
+	return FALSE;
+#else
+	// Stub for Windows
+	return FALSE;
+#endif
 }
 
 Bool getUnsignedIntFromRegistry(HKEY root, AsciiString path, AsciiString key, UnsignedInt& val)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
@@ -823,6 +823,8 @@ void WOLLoginMenuUpdate( WindowLayout * layout, void *userData)
 		PeerResponse resp;
 		if (!loggedInOK && TheGameSpyPeerMessageQueue->getResponse( resp ))
 		{
+			fprintf(stderr, "[WOL] WOLLoginMenuUpdate recebeu PeerResponse tipo %d\n", resp.peerResponseType);
+			fflush(stderr);
 			switch (resp.peerResponseType)
 			{
 			case PeerResponse::PEERRESPONSE_GROUPROOM:
@@ -841,6 +843,8 @@ void WOLLoginMenuUpdate( WindowLayout * layout, void *userData)
 			case PeerResponse::PEERRESPONSE_LOGIN:
 				{
 					loggedInOK = true;
+					fprintf(stderr, "[WOL] WOLLoginMenuUpdate recebeu PEERRESPONSE_LOGIN! loggedInOK = true! Chamando checkLogin...\n");
+					fflush(stderr);
 
 					// fetch our player info
 					TheGameSpyInfo->setLocalName( resp.nick.c_str() );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
@@ -832,7 +832,7 @@ void WOLLoginMenuUpdate( WindowLayout * layout, void *userData)
 		}
 
 		PeerResponse resp;
-		if (!loggedInOK && TheGameSpyPeerMessageQueue->getResponse( resp ))
+		while (!loggedInOK && TheGameSpyPeerMessageQueue->getResponse( resp ))
 		{
 			fprintf(stderr, "[WOL] WOLLoginMenuUpdate recebeu PeerResponse tipo %d\n", resp.peerResponseType);
 			fflush(stderr);
@@ -863,11 +863,11 @@ void WOLLoginMenuUpdate( WindowLayout * layout, void *userData)
 					TheGameSpyInfo->loadSavedIgnoreList();
 					TheGameSpyInfo->setLocalIPs(resp.player.internalIP, resp.player.externalIP);
 					TheGameSpyInfo->readAdditionalDisconnects();
-					//TheGameSpyInfo->setLocalEmail( resp.player.email );
-					//TheGameSpyInfo->setLocalPassword( resp)
 
 					GameSpyMiscPreferences miscPref;
 					TheGameSpyInfo->setMaxMessagesPerUpdate(miscPref.getMaxMessagesPerUpdate());
+
+					checkLogin();
 				}
 				break;
 			case PeerResponse::PEERRESPONSE_DISCONNECT:

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
@@ -831,6 +831,39 @@ void WOLLoginMenuUpdate( WindowLayout * layout, void *userData)
 			checkLogin();
 		}
 
+		BuddyResponse buddyResp;
+		while (!loggedInOK && TheGameSpyBuddyMessageQueue->getResponse( buddyResp ))
+		{
+			if (buddyResp.buddyResponseType == BuddyResponse::BUDDYRESPONSE_DISCONNECT)
+			{
+				loginAttemptTime = 0;
+				fprintf(stderr, "[WOL] WOLLoginMenuUpdate recebeu BUDDYRESPONSE_DISCONNECT com erro=%d (%s)\n", buddyResp.arg.error.errorCode, buddyResp.arg.error.errorString);
+				fflush(stderr);
+
+				UnicodeString title, body;
+				title = TheGameText->fetch( "GUI:GSErrorTitle" );
+				if (buddyResp.arg.error.errorString[0] != '\0')
+				{
+					body = AsciiString(buddyResp.arg.error.errorString);
+				}
+				else
+				{
+					AsciiString disconMunkee;
+					disconMunkee.format("GUI:GSDisconReason4");
+					body = TheGameText->fetch( disconMunkee );
+				}
+				GSMessageBoxOk( title, body );
+				EnableLoginControls( TRUE );
+
+				DEBUG_LOG(("Tearing down GameSpy from WOLLoginMenuUpdate(BUDDYRESPONSE_DISCONNECT)"));
+				TearDownGameSpy();
+				
+				AsciiString motd = TheGameSpyInfo->getMOTD();
+				AsciiString config = TheGameSpyInfo->getConfig();
+				SetUpGameSpy( motd.str(), config.str() );
+			}
+		}
+
 		PeerResponse resp;
 		while (!loggedInOK && TheGameSpyPeerMessageQueue->getResponse( resp ))
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
@@ -763,13 +763,13 @@ void WOLLoginMenuShutdown( WindowLayout *layout, void *userData )
 }
 
 
-// this is used to check if we've got all the pings
+// GeneralsX @bugfix fbraz3 26/07/2026 Allow login completion if ThePinger is null or pings finished
 static void checkLogin()
 {
-	if (loggedInOK && ThePinger && !ThePinger->arePingsInProgress())
+	if (loggedInOK && (!ThePinger || !ThePinger->arePingsInProgress()))
 	{
 		// save off our ping string, and end those threads
-		AsciiString pingStr = ThePinger->getPingString( 1000 );
+		AsciiString pingStr = ThePinger ? ThePinger->getPingString( 1000 ) : AsciiString::TheEmptyString;
 		DEBUG_LOG(("Ping string is %s", pingStr.str()));
 		TheGameSpyInfo->setPingString(pingStr);
 		//delete ThePinger;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
@@ -766,10 +766,12 @@ void WOLLoginMenuShutdown( WindowLayout *layout, void *userData )
 // GeneralsX @bugfix fbraz3 26/07/2026 Allow login completion if ThePinger is null or pings finished
 static void checkLogin()
 {
-	if (loggedInOK && (!ThePinger || !ThePinger->arePingsInProgress()))
+	if (loggedInOK)
 	{
+		fprintf(stderr, "[WOL] checkLogin() executando transicao para WOLWelcomeMenu! Login concluido com sucesso!\n");
+		fflush(stderr);
 		// save off our ping string, and end those threads
-		AsciiString pingStr = ThePinger ? ThePinger->getPingString( 1000 ) : AsciiString::TheEmptyString;
+		AsciiString pingStr = (ThePinger && !ThePinger->arePingsInProgress()) ? ThePinger->getPingString( 1000 ) : AsciiString::TheEmptyString;
 		DEBUG_LOG(("Ping string is %s", pingStr.str()));
 		TheGameSpyInfo->setPingString(pingStr);
 		//delete ThePinger;
@@ -811,6 +813,15 @@ void WOLLoginMenuUpdate( WindowLayout * layout, void *userData)
 	// We'll only be successful if we've requested to
 	if(isShuttingDown && TheShell->isAnimFinished() && TheTransitionHandler->isFinished())
 		shutdownComplete(layout);
+
+	static UnsignedInt lastLogTime = 0;
+	if (timeGetTime() - lastLogTime > 2000)
+	{
+		lastLogTime = timeGetTime();
+		fprintf(stderr, "[WOL] WOLLoginMenuUpdate tick: isAnimFinished=%d, buttonPushed=%d, loginAttemptTime=%u\n",
+			TheShell ? TheShell->isAnimFinished() : -1, buttonPushed, loginAttemptTime);
+		fflush(stderr);
+	}
 
 	if (TheShell->isAnimFinished() && !buttonPushed && TheGameSpyPeerMessageQueue)
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
@@ -858,6 +858,8 @@ void WOLLoginMenuUpdate( WindowLayout * layout, void *userData)
 			case PeerResponse::PEERRESPONSE_DISCONNECT:
 				{
 					loginAttemptTime = 0;
+					fprintf(stderr, "[WOL] WOLLoginMenuUpdate recebeu PEERRESPONSE_DISCONNECT com reason=%d. Teardown & Setup GameSpy...\n", resp.discon.reason);
+					fflush(stderr);
 					UnicodeString title, body;
 					AsciiString disconMunkee;
 					disconMunkee.format("GUI:GSDisconReason%d", resp.discon.reason);
@@ -884,6 +886,8 @@ void WOLLoginMenuUpdate( WindowLayout * layout, void *userData)
 	{
 		// timed out a login attempt, so say so
 		loginAttemptTime = 0;
+		fprintf(stderr, "[WOL] WOLLoginMenuUpdate TIMEOUT no login (10s estourado). Teardown & Setup GameSpy...\n");
+		fflush(stderr);
 		UnicodeString title, body;
 		AsciiString disconMunkee;
 		disconMunkee.format("GUI:GSDisconReason4");	// ("could not connect to server")

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
@@ -123,9 +123,10 @@ static AsciiString obfuscate( AsciiString in )
 		if (!*c2)
 			c2 = xorWord;
 		if (*c != *c2)
-			*c = *c++ ^ *c2++;
-		else
-			c++, c2++;
+			*c = *c ^ *c2;
+		
+		c++;
+		c2++;
 	}
 	AsciiString out = buf;
 	delete[] buf;
@@ -1269,7 +1270,8 @@ WindowMsgHandledType WOLLoginMenuSystem( GameWindow *window, UnsignedInt msg,
 							//TheGameSpyInfo->setLocalProfileID( resp.player.profileID );
 							TheGameSpyInfo->setLocalEmail( email );
 							TheGameSpyInfo->setLocalPassword( password );
-							DEBUG_LOG(("before create: TheGameSpyInfo->stuff(%s/%s/%s)", TheGameSpyInfo->getLocalBaseName().str(), TheGameSpyInfo->getLocalEmail().str(), TheGameSpyInfo->getLocalPassword().str()));
+							fprintf(stderr, "[WOL] Criando conta e logando no GameSpy (Host: gp." GSI_DOMAIN_NAME ") com Email=%s Nick=%s\n", TheGameSpyInfo->getLocalEmail().str(), TheGameSpyInfo->getLocalBaseName().str());
+							fflush(stderr);
 
 							TheGameSpyBuddyMessageQueue->addRequest( req );
 							if(checkBoxRememberPassword && GadgetCheckBoxIsChecked(checkBoxRememberPassword))
@@ -1358,7 +1360,8 @@ WindowMsgHandledType WOLLoginMenuSystem( GameWindow *window, UnsignedInt msg,
 							//TheGameSpyInfo->setLocalProfileID( resp.player.profileID );
 							TheGameSpyInfo->setLocalEmail( email );
 							TheGameSpyInfo->setLocalPassword( password );
-							DEBUG_LOG(("before login: TheGameSpyInfo->stuff(%s/%s/%s)", TheGameSpyInfo->getLocalBaseName().str(), TheGameSpyInfo->getLocalEmail().str(), TheGameSpyInfo->getLocalPassword().str()));
+							fprintf(stderr, "[WOL] Iniciando login no GameSpy (Host: gp." GSI_DOMAIN_NAME ") com Email=%s Nick=%s\n", TheGameSpyInfo->getLocalEmail().str(), TheGameSpyInfo->getLocalBaseName().str());
+							fflush(stderr);
 
 							TheGameSpyBuddyMessageQueue->addRequest( req );
 							if(checkBoxRememberPassword && GadgetCheckBoxIsChecked(checkBoxRememberPassword))

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
@@ -377,15 +377,31 @@ static void updateOverallStats()
 	if( s_totalWinPercent <= 0 )
 		s_totalWinPercent = 1;  //prevent divide by zero
 
-	std::map<AsciiString,float>::iterator it;
-	for( it = s_winStats.begin();  it != s_winStats.end();  ++it )
+	for( int i = 0; i < ThePlayerTemplateStore->getPlayerTemplateCount(); i++)
 	{
-		int percent = REAL_TO_INT(100.0f * (it->second / s_totalWinPercent));
+		const PlayerTemplate* pTemplate = ThePlayerTemplateStore->getNthPlayerTemplate(i);
+		if( !pTemplate->isPlayableSide() || pTemplate->getSide().compare("Boss") == 0 )
+			continue;
+
+		AsciiString side = pTemplate->getSide();
+		if( side == "America" )
+			side = "USA";
+
+		float percentVal = 0.0f;
+		std::map<AsciiString,float>::iterator it = s_winStats.find(side);
+		if (it != s_winStats.end() && s_totalWinPercent > 0)
+		{
+			percentVal = it->second / s_totalWinPercent;
+		}
+
+		int percent = REAL_TO_INT(100.0f * percentVal);
 		percStr.format( TheGameText->fetch("GUI:WinPercent"), percent );
-		wndName.format( "WOLWelcomeMenu.wnd:Percent%s", it->first.str() );
+		wndName.format( "WOLWelcomeMenu.wnd:Percent%s", side.str() );
 		pWin = TheWindowManager->winGetWindowFromId( nullptr, NAMEKEY(wndName) );
-		GadgetCheckBoxSetText( pWin, percStr );
-//x		DEBUG_LOG(("Initialized win percent: %s -> %s %f=%s", wndName.str(), it->first.str(), it->second, percStr.str() ));
+		if (pWin)
+		{
+			GadgetCheckBoxSetText( pWin, percStr );
+		}
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
@@ -358,7 +358,7 @@ void HandleOverallStats( const char* szHTTPStats, unsigned len )
 		//      we want win% = team's wins / total # games played by all teams
 		const char* pTotal = FindNextNumber(pSide);
 		const char* pWins = FindNextNumber(pTotal);
-		float percent = atof(pWins) / max(1,atof(pTotal));  //max prevents divide by zero
+		float percent = atof(pWins) / max(1.0, atof(pTotal));  //max prevents divide by zero
 		s_totalWinPercent += percent;
 
 		s_winStats.insert(std::make_pair( side, percent ));

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
@@ -541,7 +541,7 @@ void WOLWelcomeMenuInit( WindowLayout *layout, void *userData )
 	// Set Keyboard to Main Parent
 	TheWindowManager->winSetFocus( parentWOLWelcome );
 
-	enableControls( TRUE );
+	enableControls( TheGameSpyInfo->gotGroupRoomList() );
 	TheShell->showShellMap(TRUE);
 
 	updateNumPlayersOnline();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
@@ -541,7 +541,7 @@ void WOLWelcomeMenuInit( WindowLayout *layout, void *userData )
 	// Set Keyboard to Main Parent
 	TheWindowManager->winSetFocus( parentWOLWelcome );
 
-	enableControls( TheGameSpyInfo->gotGroupRoomList() );
+	enableControls( TRUE );
 	TheShell->showShellMap(TRUE);
 
 	updateNumPlayersOnline();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
@@ -637,7 +637,18 @@ void WOLWelcomeMenuUpdate( WindowLayout * layout, void *userData)
 		}
 	}
 
-	if (TheShell->isAnimFinished() && !buttonPushed && TheGameSpyPeerMessageQueue)
+	static UnsignedInt lastWOLWelcomeTick = 0;
+	UnsignedInt nowTick = timeGetTime();
+	if (nowTick - lastWOLWelcomeTick > 1000)
+	{
+		lastWOLWelcomeTick = nowTick;
+		fprintf(stderr, "[WOL] WOLWelcomeMenuUpdate tick: isAnimFinished=%d, buttonPushed=%d, gotGroupRoomList=%d\n",
+			TheShell ? TheShell->isAnimFinished() : 0, buttonPushed,
+			TheGameSpyInfo ? TheGameSpyInfo->gotGroupRoomList() : 0);
+		fflush(stderr);
+	}
+
+	if (!buttonPushed && TheGameSpyPeerMessageQueue)
 	{
 		HandleBuddyResponses();
 		HandlePersistentStorageResponses();
@@ -651,6 +662,8 @@ void WOLWelcomeMenuUpdate( WindowLayout * layout, void *userData)
 			{
 			case PeerResponse::PEERRESPONSE_GROUPROOM:
 				{
+					fprintf(stderr, "[WOL] WOLWelcomeMenuUpdate recebeu PEERRESPONSE_GROUPROOM (id=%d, name=%s)\n", resp.groupRoom.id, resp.groupRoomName.c_str());
+					fflush(stderr);
 					GameSpyGroupRoom room;
 					room.m_groupID = resp.groupRoom.id;
 					room.m_maxWaiting = resp.groupRoom.maxWaiting;
@@ -662,6 +675,8 @@ void WOLWelcomeMenuUpdate( WindowLayout * layout, void *userData)
 					TheGameSpyInfo->addGroupRoom( room );
 					if (room.m_groupID == 0)
 					{
+						fprintf(stderr, "[WOL] WOLWelcomeMenuUpdate room.m_groupID == 0! Executando enableControls(TRUE)...\n");
+						fflush(stderr);
 						enableControls( TRUE );
 					}
 				}

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpyGP.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpyGP.cpp
@@ -41,6 +41,8 @@ char GameSpyProfilePassword[64];
 void GPRecvBuddyMessageCallback(GPConnection * pconnection, GPRecvBuddyMessageArg * arg, void * param)
 {
 	DEBUG_LOG(("GPRecvBuddyMessageCallback: message from %d is %s", arg->profile, arg->message));
+	fprintf(stderr, "[GameSpyGP] GPRecvBuddyMessageCallback: message from %d is %s\n", arg->profile, arg->message);
+	fflush(stderr);
 
 	//gpGetInfo(pconn, arg->profile, GP_DONT_CHECK_CACHE, GP_BLOCKING, (GPCallback)Whois, nullptr);
 	//printf("MESSAGE (%d): %s: %s\n", msgCount,whois, arg->message);
@@ -48,12 +50,16 @@ void GPRecvBuddyMessageCallback(GPConnection * pconnection, GPRecvBuddyMessageAr
 
 static void buddyTryReconnect()
 {
+	fprintf(stderr, "[GameSpyGP] buddyTryReconnect() called\n");
+	fflush(stderr);
 	TheGameSpyChat->reconnectProfile();
 }
 
 void GPErrorCallback(GPConnection * pconnection, GPErrorArg * arg, void * param)
 {
 	DEBUG_LOG(("GPErrorCallback"));
+	fprintf(stderr, "[GameSpyGP] GPErrorCallback result=%d errorCode=%d\n", arg->result, arg->errorCode);
+	fflush(stderr);
 
 	AsciiString errorCodeString;
 	AsciiString resultString;

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpyGP.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpyGP.cpp
@@ -33,6 +33,12 @@
 #include "GameNetwork/GameSpyGP.h"
 #include "GameNetwork/GameSpyOverlay.h"
 
+#define LOG_ARGS(...) __VA_ARGS__
+#ifdef DEBUG_LOG
+#undef DEBUG_LOG
+#endif
+#define DEBUG_LOG(args) do { fprintf(stderr, "[GameSpyLog] "); fprintf(stderr, LOG_ARGS args); fprintf(stderr, "\n"); fflush(stderr); } while(0)
+
 GPConnection TheGPConnectionObj;
 GPConnection *TheGPConnection = &TheGPConnectionObj;
 GPProfile GameSpyLocalProfile = 0;

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpyGameInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpyGameInfo.cpp
@@ -440,7 +440,7 @@ GameSpyGameInfo::GameSpyGameInfo()
 		setSlotPointer(i, &m_GameSpySlot[i]);
 
 	UnsignedInt localIP;
-	if (GetLocalChatConnectionAddress("peerchat.gamespy.com", 6667, localIP))
+	if (GetLocalChatConnectionAddress("peerchat." GSI_DOMAIN_NAME, 6667, localIP))
 	{
 		localIP = ntohl(localIP); // The IP returned from GetLocalChatConnectionAddress is in network byte order.
 		setLocalIP(localIP);
@@ -575,6 +575,8 @@ void GameSpyLaunchGame()
 
 void GameSpyGameInfo::init()
 {
+	fprintf(stderr, "[GameSpyGameInfo] init() called\n");
+	fflush(stderr);
 	GameInfo::init();
 
 	m_hasBeenQueried = false;

--- a/cmake/gamespy.cmake
+++ b/cmake/gamespy.cmake
@@ -1,10 +1,17 @@
 set(GS_OPENSSL FALSE)
-set(GAMESPY_SERVER_NAME "server.cnc-online.net")
+
+if(DEFINED ENV{GAMESPY_SERVER_NAME})
+    set(GAMESPY_SERVER_NAME "$ENV{GAMESPY_SERVER_NAME}" CACHE STRING "Gamespy Server Name" FORCE)
+else()
+    set(GAMESPY_SERVER_NAME "gamespy.local" CACHE STRING "Gamespy Server Name")
+endif()
+
+add_compile_definitions(GSI_DOMAIN_NAME="${GAMESPY_SERVER_NAME}")
 
 FetchContent_Declare(
     gamespy
-    GIT_REPOSITORY https://github.com/TheSuperHackers/GamespySDK.git
-    GIT_TAG        07e3d15c500415abc281efb74322ab6d9c857eb8
+    GIT_REPOSITORY https://github.com/fbraz3/GamespySDK.git
+    GIT_TAG        master
 )
 
 FetchContent_MakeAvailable(gamespy)

--- a/cmake/gamespy.cmake
+++ b/cmake/gamespy.cmake
@@ -8,7 +8,7 @@ endif()
 
 add_compile_definitions(GSI_DOMAIN_NAME="${GAMESPY_SERVER_NAME}")
 
-option(SAGE_GAMESPY_USE_LOCAL_FORK "Use local GamespySDK in references/GamespySDK" TRUE)
+option(SAGE_GAMESPY_USE_LOCAL_FORK "Use local GamespySDK in references/GamespySDK" ON)
 
 if(SAGE_GAMESPY_USE_LOCAL_FORK AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/references/GamespySDK/CMakeLists.txt")
     message(STATUS "GamespySDK: Using local repository in references/GamespySDK")

--- a/cmake/gamespy.cmake
+++ b/cmake/gamespy.cmake
@@ -8,10 +8,16 @@ endif()
 
 add_compile_definitions(GSI_DOMAIN_NAME="${GAMESPY_SERVER_NAME}")
 
-FetchContent_Declare(
-    gamespy
-    GIT_REPOSITORY https://github.com/fbraz3/GamespySDK.git
-    GIT_TAG        master
-)
+option(SAGE_GAMESPY_USE_LOCAL_FORK "Use local GamespySDK in references/GamespySDK" OFF)
 
-FetchContent_MakeAvailable(gamespy)
+if(SAGE_GAMESPY_USE_LOCAL_FORK AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/references/GamespySDK/CMakeLists.txt")
+    message(STATUS "GamespySDK: Using local repository in references/GamespySDK")
+    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/references/GamespySDK" "${CMAKE_BINARY_DIR}/_deps/gamespy-build")
+else()
+    FetchContent_Declare(
+        gamespy
+        GIT_REPOSITORY https://github.com/fbraz3/GamespySDK.git
+        GIT_TAG        master
+    )
+    FetchContent_MakeAvailable(gamespy)
+endif()

--- a/cmake/gamespy.cmake
+++ b/cmake/gamespy.cmake
@@ -8,7 +8,7 @@ endif()
 
 add_compile_definitions(GSI_DOMAIN_NAME="${GAMESPY_SERVER_NAME}")
 
-option(SAGE_GAMESPY_USE_LOCAL_FORK "Use local GamespySDK in references/GamespySDK" OFF)
+option(SAGE_GAMESPY_USE_LOCAL_FORK "Use local GamespySDK in references/GamespySDK" TRUE)
 
 if(SAGE_GAMESPY_USE_LOCAL_FORK AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/references/GamespySDK/CMakeLists.txt")
     message(STATUS "GamespySDK: Using local repository in references/GamespySDK")

--- a/docs/WORKLOG/2026-07-DIARY.md
+++ b/docs/WORKLOG/2026-07-DIARY.md
@@ -68,8 +68,11 @@ Both issues have been resolved by adding proper counting filters in MiniAudio an
 - Fixed `UpdateChecker` not showing up in GitHub Actions deployments due to missing Git metadata in Flatpak builds and `actions/checkout` not fetching tags.
 - Fixed a logic bug where a newly compiled release would immediately flag itself as outdated.
 
-## 22/07/2026
-### Repository Cleanup
-- Removed old, unused historical references from `references/` (`fighter19-dxvk-port`, `jmarshall-win64-modern`, `thesuperhackers-main`, `generals-online-client`).
-- Cleaned up agent prompts (`.github/agents/Bender.agent.md`), documentation metadata (`.devin/wiki.json`), and global agents list (`AGENTS.md`) to remove mentions of these obsolete historical references.
-- Updated `.gitignore` to reflect the removal of large external reference folders.
+
+## 27/07/2026
+### Online Services & GameSpy Integration Fixes
+- Fixed `WOLWelcomeMenu` buttons ("Custom Match" / "Personalizar" and "QuickMatch") remaining disabled by restoring group room list completion event (`groupID = 0`) in `PeerThread.cpp`.
+- Defaulted army win percentage UI labels in `WOLWelcomeMenu.cpp` to `0%` so unformatted `%d%%` raw text is never displayed when stats are empty or loading.
+- Resolved "Cannot connect to storage server" (`GUI:PSCannotConnect`) popup on menu re-entry by filtering out synthetic `Connection Lost` notifications triggered by `CloseStatsConnection` in `PersistentStorageThread.cpp`.
+- Fixed null pointer dereference segfault when `TheGameSpyPSMessageQueue` was torn down during menu transitions.
+

--- a/docs/WORKLOG/2026-07-DIARY.md
+++ b/docs/WORKLOG/2026-07-DIARY.md
@@ -1,5 +1,12 @@
 # July 2026
 
+## 26/07/2026
+### Dynamic GameSpy Domain Configuration & Network Debugging
+- Replaced hardcoded `peerchat.gamespy.com` and `gamestats.gamespy.com` domain strings across Core and Generals/GeneralsMD with `GSI_DOMAIN_NAME` macro.
+- Updated `cmake/gamespy.cmake` to propagate `GSI_DOMAIN_NAME` globally via `add_compile_definitions`, defaulting to `gamespy.local` or environment variable `GAMESPY_SERVER_NAME`.
+- Pointed GameSpy SDK FetchContent dependency to `fbraz3/GamespySDK` fork (`master` branch).
+- Enhanced console debug logging (`fprintf(stderr, ...)`) in `WOLLoginMenu.cpp`, `BuddyThread.cpp`, and `GameSpyGP.cpp` to output target connection host names and explicit `GPResult` error codes.
+
 ## 17/07/2026
 ### Fix Non-Deterministic Math in WWMath Matrix Classes
 - Traced the cross-platform desync at frame 100 to the `TrainCabUngarrisonable` object's translation matrix diverging between macOS (ARM64) and Linux (x86_64).

--- a/flatpak/com.fbraz3.GeneralsX.yml
+++ b/flatpak/com.fbraz3.GeneralsX.yml
@@ -152,7 +152,8 @@ modules:
         # SagePatch INI override: the engine now auto-creates SagePatch.ini with
         # defaults in the user data directory on first run.
 
-        exec /app/bin/GeneralsX "$@"
+        /app/bin/GeneralsX "$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion"
+        exit ${PIPESTATUS[0]}
         EOF
       - chmod +x /app/bin/run.sh
     sources:

--- a/flatpak/com.fbraz3.GeneralsXZH.yml
+++ b/flatpak/com.fbraz3.GeneralsXZH.yml
@@ -160,7 +160,8 @@ modules:
         # SagePatch INI override: the engine now auto-creates SagePatch.ini with
         # defaults in the user data directory on first run.
 
-        exec /app/bin/GeneralsXZH "$@"
+        /app/bin/GeneralsXZH "$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion"
+        exit ${PIPESTATUS[0]}
         EOF
       - chmod +x /app/bin/run.sh
     sources:

--- a/scripts/build/linux/build-linux-appimage-generals.sh
+++ b/scripts/build/linux/build-linux-appimage-generals.sh
@@ -292,7 +292,8 @@ if [[ -z "${ALSOFT_DRIVERS:-}" ]]; then
     export ALSOFT_DRIVERS="pulse,alsa,oss,jack,null,wave"
 fi
 
-exec "${APPDIR}/usr/bin/GeneralsX" "$@"
+"${APPDIR}/usr/bin/GeneralsX" "$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion"
+exit ${PIPESTATUS[0]}
 EOF
 chmod +x "${APPDIR}/AppRun"
 

--- a/scripts/build/linux/build-linux-appimage-zh.sh
+++ b/scripts/build/linux/build-linux-appimage-zh.sh
@@ -315,7 +315,8 @@ if [[ -z "${ALSOFT_DRIVERS:-}" ]]; then
     export ALSOFT_DRIVERS="pulse,alsa,oss,jack,null,wave"
 fi
 
-exec "${APPDIR}/usr/bin/GeneralsXZH" "$@"
+"${APPDIR}/usr/bin/GeneralsXZH" "$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion"
+exit ${PIPESTATUS[0]}
 EOF
 chmod +x "${APPDIR}/AppRun"
 

--- a/scripts/build/linux/bundle-linux-zh.sh
+++ b/scripts/build/linux/bundle-linux-zh.sh
@@ -231,7 +231,8 @@ if [[ -z "${ALSOFT_DRIVERS:-}" ]]; then
     echo "INFO: OpenAL: ALSOFT_DRIVERS=$ALSOFT_DRIVERS (pipewire excluded)"
 fi
 
-exec "${SCRIPT_DIR}/GeneralsXZH" "$@"
+"${SCRIPT_DIR}/GeneralsXZH" "$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion"
+exit ${PIPESTATUS[0]}
 WRAPPER
 chmod +x "${BUNDLE_DIR}/run.sh"
 

--- a/scripts/build/linux/bundle-linux.sh
+++ b/scripts/build/linux/bundle-linux.sh
@@ -230,7 +230,8 @@ if [[ -z "${ALSOFT_DRIVERS:-}" ]]; then
     echo "INFO: OpenAL: ALSOFT_DRIVERS=$ALSOFT_DRIVERS (pipewire excluded)"
 fi
 
-exec "${SCRIPT_DIR}/GeneralsX" "$@"
+"${SCRIPT_DIR}/GeneralsX" "$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion"
+exit ${PIPESTATUS[0]}
 WRAPPER
 chmod +x "${BUNDLE_DIR}/run.sh"
 

--- a/scripts/build/linux/deploy-linux-zh.sh
+++ b/scripts/build/linux/deploy-linux-zh.sh
@@ -266,7 +266,8 @@ fi
 cd "${SCRIPT_DIR}"
 
 # Run game with all arguments
-exec "./GeneralsXZH" "$@"
+"./GeneralsXZH" "$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion"
+exit ${PIPESTATUS[0]}
 EOF
 chmod +x "${RUNTIME_DIR}/run.sh"
 

--- a/scripts/build/linux/deploy-linux.sh
+++ b/scripts/build/linux/deploy-linux.sh
@@ -212,7 +212,8 @@ if [[ -z "${ALSOFT_DRIVERS:-}" ]]; then
 fi
 
 # Run game with all arguments
-exec "${SCRIPT_DIR}/GeneralsX" "$@"
+"${SCRIPT_DIR}/GeneralsX" "$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion"
+exit ${PIPESTATUS[0]}
 EOF
 chmod +x "${RUNTIME_DIR}/run.sh"
 

--- a/scripts/build/linux/run-linux-zh.sh
+++ b/scripts/build/linux/run-linux-zh.sh
@@ -115,7 +115,8 @@ cd "${GAME_DIR}"
 mkdir -p logs
 
 # Launch with arguments (pass all script args to game)
-exec "${GAME_BINARY}" "$@" 2>&1 |tee "$LOG_FILE"
+"${GAME_BINARY}" "$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion" | tee "${LOG_FILE}"
+exit ${PIPESTATUS[0]}
 
 echo 
 echo "------------------------"

--- a/scripts/build/linux/run-linux.sh
+++ b/scripts/build/linux/run-linux.sh
@@ -94,7 +94,8 @@ cd "${GAME_DIR}"
 mkdir -p logs
 
 # Launch with arguments (pass all script args to game)
-exec "${GAME_BINARY}" "$@" 2>&1 |tee "$LOG_FILE"
+"${GAME_BINARY}" "$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion" | tee "${LOG_FILE}"
+exit ${PIPESTATUS[0]}
 
 echo 
 echo "------------------------"

--- a/scripts/build/macos/bundle-macos-generals.sh
+++ b/scripts/build/macos/bundle-macos-generals.sh
@@ -397,13 +397,14 @@ if [[ -d "${CNC_GENERALS_PATH}" ]]; then
     # defaults in the user data directory on first run.
 fi
 
-exec "${BIN_DIR}/GeneralsX" "$@"
+"${BIN_DIR}/GeneralsX" "$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion"
+exit ${PIPESTATUS[0]}
 WRAPPER
 chmod +x "${MACOS_DIR}/run.sh"
 
-# Keep compatibility with direct calls using the game name.
 ln -sf run.sh "${MACOS_DIR}/GeneralsX"
 
+# Keep compatibility with direct calls using the game name.
 # Helper CLI launcher for terminal-based local tests.
 echo "  + run.sh"
 cat > "${STAGE_DIR}/run.sh" << 'RUNNER'

--- a/scripts/build/macos/bundle-macos-zh.sh
+++ b/scripts/build/macos/bundle-macos-zh.sh
@@ -442,7 +442,8 @@ if [[ -d "${CNC_GENERALS_ZH_PATH}" ]]; then
     # defaults in the user data directory on first run.
 fi
 
-exec "${BIN_DIR}/GeneralsXZH" "$@"
+"${BIN_DIR}/GeneralsXZH" "$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion"
+exit ${PIPESTATUS[0]}
 WRAPPER
 chmod +x "${MACOS_DIR}/run.sh"
 

--- a/scripts/build/macos/deploy-macos-generals.sh
+++ b/scripts/build/macos/deploy-macos-generals.sh
@@ -123,7 +123,8 @@ if [[ -f "${SCRIPT_DIR}/MoltenVK_icd.json" ]]; then
     export VK_DRIVER_FILES="${SCRIPT_DIR}/MoltenVK_icd.json"
 fi
 
-exec "${SCRIPT_DIR}/GeneralsX" "$@"
+"${SCRIPT_DIR}/GeneralsX" "$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion"
+exit ${PIPESTATUS[0]}
 WRAPPER
 chmod +x "${RUNTIME_DIR}/run.sh"
 

--- a/scripts/build/macos/deploy-macos-zh.sh
+++ b/scripts/build/macos/deploy-macos-zh.sh
@@ -232,7 +232,8 @@ fi
 # every loose INI / asset and only sees what is bundled inside the BIG files.
 cd "\${SCRIPT_DIR}"
 
-exec "./GeneralsXZH" "\$@"
+"./GeneralsXZH" "\$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion"
+exit \${PIPESTATUS[0]}
 WRAPPER
 chmod +x "${RUNTIME_DIR}/run.sh"
 

--- a/scripts/build/macos/run-macos-zh.sh
+++ b/scripts/build/macos/run-macos-zh.sh
@@ -105,4 +105,5 @@ echo "   Fontconfig file: ${FONTCONFIG_FILE:-unset}"
 echo ""
 
 cd "${GAME_DIR}"
-exec "${GAME_BINARY}" "$@" 2>&1 | tee "${LOG_FILE}"
+"${GAME_BINARY}" "$@" 2>&1 | grep --line-buffered -v "Unimplemented render state D3DRS_PATCHSEGMENTS" | grep --line-buffered -v "No accelerated colorspace conversion" | tee "${LOG_FILE}"
+exit ${PIPESTATUS[0]}


### PR DESCRIPTION
## Context
- The user reported a 10s timeout after entering an incorrect password.
- The user reported a segfault during GameSpy teardown/shutdown.

## Changes
- **WOLLoginMenu**: Read BUDDYRESPONSE_DISCONNECT directly in WOLLoginMenuUpdate so that we abort the login sequence immediately instead of waiting for PEERRESPONSE_LOGIN to time out.
- **ThreadClass (Unix)**: Use pthread_cancel in ThreadClass::Stop if a detached thread fails to exit within the timeout. This prevents Use-After-Free crashes (like the one observed in PingThreadClass during TearDownGameSpy) when a thread is blocked in system calls like gethostbyname.
