### PR TITLE
bugfix: Fix null dereference of rider container in TransportContain::isSpecificRiderFreeToExit

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -471,7 +471,10 @@ Bool TransportContain::isSpecificRiderFreeToExit(Object* specificObject)
 	// TheSuperHackers @bugfix Stubbjax 02/03/2026 If our parent container is held, then we
 	// are not free to exit.
 	DEBUG_ASSERTCRASH(specificObject->getContainedBy(), ("rider must be contained"));
-	if (specificObject->getContainedBy()->isDisabledByType(DISABLED_HELD))
+	// GeneralsX @bugfix mhb8898 08/08/2026 Null check the rider's container before dereferencing it,
+	// because the rider can reach here without a container and DEBUG_ASSERTCRASH is compiled out of release builds. (#247)
+	const Object* riderContainer = specificObject->getContainedBy();
+	if (riderContainer != nullptr && riderContainer->isDisabledByType(DISABLED_HELD))
 		return FALSE;
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -582,7 +582,10 @@ Bool TransportContain::isSpecificRiderFreeToExit(Object* specificObject)
 	// TheSuperHackers @bugfix Stubbjax 02/03/2026 If our parent container is held, then we
 	// are not free to exit.
 	DEBUG_ASSERTCRASH(specificObject->getContainedBy(), ("rider must be contained"));
-	if (specificObject->getContainedBy()->isDisabledByType(DISABLED_HELD))
+	// GeneralsX @bugfix mhb8898 08/08/2026 Null check the rider's container before dereferencing it,
+	// because the rider can reach here without a container and DEBUG_ASSERTCRASH is compiled out of release builds. (#247)
+	const Object* riderContainer = specificObject->getContainedBy();
+	if (riderContainer != nullptr && riderContainer->isDisabledByType(DISABLED_HELD))
 		return FALSE;
 #endif
 


### PR DESCRIPTION
Fixes #246

## Problem

`TransportContain::isSpecificRiderFreeToExit()` dereferences `specificObject->getContainedBy()` when testing for `DISABLED_HELD`. The only guard on that pointer is a `DEBUG_ASSERTCRASH`, which is compiled out of release builds, so a rider with no container segfaults the release build:

```
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS at 0x0000000000000158

0  TransportContain::isSpecificRiderFreeToExit(Object*) + 56
1  non-virtual thunk to TransportContain::reserveDoorForExit(ThingTemplate const*, Object*) + 24
2  AIExitState::update() + 164
3  StateMachine::updateStateMachine() + 104
4  AIUpdateInterface::update() + 52
5  GameLogic::update() + 796
```

The call arrives from `AIExitState::update()` via `reserveDoorForExit()`, which does not guarantee the rider is still contained at that moment. The `DEBUG_ASSERTCRASH` on the preceding line shows the null case was already anticipated when the `DISABLED_HELD` check was added.

Because the crash is inside `GameLogic::update()`, the affected client is dropped mid-match.

## Change

Null check the container before dereferencing it. Behaviour is unchanged whenever the pointer is valid, so this only affects the case that previously crashed. Applied to both `Generals` and `GeneralsMD`.

I kept the existing `DEBUG_ASSERTCRASH` rather than removing it, since it still documents the expected state for debug builds — but if reaching this function with an uncontained rider turns out to be legitimate rather than a symptom of a separate bug, that assert will fire spuriously in debug builds and may be worth dropping. Happy to remove it if you prefer.

## Verification

Reproduced three times in a row on macOS/arm64 (Beta 15) in consecutive 2-player LAN games, China Infantry General vs USA Superweapon General, crashing 3–7 minutes into each match on two different maps. All three crash reports show the identical faulting instruction and fault address `0x158`, with `specificObject` a valid pointer and its container back-pointer exactly `0` every time.

No `deep_crc_*.bin` dumps were produced in any of the three, so these were hard segfaults rather than SyncCrashes.

After building this branch and playing further matches in the same matchup, the crash no longer occurs.

## AI disclosure

Per CONTRIBUTING.md: the crash analysis and this change were produced with Claude (Anthropic) assistance. The diagnosis was derived from the crash reports' disassembly and cross-checked against the source; I reviewed the change, built it locally, and verified it in real multiplayer games before opening this PR. The change is three lines and I have read and understood all of it.
