### PR TITLE
Add wasm-generals (WebAssembly + WebGPU browser port) to community ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For **official releases and instructions**, visit:
 * [Generals-Mac-iOS-iPad](https://github.com/ammaarreshi/Generals-Mac-iOS-iPad) - iOS port by [@ammaarreshi](https://github.com/ammaarreshi)
 * [Generals-Android](https://github.com/fadi-labib/Generals-Android) - Android port by [@fadi-labib](https://github.com/fadi-labib)
 * [GeneralsXWeb](https://github.com/meerzulee/GeneralsXWeb) - Web port by [@meerzulee](https://github.com/meerzulee)
+* [wasm-generals](https://github.com/origami-ltd/wasm-generals) - WebAssembly + WebGPU browser port by [@ebellumat](https://github.com/ebellumat), playable at [generals.wasm.com.br](https://generals.wasm.com.br)
 
 ## 💖 Support This Project
 


### PR DESCRIPTION
Adds [wasm-generals](https://github.com/origami-ltd/wasm-generals) to the *Community Ports based on GeneralsX* list — the full Zero Hour game compiled to WebAssembly with WebGPU rendering, streaming assets from the player's own installed copy, LAN multiplayer over a WebSocket relay, playable at [generals.wasm.com.br](https://generals.wasm.com.br).

Thanks for GeneralsX — it is the base this port stands on.