### PR TITLE
feat: dynamic project watermark and update checker fixes

### DIFF
--- a/.github/workflows/build-linux-flatpak.yml
+++ b/.github/workflows/build-linux-flatpak.yml
@@ -10,6 +10,11 @@ on:
         required: false
         type: string
         default: linux64-deploy
+      checkout_ref:
+        required: false
+        type: string
+        default: ""
+        description: "Git ref to checkout (branch, tag, or SHA). Leaves empty for default."
   workflow_dispatch:
     inputs:
       preset:
@@ -45,6 +50,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -12,6 +12,11 @@ on:
         type: string
         default: "macos-vulkan"
         description: "CMake preset for macOS"
+      checkout_ref:
+        required: false
+        type: string
+        default: ""
+        description: "Git ref to checkout (branch, tag, or SHA). Leaves empty for default."
   workflow_dispatch:
     inputs:
       preset:
@@ -46,6 +51,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,12 +69,14 @@ jobs:
     uses: ./.github/workflows/build-linux-flatpak.yml
     with:
       preset: linux64-deploy
+      checkout_ref: refs/tags/${{ inputs.release_version }}
 
   build-macos:
     needs: [create-tag]
     uses: ./.github/workflows/build-macos.yml
     with:
       preset: macos-vulkan
+      checkout_ref: refs/tags/${{ inputs.release_version }}
 
   # GeneralsX @build BenderAI 21/04/2026 Roll back the pushed tag when anything
   # downstream of create-tag fails, so a re-run with the same version is possible.

--- a/Core/GameEngine/Include/Common/version.h
+++ b/Core/GameEngine/Include/Common/version.h
@@ -83,6 +83,7 @@ public:
 	UnicodeString getUnicodeProductAuthor() const; ///< Is decorated with localized string
 	UnicodeString getUnicodeProductString() const; ///< Returns a string that contains product title, version and other, if specified. Is decorated with localized string
 	UnicodeString getUnicodeProductVersionHashString() const; ///< Returns a string that contains the product string, game version and hashes. Is decorated with localized string
+	UnicodeString getUnicodeProjectWatermark() const; ///< Returns the project watermark with the git tag if present
 
 	Bool showFullVersion() const { return m_showFullVersion; }
 	void setShowFullVersion( Bool val ) { m_showFullVersion = val; }

--- a/Core/GameEngine/Source/Common/UpdateChecker.cpp
+++ b/Core/GameEngine/Source/Common/UpdateChecker.cpp
@@ -182,6 +182,9 @@ static int SDLCALL threadFunc(void* /*userData*/)
     curl_slist_free_all(headers);
     curl_easy_cleanup(curl);
 
+    fprintf(stderr, "[UpdateChecker] curl_easy_perform returned %d. Response length=%zu\n", (int)res, responseBody.length());
+    fflush(stderr);
+
     if (res != CURLE_OK)
     {
         // Network error: fail silently
@@ -192,9 +195,14 @@ static int SDLCALL threadFunc(void* /*userData*/)
     char latestTag[128] = {0};
     if (!extractTagName(responseBody, latestTag, sizeof(latestTag)))
     {
+        fprintf(stderr, "[UpdateChecker] Failed to extract tag_name from response. Response Body (truncated):\n%.256s\n", responseBody.c_str());
+        fflush(stderr);
         SDL_SetAtomicInt(&s_done, 1);
         return 0;
     }
+    
+    fprintf(stderr, "[UpdateChecker] Extracted remote latestTag='%s'\n", latestTag);
+    fflush(stderr);
 
     // Compare publication date of the remote release against the local build's
     // commit timestamp. Date comparison is tag-format-agnostic: it works for
@@ -206,6 +214,8 @@ static int SDLCALL threadFunc(void* /*userData*/)
     if (forceCheck)
     {
         hasUpdate = latestTag[0] != '\0';
+        fprintf(stderr, "[UpdateChecker] forceCheck is true. hasUpdate=%d\n", (int)hasUpdate);
+        fflush(stderr);
     }
     else
     {
@@ -213,6 +223,8 @@ static int SDLCALL threadFunc(void* /*userData*/)
         if (GitTag[0] != '\0' && strcmp(latestTag, GitTag) == 0)
         {
             hasUpdate = false;
+            fprintf(stderr, "[UpdateChecker] Local tag matches remote tag precisely ('%s'). No update.\n", GitTag);
+            fflush(stderr);
         }
         else
         {
@@ -221,15 +233,34 @@ static int SDLCALL threadFunc(void* /*userData*/)
             if (hasCommitTimestamp && extractPublishedAt(responseBody, publishedAt, sizeof(publishedAt)))
             {
                 time_t remoteTime = parseISO8601(publishedAt);
+                fprintf(stderr, "[UpdateChecker] Extracted published_at='%s' (parsed %lld). Local commit time=%lld\n", publishedAt, (long long)remoteTime, (long long)GitCommitTimeStamp);
+                fflush(stderr);
+                
                 // Signal update only when the remote release was published strictly
                 // AFTER the commit this binary was built from.
                 if (remoteTime != (time_t)-1 && remoteTime > GitCommitTimeStamp)
+                {
                     hasUpdate = true;
+                    fprintf(stderr, "[UpdateChecker] Remote release is newer based on timestamp!\n");
+                    fflush(stderr);
+                }
+                else
+                {
+                    fprintf(stderr, "[UpdateChecker] Remote release is NOT newer based on timestamp.\n");
+                    fflush(stderr);
+                }
             }
             else if (GitTag[0] != '\0')
             {
                 // No usable published_at comparison; fall back to tag string comparison.
                 hasUpdate = (strcmp(latestTag, GitTag) != 0);
+                fprintf(stderr, "[UpdateChecker] No valid published_at found or no local timestamp. Falling back to tag string diff. hasUpdate=%d\n", (int)hasUpdate);
+                fflush(stderr);
+            }
+            else
+            {
+                fprintf(stderr, "[UpdateChecker] No local tag and no usable timestamp. Cannot determine update reliably. Assuming hasUpdate=false\n");
+                fflush(stderr);
             }
         }
     }
@@ -259,17 +290,29 @@ void UpdateChecker::start()
     // some packaged CI contexts even when the binary is a real release artifact).
     // Set env var GENERALS_FORCE_UPDATE_CHECK=1 to bypass release guards (for testing).
     const bool forceCheck = SDL_getenv("GENERALS_FORCE_UPDATE_CHECK") != nullptr;
+    
+    fprintf(stderr, "[UpdateChecker] start() called. GitTag='%s', GitCommitTimeStamp=%lld, GitUncommittedChanges=%d, forceCheck=%d\n", GitTag, (long long)GitCommitTimeStamp, (int)GitUncommittedChanges, (int)forceCheck);
+    fflush(stderr);
+    
     if (!forceCheck)
     {
         const bool hasTag = (GitTag[0] != '\0');
         const bool hasCommitTimestamp = (GitCommitTimeStamp > 0);
         if (GitUncommittedChanges || (!hasTag && !hasCommitTimestamp))
+        {
+            fprintf(stderr, "[UpdateChecker] start() aborted. GitUncommittedChanges=%d, hasTag=%d, hasCommitTimestamp=%d\n", (int)GitUncommittedChanges, (int)hasTag, (int)hasCommitTimestamp);
+            fflush(stderr);
             return;
+        }
     }
 
     // Respect the user opt-out setting
     if (TheGlobalData && !TheGlobalData->m_checkForUpdates)
+    {
+        fprintf(stderr, "[UpdateChecker] start() aborted. User opted out of updates in settings.\n");
+        fflush(stderr);
         return;
+    }
 
     SDL_SetAtomicInt(&s_done, 0);
     SDL_SetAtomicInt(&s_hasUpdate, 0);
@@ -280,6 +323,9 @@ void UpdateChecker::start()
     // cleanup on exit and there is no safe single-owner shutdown hook here.
     curl_global_init(CURL_GLOBAL_DEFAULT);
 
+    fprintf(stderr, "[UpdateChecker] Launching background thread to check %s\n", UpdateChecker::getReleasesUrl());
+    fflush(stderr);
+    
     s_thread = SDL_CreateThread(threadFunc, "UpdateChecker", nullptr);
     if (!s_thread)
     {

--- a/Core/GameEngine/Source/Common/version.cpp
+++ b/Core/GameEngine/Source/Common/version.cpp
@@ -32,6 +32,8 @@
 #include "Common/version.h"
 
 #include "gitinfo.h"
+#include <ctype.h>
+#include <stdio.h>
 
 Version *TheVersion = nullptr;	///< The Version singleton
 
@@ -450,4 +452,38 @@ UnicodeString Version::buildUnicodeGitCommitTime()
 	tm* time = gmtime(&GitCommitTimeStamp);
 	wcsftime(buf, len+1, L"%Y-%m-%d %H:%M:%S", time);
 	return str;
+}
+
+UnicodeString Version::getUnicodeProjectWatermark() const
+{
+	char finalCredit[256];
+	if (GitTag && GitTag[0] != '\0')
+	{
+		const char* prefix = "generalsx-";
+		const char* tagBase = GitTag;
+
+		if (strncmp(tagBase, prefix, strlen(prefix)) == 0)
+		{
+			tagBase += strlen(prefix);
+		}
+
+		char formattedTag[128];
+		strncpy(formattedTag, tagBase, sizeof(formattedTag) - 1);
+		formattedTag[sizeof(formattedTag) - 1] = '\0';
+
+		if (formattedTag[0] != '\0')
+		{
+			formattedTag[0] = toupper((unsigned char)formattedTag[0]);
+		}
+
+		snprintf(finalCredit, sizeof(finalCredit), "GeneralsX %s - Multiplatform C&C Generals", formattedTag);
+	}
+	else
+	{
+		strncpy(finalCredit, "GeneralsX - Multiplatform C&C Generals", sizeof(finalCredit));
+	}
+
+	UnicodeString watermark;
+	watermark.translate(finalCredit);
+	return watermark;
 }

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -394,7 +394,11 @@ static void initLabelVersion()
 	NameKeyType versionID = TheNameKeyGenerator->nameToKey( "MainMenu.wnd:LabelVersion" );
 	GameWindow *labelVersion = TheWindowManager->winGetWindowFromId( nullptr, versionID );
 	UnicodeString creditText;
-	creditText.translate("GeneralsX - Multiplatform C&C Generals");
+	if (TheVersion) {
+		creditText = TheVersion->getUnicodeProjectWatermark();
+	} else {
+		creditText.translate("GeneralsX - Multiplatform C&C Generals");
+	}
 
 	if (labelVersion)
 	{

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DMainMenu.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DMainMenu.cpp
@@ -73,6 +73,7 @@
 #include "W3DDevice/GameClient/W3DGadget.h"
 
 #include "GameClient/GUICallbacks.h"
+#include "Common/version.h"
 
 // forward declaration for credit draw added by GeneralsX
 extern void W3DGeneralsXCreditDraw( GameWindow *window, WinInstanceData *instData );
@@ -421,7 +422,11 @@ void W3DGeneralsXCreditDraw( GameWindow *window, WinInstanceData *instData )
 		return;
 
 	UnicodeString ucredit;
-	ucredit.translate("GeneralsX - Multiplatform C&C Generals");
+	if (TheVersion) {
+		ucredit = TheVersion->getUnicodeProjectWatermark();
+	} else {
+		ucredit.translate("GeneralsX - Multiplatform C&C Generals");
+	}
 	instData->setText(ucredit);
 
 	DisplayString *dString = instData->getTextDisplayString();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -428,7 +428,11 @@ static void initLabelVersion()
 	NameKeyType versionID = TheNameKeyGenerator->nameToKey( "MainMenu.wnd:LabelVersion" );
 	GameWindow *labelVersion = TheWindowManager->winGetWindowFromId( nullptr, versionID );
 	UnicodeString creditText;
-	creditText.translate("GeneralsX - Multiplatform C&C Generals");
+	if (TheVersion) {
+		creditText = TheVersion->getUnicodeProjectWatermark();
+	} else {
+		creditText.translate("GeneralsX - Multiplatform C&C Generals");
+	}
 
 	if (labelVersion)
 	{

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DMainMenu.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DMainMenu.cpp
@@ -73,6 +73,7 @@
 #include "W3DDevice/GameClient/W3DGadget.h"
 
 #include "GameClient/GUICallbacks.h"
+#include "Common/version.h"
 
 // forward declaration for credit draw added by GeneralsX
 extern void W3DGeneralsXCreditDraw( GameWindow *window, WinInstanceData *instData );
@@ -419,7 +420,11 @@ void W3DGeneralsXCreditDraw( GameWindow *window, WinInstanceData *instData )
 		return;
 
 	UnicodeString ucredit;
-	ucredit.translate("GeneralsX - Multiplatform C&C Generals");
+	if (TheVersion) {
+		ucredit = TheVersion->getUnicodeProjectWatermark();
+	} else {
+		ucredit.translate("GeneralsX - Multiplatform C&C Generals");
+	}
 	instData->setText(ucredit);
 
 	DisplayString *dString = instData->getTextDisplayString();


### PR DESCRIPTION
## Description
This PR introduces a dynamic project watermark in the main menu based on the Git tag (with Semantic Versioning fallback). It also instruments the `UpdateChecker` with extensive logs to diagnose issues with GitHub releases, and fixes a CI bug where `actions/checkout` was not fetching the newly created tag by passing an explicit `checkout_ref`.

## Changes
- **UI**: Added `TheVersion->getUnicodeProjectWatermark()` which replaces the hardcoded string with the Git tag, stripping the `generalsx-` prefix and capitalizing the first letter.
- **UpdateChecker**: Added `fprintf(stderr)` instrumentation at various stages to diagnose missing tags or incorrect timestamps during update checks.
- **CI**: Introduced `checkout_ref` input to `build-macos.yml` and `build-linux-flatpak.yml`, and updated `release.yml` to pass the newly created tag reference explicitly.
